### PR TITLE
fix(frontend): migrate to MUI v9 after MLMD removal

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
       - id: check-json
       - id: end-of-file-fixer
       - id: trailing-whitespace
-        exclude: ^manifests/gcp_marketplace/test/
+        # Generated snapshots preserve whitespace in rendered text nodes.
+        exclude: ^manifests/gcp_marketplace/test/|^frontend/src/.*/__snapshots__/.*\.snap$
       - id: debug-statements
       - id: check-merge-conflict
       - id: name-tests-test

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,8 +12,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^5.18.0",
-        "@mui/material": "^5.18.0",
+        "@mui/icons-material": "^9.4.0",
+        "@mui/material": "^9.4.0",
         "@tanstack/react-query": "^5.102.8",
         "@types/lodash.groupby": "^4.6.9",
         "@types/pako": "^3.0.0",
@@ -593,33 +593,6 @@
         "stylis": "4.2.0"
       }
     },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "license": "MIT"
-    },
     "node_modules/@emotion/babel-plugin/node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "license": "MIT",
@@ -633,10 +606,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/@emotion/babel-plugin/node_modules/csstype": {
-      "version": "3.2.3",
-      "license": "MIT"
-    },
     "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "license": "MIT",
@@ -646,6 +615,31 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
@@ -669,27 +663,10 @@
         }
       }
     },
-    "node_modules/@emotion/react/node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/serialize": {
+    "node_modules/@emotion/serialize": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
@@ -699,24 +676,10 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@emotion/react/node_modules/@emotion/sheet": {
+    "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react/node_modules/csstype": {
-      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
       "license": "MIT"
     },
     "node_modules/@emotion/styled": {
@@ -740,10 +703,6 @@
         }
       }
     },
-    "node_modules/@emotion/styled/node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "license": "MIT"
-    },
     "node_modules/@emotion/styled/node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
       "license": "MIT",
@@ -751,31 +710,10 @@
         "@emotion/memoize": "^0.9.0"
       }
     },
-    "node_modules/@emotion/styled/node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/styled/node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/styled/node_modules/@emotion/unitless": {
+    "node_modules/@emotion/unitless": {
       "version": "0.10.0",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/styled/node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/styled/node_modules/csstype": {
-      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
       "license": "MIT"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
@@ -784,6 +722,18 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",
@@ -1492,7 +1442,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.18.0",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.4.0.tgz",
+      "integrity": "sha512-d+gIYM1raJP87yrVQcVg+Q3vycVMArMkgu/TjJLi2vTvO9FHKWNRR1xs9nnN4eLpM9nGxxm02UMvc9BrmcUKvQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1500,20 +1452,22 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.18.0",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.4.0.tgz",
+      "integrity": "sha512-5PVgBYtLOXTk6u0YUAjoV9GoTUQDbeZ8g+pus2h0GphLT/rpmftRnB5D/Kw6QCAovB7EyBX7UxKdZqPBBAHUKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9"
+        "@babel/runtime": "^7.29.7"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^5.0.0",
+        "@mui/material": "^9.4.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1523,25 +1477,36 @@
         }
       }
     },
+    "node_modules/@mui/icons-material/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/material": {
-      "version": "5.18.0",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.4.0.tgz",
+      "integrity": "sha512-6KKUIvkQ2r/s48s9VZV9JEZ1W2dRa7RndVsF+Ipx4CYxDOQeozeRsS5r9NiheFf8A5hpbqJJIGoX7hjg5X4XUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.18.0",
-        "@mui/system": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
+        "@babel/runtime": "^7.29.7",
+        "@mui/core-downloads-tracker": "^9.4.0",
+        "@mui/system": "^9.4.0",
+        "@mui/types": "^9.4.0",
+        "@mui/utils": "^9.4.0",
         "@popperjs/core": "^2.11.8",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
+        "react-is": "^19.2.8",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1550,6 +1515,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^9.4.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1561,13 +1527,27 @@
         "@emotion/styled": {
           "optional": true
         },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }
       }
     },
+    "node_modules/@mui/material/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/material/node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1575,22 +1555,28 @@
     },
     "node_modules/@mui/material/node_modules/csstype": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/@mui/material/node_modules/react-is": {
-      "version": "19.2.4",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.17.1",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.4.0.tgz",
+      "integrity": "sha512-qQpX/2XPGDz5F2OIWzo4kkorURlDeXGKytRQudXCdLS5TuwKsMKaZyx77LZEVSB73c7o3UrLWwQ/goRuHBdtjw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.17.1",
+        "@babel/runtime": "^7.29.7",
+        "@mui/utils": "^9.4.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1606,18 +1592,30 @@
         }
       }
     },
+    "node_modules/@mui/private-theming/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/styled-engine": {
-      "version": "5.18.0",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.4.0.tgz",
+      "integrity": "sha512-SlqVEYqnyEgXMFW4JuIDMelyhKzoWBJ85v2mNCQd0XtU0uk7U9E1zaJZ06XqodhA8oJrb+4Q+3E/JlwBe4jWkw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.13.5",
+        "@babel/runtime": "^7.29.7",
+        "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
-        "csstype": "^3.1.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1637,71 +1635,38 @@
         }
       }
     },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/cache": {
-      "version": "11.14.0",
+    "node_modules/@mui/styled-engine/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
+      "engines": {
+        "node": ">=6.9.0"
       }
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "license": "MIT"
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "license": "MIT"
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "license": "MIT"
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "license": "MIT"
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "license": "MIT"
-    },
-    "node_modules/@mui/styled-engine/node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "license": "MIT"
     },
     "node_modules/@mui/styled-engine/node_modules/csstype": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/@mui/system": {
-      "version": "5.18.0",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.4.0.tgz",
+      "integrity": "sha512-AZz9z13oGS1J0BYeAFHTbV7PegCtPiE/uMEIi7TJ1kTx3Vkt+jUpLyXF/2uV8B6Y79iTh98kVeOH9fX3x3zXXg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.17.1",
-        "@mui/styled-engine": "^5.18.0",
-        "@mui/types": "~7.2.15",
-        "@mui/utils": "^5.17.1",
-        "clsx": "^2.1.0",
-        "csstype": "^3.1.3",
+        "@babel/runtime": "^7.29.7",
+        "@mui/private-theming": "^9.4.0",
+        "@mui/styled-engine": "^9.4.0",
+        "@mui/types": "^9.4.0",
+        "@mui/utils": "^9.4.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1725,8 +1690,19 @@
         }
       }
     },
+    "node_modules/@mui/system/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/system/node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1734,11 +1710,18 @@
     },
     "node_modules/@mui/system/node_modules/csstype": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/@mui/types": {
-      "version": "7.2.24",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.4.0.tgz",
+      "integrity": "sha512-13DH0Oniua4WmGqeYbQAZqmiN7r4nfd0zwIoGJ5QeJwyIHgEmf+LkRw/jV1HZb6AiUoHX8Oxf4xgalq3vYHcIw==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7"
+      },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1748,19 +1731,30 @@
         }
       }
     },
+    "node_modules/@mui/types/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/utils": {
-      "version": "5.17.1",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.4.0.tgz",
+      "integrity": "sha512-WkzY8uYtqUDyGKPShrRQRBomfMQHddlsyKu/gRRESYO24tDPD2z0xRE8CBoUsWqpBa+YrFs9KixiS7kQRjsPAQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/types": "~7.2.15",
-        "@types/prop-types": "^15.7.12",
+        "@babel/runtime": "^7.29.7",
+        "@mui/types": "^9.4.0",
+        "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
+        "react-is": "^19.2.8"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1776,15 +1770,28 @@
         }
       }
     },
+    "node_modules/@mui/utils/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@mui/utils/node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "19.2.4",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2545,6 +2552,8 @@
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3605,6 +3614,8 @@
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^5.18.0",
-    "@mui/material": "^5.18.0",
+    "@mui/icons-material": "^9.4.0",
+    "@mui/material": "^9.4.0",
     "@tanstack/react-query": "^5.102.8",
     "@types/lodash.groupby": "^4.6.9",
     "@types/pako": "^3.0.0",

--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -116,20 +116,20 @@ export const theme = createTheme({
     MuiButton: {
       styleOverrides: {
         text: {
+          '&.MuiButton-colorPrimary': {
+            border: '1px solid #ddd',
+            cursor: 'pointer',
+            fontSize: fontsize.base,
+            marginRight: 10,
+            textTransform: 'none',
+          },
+          '&.MuiButton-colorSecondary': {
+            color: color.theme,
+          },
           fontSize: fontsize.base,
           fontWeight: 'bold',
           minHeight: dimension.tiny,
           textTransform: 'none',
-        },
-        textPrimary: {
-          border: '1px solid #ddd',
-          cursor: 'pointer',
-          fontSize: fontsize.base,
-          marginRight: 10,
-          textTransform: 'none',
-        },
-        textSecondary: {
-          color: color.theme,
         },
         root: {
           '&.Mui-disabled': {

--- a/frontend/src/atoms/Input.test.tsx
+++ b/frontend/src/atoms/Input.test.tsx
@@ -17,6 +17,7 @@
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
 import Input from './Input';
+import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 
 describe('Input', () => {
   const handleChange = vi.fn();
@@ -26,7 +27,7 @@ describe('Input', () => {
     const { asFragment } = render(
       <Input onChange={handleChange('fieldname')} value={value} variant='outlined' />,
     );
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('accepts height and width as prop overrides', () => {
@@ -39,6 +40,6 @@ describe('Input', () => {
         variant='outlined'
       />,
     );
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 });

--- a/frontend/src/atoms/__snapshots__/BusyButton.test.tsx.snap
+++ b/frontend/src/atoms/__snapshots__/BusyButton.test.tsx.snap
@@ -3,16 +3,13 @@
 exports[`BusyButton > renders a primary outlined buton 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-dizc30-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
     <span>
       test busy button
     </span>
-    <span
-      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-    />
   </button>
 </DocumentFragment>
 `;
@@ -20,14 +17,14 @@ exports[`BusyButton > renders a primary outlined buton 1`] = `
 exports[`BusyButton > renders disabled 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
     disabled=""
     tabindex="-1"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
       data-testid="HelpIcon"
       focusable="false"
       viewBox="0 0 24 24"
@@ -46,13 +43,13 @@ exports[`BusyButton > renders disabled 1`] = `
 exports[`BusyButton > renders with a title and icon 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
       data-testid="HelpIcon"
       focusable="false"
       viewBox="0 0 24 24"
@@ -64,9 +61,6 @@ exports[`BusyButton > renders with a title and icon 1`] = `
     <span>
       test busy button
     </span>
-    <span
-      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-    />
   </button>
 </DocumentFragment>
 `;
@@ -74,14 +68,14 @@ exports[`BusyButton > renders with a title and icon 1`] = `
 exports[`BusyButton > renders with a title and icon, and busy 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 rootBusy_fronhm5 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 rootBusy_fronhm5 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
     disabled=""
     tabindex="-1"
     type="button"
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
       data-testid="HelpIcon"
       focusable="false"
       viewBox="0 0 24 24"
@@ -94,16 +88,16 @@ exports[`BusyButton > renders with a title and icon, and busy 1`] = `
       test busy button
     </span>
     <span
-      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary spinner_fiqr0h3 spinnerBusy_f1wemlvb css-18lrjg1-MuiCircularProgress-root"
+      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary spinner_fiqr0h3 spinnerBusy_f1wemlvb css-1wxecgq-MuiCircularProgress-root"
       role="progressbar"
       style="width: 15px; height: 15px;"
     >
       <svg
-        class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+        class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
         viewBox="22 22 44 44"
       >
         <circle
-          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+          class="MuiCircularProgress-circle css-19t5dcl-MuiCircularProgress-circle"
           cx="44"
           cy="44"
           fill="none"
@@ -119,16 +113,13 @@ exports[`BusyButton > renders with a title and icon, and busy 1`] = `
 exports[`BusyButton > renders with just a title 1`] = `
 <DocumentFragment>
   <button
-    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
     tabindex="0"
     type="button"
   >
     <span>
       test busy button
     </span>
-    <span
-      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-    />
   </button>
 </DocumentFragment>
 `;

--- a/frontend/src/atoms/__snapshots__/IconWithTooltip.test.tsx.snap
+++ b/frontend/src/atoms/__snapshots__/IconWithTooltip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`IconWithTooltip > renders with height and weight 1`] = `
   <svg
     aria-hidden="true"
     aria-label="test icon tooltip"
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
     data-mui-internal-clone-element="true"
     data-testid="HelpIcon"
     focusable="false"
@@ -24,7 +24,7 @@ exports[`IconWithTooltip > renders without height or weight 1`] = `
   <svg
     aria-hidden="true"
     aria-label="test icon tooltip"
-    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
     data-mui-internal-clone-element="true"
     data-testid="HelpIcon"
     focusable="false"

--- a/frontend/src/atoms/__snapshots__/Input.test.tsx.snap
+++ b/frontend/src/atoms/__snapshots__/Input.test.tsx.snap
@@ -3,28 +3,29 @@
 exports[`Input > accepts height and width as prop overrides 1`] = `
 <DocumentFragment>
   <div
-    class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+    class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
     spellcheck="false"
     style="height: 123px; max-width: 600px; width: 456px;"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-        id="_r_1_"
+        class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+        id="react-use-id-0"
         type="text"
         value="some input value"
       />
       <fieldset
         aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+        class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
       >
         <legend
-          class="css-1whs34k-MuiNotchedOutlined-root"
+          class="css-1nf2c5d-MuiNotchedOutlined-root"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -39,28 +40,29 @@ exports[`Input > accepts height and width as prop overrides 1`] = `
 exports[`Input > renders with the right styles by default 1`] = `
 <DocumentFragment>
   <div
-    class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+    class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
     spellcheck="false"
     style="height: 40px; max-width: 600px; width: 100%;"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+      class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
     >
       <input
         aria-invalid="false"
-        class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-        id="_r_0_"
+        class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+        id="react-use-id-0"
         type="text"
         value="some input value"
       />
       <fieldset
         aria-hidden="true"
-        class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+        class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
       >
         <legend
-          class="css-1whs34k-MuiNotchedOutlined-root"
+          class="css-1nf2c5d-MuiNotchedOutlined-root"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​

--- a/frontend/src/atoms/__snapshots__/MD2Tabs.test.tsx.snap
+++ b/frontend/src/atoms/__snapshots__/MD2Tabs.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`MD2Tabs > gracefully handles an out of bound selectedTab value 1`] = `
     />
     <button
       aria-label=""
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
       data-mui-internal-clone-element="true"
       tabindex="0"
       type="button"
@@ -21,13 +21,10 @@ exports[`MD2Tabs > gracefully handles an out of bound selectedTab value 1`] = `
       <span>
         tab1
       </span>
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
     <button
       aria-label=""
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
       data-mui-internal-clone-element="true"
       tabindex="0"
       type="button"
@@ -35,9 +32,6 @@ exports[`MD2Tabs > gracefully handles an out of bound selectedTab value 1`] = `
       <span>
         tab2
       </span>
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
   </div>
 </DocumentFragment>
@@ -56,7 +50,7 @@ exports[`MD2Tabs > renders with the right styles by default 1`] = `
     />
     <button
       aria-label=""
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
       data-mui-internal-clone-element="true"
       tabindex="0"
       type="button"
@@ -64,13 +58,10 @@ exports[`MD2Tabs > renders with the right styles by default 1`] = `
       <span>
         tab1
       </span>
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
     <button
       aria-label=""
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
       data-mui-internal-clone-element="true"
       tabindex="0"
       type="button"
@@ -78,9 +69,6 @@ exports[`MD2Tabs > renders with the right styles by default 1`] = `
       <span>
         tab2
       </span>
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
   </div>
 </DocumentFragment>

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -206,7 +206,9 @@ describe('CustomTable', () => {
     expect(col1Label.closest('.MuiTableSortLabel-root')).toHaveClass('Mui-active');
     const sortIcon = document.querySelector('.MuiTableSortLabel-icon');
     expect(sortIcon).not.toBeNull();
-    expect(sortIcon).toHaveClass('MuiTableSortLabel-iconDirectionDesc');
+    expect(col1Label.closest('.MuiTableSortLabel-root')).toHaveClass(
+      'MuiTableSortLabel-directionDesc',
+    );
     wrapper.unmount();
   });
 

--- a/frontend/src/components/CustomTable.tsx
+++ b/frontend/src/components/CustomTable.tsx
@@ -317,21 +317,23 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
               height={48}
               maxWidth={'100%'}
               className={css.filterBox}
-              InputLabelProps={{ classes: { root: css.noMargin } }}
+              slotProps={{
+                inputLabel: { classes: { root: css.noMargin } },
+                input: {
+                  classes: {
+                    notchedOutline: css.filterBorderRadius,
+                    root: css.noLeftPadding,
+                  },
+                  startAdornment: (
+                    <InputAdornment position='end'>
+                      <FilterIcon style={{ color: color.lowContrast, paddingRight: 16 }} />
+                    </InputAdornment>
+                  ),
+                },
+              }}
               onChange={this.handleFilterChange}
               value={filterString}
               variant='outlined'
-              InputProps={{
-                classes: {
-                  notchedOutline: css.filterBorderRadius,
-                  root: css.noLeftPadding,
-                },
-                startAdornment: (
-                  <InputAdornment position='end'>
-                    <FilterIcon style={{ color: color.lowContrast, paddingRight: 16 }} />
-                  </InputAdornment>
-                ),
-              }}
             />
           </div>
         )}
@@ -461,7 +463,7 @@ export default class CustomTable extends React.Component<CustomTableProps, Custo
               variant='standard'
               className={css.rowsPerPage}
               classes={{ root: css.verticalAlignInitial }}
-              InputProps={{ disableUnderline: true }}
+              slotProps={{ input: { disableUnderline: true } }}
               onChange={this._requestRowsPerPage.bind(this)}
               value={pageSize}
             >

--- a/frontend/src/components/NewRunParameters.tsx
+++ b/frontend/src/components/NewRunParameters.tsx
@@ -147,16 +147,18 @@ class ParamEditor extends React.Component<ParamEditorProps, ParamEditorState> {
             value={param.value || ''}
             onChange={(ev) => onChange(ev.target.value || '')}
             className={classes(commonCss.textField, css.textfield)}
-            InputProps={{
-              classes: { disabled: css.nonEditableInput },
-              endAdornment: (
-                <InputAdornment position='end'>
-                  <Button className={css.button} color='secondary' onClick={onClick}>
-                    {this.state.isEditorOpen ? 'Close Json Editor' : 'Open Json Editor'}
-                  </Button>
-                </InputAdornment>
-              ),
-              readOnly: false,
+            slotProps={{
+              input: {
+                classes: { disabled: css.nonEditableInput },
+                endAdornment: (
+                  <InputAdornment position='end'>
+                    <Button className={css.button} color='secondary' onClick={onClick}>
+                      {this.state.isEditorOpen ? 'Close Json Editor' : 'Open Json Editor'}
+                    </Button>
+                  </InputAdornment>
+                ),
+                readOnly: false,
+              },
             }}
           />
         ) : (

--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -134,7 +134,7 @@ function NewRunParametersV2(props: NewRunParametersProps) {
                   }
                 }
               }}
-              inputProps={{ 'aria-label': 'Set custom pipeline root.' }}
+              slotProps={{ input: { 'aria-label': 'Set custom pipeline root.' } }}
             />
           }
         />
@@ -358,16 +358,18 @@ class ParamEditor extends React.Component<ParamEditorProps, ParamEditorState> {
             value={param.value || ''}
             onChange={(ev) => onChange(ev.target.value || '')}
             className={classes(commonCss.textField, css.textfield)}
-            InputProps={{
-              classes: { disabled: css.nonEditableInput },
-              endAdornment: (
-                <InputAdornment position='end'>
-                  <Button className={css.button} color='secondary' onClick={onClick}>
-                    {this.state.isEditorOpen ? 'Close Json Editor' : 'Open Json Editor'}
-                  </Button>
-                </InputAdornment>
-              ),
-              readOnly: false,
+            slotProps={{
+              input: {
+                classes: { disabled: css.nonEditableInput },
+                endAdornment: (
+                  <InputAdornment position='end'>
+                    <Button className={css.button} color='secondary' onClick={onClick}>
+                      {this.state.isEditorOpen ? 'Close Json Editor' : 'Open Json Editor'}
+                    </Button>
+                  </InputAdornment>
+                ),
+                readOnly: false,
+              },
             }}
           />
         ) : (

--- a/frontend/src/components/PipelinesDialog.tsx
+++ b/frontend/src/components/PipelinesDialog.tsx
@@ -124,7 +124,7 @@ const PipelinesDialog: React.FC<PipelinesDialogProps> = (props): React.JSX.Eleme
       open={props.open}
       classes={{ paper: props.selectorDialog }}
       onClose={() => closeAndResetState()}
-      PaperProps={{ id: 'pipelineSelectorDialog' }}
+      slotProps={{ paper: { id: 'pipelineSelectorDialog' } }}
     >
       <DialogContent>
         {getToolbar()}

--- a/frontend/src/components/PipelinesDialogV2.tsx
+++ b/frontend/src/components/PipelinesDialogV2.tsx
@@ -134,7 +134,7 @@ const PipelinesDialogV2: React.FC<PipelinesDialogV2Props> = (props): React.JSX.E
       open={props.open}
       classes={{ paper: props.selectorDialog }}
       onClose={() => closeAndResetState()}
-      PaperProps={{ id: 'pipelineSelectorDialog' }}
+      slotProps={{ paper: { id: 'pipelineSelectorDialog' } }}
     >
       <DialogContent>
         {getToolbar()}

--- a/frontend/src/components/ReduceGraphSwitch.test.tsx
+++ b/frontend/src/components/ReduceGraphSwitch.test.tsx
@@ -26,20 +26,20 @@ describe('ReduceGraphSwitch', () => {
 
   it('renders the switch in unchecked state by default', () => {
     render(<ReduceGraphSwitch />);
-    const switchInput = screen.getByRole('checkbox');
+    const switchInput = screen.getByRole('switch', { name: 'Simplify Graph' });
     expect(switchInput).not.toBeChecked();
   });
 
   it('renders the switch in checked state when checked prop is true', () => {
     render(<ReduceGraphSwitch checked={true} />);
-    const switchInput = screen.getByRole('checkbox');
+    const switchInput = screen.getByRole('switch', { name: 'Simplify Graph' });
     expect(switchInput).toBeChecked();
   });
 
   it('calls onChange when the switch is toggled', () => {
     const handleChange = vi.fn();
     render(<ReduceGraphSwitch onChange={handleChange} />);
-    const switchInput = screen.getByRole('checkbox');
+    const switchInput = screen.getByRole('switch', { name: 'Simplify Graph' });
     fireEvent.click(switchInput);
     expect(handleChange).toHaveBeenCalled();
   });

--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -103,10 +103,10 @@ describe('SideNav', () => {
     const docsButton = renderResult.getByRole('button', { name: 'Documentation' });
     const docsLink = docsButton.closest('a');
 
-    expect(pipelinesButton).toHaveClass('MuiButton-textInherit');
-    expect(pipelinesButton).not.toHaveClass('MuiButton-textPrimary');
-    expect(docsButton).toHaveClass('MuiButton-textInherit');
-    expect(docsButton).not.toHaveClass('MuiButton-textPrimary');
+    expect(pipelinesButton).toHaveClass('MuiButton-text', 'MuiButton-colorInherit');
+    expect(pipelinesButton).not.toHaveClass('MuiButton-colorPrimary');
+    expect(docsButton).toHaveClass('MuiButton-text', 'MuiButton-colorInherit');
+    expect(docsButton).not.toHaveClass('MuiButton-colorPrimary');
     expect(docsLink).toHaveAttribute('href', ExternalLinks.DOCUMENTATION);
     expect(docsLink).toHaveAttribute('target', '_blank');
     expect(docsLink).toHaveAttribute('rel', 'noopener noreferrer');

--- a/frontend/src/components/Trigger.test.tsx
+++ b/frontend/src/components/Trigger.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
@@ -72,14 +73,14 @@ describe('Trigger', () => {
 
   it('renders periodic schedule controls for initial render', () => {
     const { asFragment, unmount } = render(<Trigger />);
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
     unmount();
   });
 
   it('renders periodic schedule controls if the trigger type is CRON', async () => {
     const { asFragment, unmount } = render(<Trigger />);
     await selectOption(getTriggerTypeSelect(), 'Cron');
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
     unmount();
   });
 
@@ -87,7 +88,7 @@ describe('Trigger', () => {
     const { asFragment, unmount } = render(<Trigger />);
     await selectOption(getTriggerTypeSelect(), 'Cron');
     await selectOption(getIntervalCategorySelect(), 'Week');
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
     unmount();
   });
 
@@ -96,7 +97,7 @@ describe('Trigger', () => {
     await selectOption(getTriggerTypeSelect(), 'Cron');
     await selectOption(getIntervalCategorySelect(), 'Week');
     fireEvent.click(screen.getByRole('checkbox', { name: 'All' }));
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
     unmount();
   });
 
@@ -106,7 +107,7 @@ describe('Trigger', () => {
     await selectOption(getIntervalCategorySelect(), 'Week');
     fireEvent.click(screen.getByRole('button', { name: 'M' }));
     fireEvent.click(screen.getByRole('button', { name: 'W' }));
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
     unmount();
   });
 

--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -204,7 +204,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
               value={startDate}
               width={160}
               variant='outlined'
-              InputLabelProps={{ classes: { outlined: css.noMargin }, shrink: true }}
+              slotProps={{ inputLabel: { classes: { outlined: css.noMargin }, shrink: true } }}
               style={{ visibility: hasStartDate ? 'visible' : 'hidden' }}
             />
             <Separator />
@@ -215,7 +215,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
               value={startTime}
               width={120}
               variant='outlined'
-              InputLabelProps={{ classes: { outlined: css.noMargin }, shrink: true }}
+              slotProps={{ inputLabel: { classes: { outlined: css.noMargin }, shrink: true } }}
               style={{ visibility: hasStartDate ? 'visible' : 'hidden' }}
             />
           </div>
@@ -245,7 +245,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
               value={endDate}
               width={160}
               style={{ visibility: hasEndDate ? 'visible' : 'hidden' }}
-              InputLabelProps={{ classes: { outlined: css.noMargin }, shrink: true }}
+              slotProps={{ inputLabel: { classes: { outlined: css.noMargin }, shrink: true } }}
               variant='outlined'
             />
             <Separator />
@@ -256,7 +256,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
               value={endTime}
               width={120}
               style={{ visibility: hasEndDate ? 'visible' : 'hidden' }}
-              InputLabelProps={{ classes: { outlined: css.noMargin }, shrink: true }}
+              slotProps={{ inputLabel: { classes: { outlined: css.noMargin }, shrink: true } }}
               variant='outlined'
             />
           </div>
@@ -307,7 +307,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
                 <Input
                   required={true}
                   type='number'
-                  inputProps={{ min: 1 }}
+                  slotProps={{ htmlInput: { min: 1 } }}
                   onChange={this.handleChange('intervalValue')}
                   value={intervalValue}
                   height={30}

--- a/frontend/src/components/UploadPipelineDialog.tsx
+++ b/frontend/src/components/UploadPipelineDialog.tsx
@@ -218,19 +218,21 @@ class UploadPipelineDialog extends React.Component<
                   required={true}
                   label='File'
                   variant='outlined'
-                  InputProps={{
-                    endAdornment: (
-                      <InputAdornment position='end'>
-                        <Button
-                          color='secondary'
-                          onClick={() => this._dropzoneRef.current!.open()}
-                          style={{ padding: '3px 5px', margin: 0, whiteSpace: 'nowrap' }}
-                        >
-                          Choose file
-                        </Button>
-                      </InputAdornment>
-                    ),
-                    readOnly: true,
+                  slotProps={{
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position='end'>
+                          <Button
+                            color='secondary'
+                            onClick={() => this._dropzoneRef.current!.open()}
+                            style={{ padding: '3px 5px', margin: 0, whiteSpace: 'nowrap' }}
+                          >
+                            Choose file
+                          </Button>
+                        </InputAdornment>
+                      ),
+                      readOnly: true,
+                    },
                   }}
                 />
                 {fileError && <div className={css.fileError}>{fileError}</div>}

--- a/frontend/src/components/__snapshots__/Banner.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Banner.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Banner > defaults to error mode 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-1umw9bq-MuiSvgIcon-root"
         data-testid="ErrorIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -38,7 +38,7 @@ exports[`Banner > shows "Details" button and has dialog when there is additional
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-1umw9bq-MuiSvgIcon-root"
         data-testid="ErrorIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -53,14 +53,11 @@ exports[`Banner > shows "Details" button and has dialog when there is additional
       class="flex_f16jawj4"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_fu86r2b detailsButton_fgq2mjo css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_fu86r2b detailsButton_fgq2mjo css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
         Details
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>
@@ -77,7 +74,7 @@ exports[`Banner > shows "Refresh" button when passed a refresh function 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-1umw9bq-MuiSvgIcon-root"
         data-testid="ErrorIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -92,14 +89,11 @@ exports[`Banner > shows "Refresh" button when passed a refresh function 1`] = `
       class="flex_f16jawj4"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_fu86r2b refreshButton_fgq2mjo css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_fu86r2b refreshButton_fgq2mjo css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
         Refresh
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>
@@ -116,7 +110,7 @@ exports[`Banner > uses error mode when instructed 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-1umw9bq-MuiSvgIcon-root"
         data-testid="ErrorIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -144,7 +138,7 @@ exports[`Banner > uses info mode when instructed 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-1umw9bq-MuiSvgIcon-root"
         data-testid="InfoIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -172,7 +166,7 @@ exports[`Banner > uses warning mode when instructed 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1jqzauf css-1umw9bq-MuiSvgIcon-root"
         data-testid="WarningIcon"
         focusable="false"
         viewBox="0 0 24 24"

--- a/frontend/src/components/__snapshots__/CollapseButton.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CollapseButton.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`CollapseButton > initial render 1`] = `
 <DocumentFragment>
   <div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       title="Expand/Collapse this section"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
         data-testid="ArrowDropUpIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -21,9 +21,6 @@ exports[`CollapseButton > initial render 1`] = `
         />
       </svg>
       testSection
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
   </div>
 </DocumentFragment>
@@ -33,14 +30,14 @@ exports[`CollapseButton > renders the button collapsed if in collapsedSections 1
 <DocumentFragment>
   <div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       title="Expand/Collapse this section"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-1umw9bq-MuiSvgIcon-root"
         data-testid="ArrowDropUpIcon"
         focusable="false"
         viewBox="0 0 24 24"
@@ -50,9 +47,6 @@ exports[`CollapseButton > renders the button collapsed if in collapsedSections 1
         />
       </svg>
       testSection
-      <span
-        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-      />
     </button>
   </div>
 </DocumentFragment>

--- a/frontend/src/components/__snapshots__/CustomTableRow.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CustomTableRow.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`CustomTable > displays warning icon with tooltip if row has error 1`] =
     <svg
       aria-hidden="true"
       aria-label="dummy error"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_fxbzgfm css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_fxbzgfm css-1umw9bq-MuiSvgIcon-root"
       data-mui-internal-clone-element="true"
       data-testid="WarningRoundedIcon"
       focusable="false"

--- a/frontend/src/components/__snapshots__/Graph.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Graph.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Graph > gracefully renders a graph with a selected node id that does no
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -53,7 +53,7 @@ exports[`Graph > gracefully renders a graph with a selected node id that does no
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -110,7 +110,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -140,7 +140,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -170,7 +170,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -200,7 +200,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -230,7 +230,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -260,7 +260,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -441,7 +441,7 @@ exports[`Graph > renders a graph with a placeholder node and edge 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -464,7 +464,7 @@ exports[`Graph > renders a graph with a placeholder node and edge 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -513,7 +513,7 @@ exports[`Graph > renders a graph with a selected node 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -543,7 +543,7 @@ exports[`Graph > renders a graph with a selected node 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -600,7 +600,7 @@ exports[`Graph > renders a graph with colored edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -630,7 +630,7 @@ exports[`Graph > renders a graph with colored edges 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -687,7 +687,7 @@ exports[`Graph > renders a graph with colored nodes 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -717,7 +717,7 @@ exports[`Graph > renders a graph with colored nodes 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -756,7 +756,7 @@ exports[`Graph > renders a graph with one node 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -795,7 +795,7 @@ exports[`Graph > renders a graph with two connectd nodes 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -825,7 +825,7 @@ exports[`Graph > renders a graph with two connectd nodes 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -882,7 +882,7 @@ exports[`Graph > renders a graph with two connectd nodes in reverse order 1`] = 
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -912,7 +912,7 @@ exports[`Graph > renders a graph with two connectd nodes in reverse order 1`] = 
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -969,7 +969,7 @@ exports[`Graph > renders a graph with two disparate nodes 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"
@@ -999,7 +999,7 @@ exports[`Graph > renders a graph with two disparate nodes 1`] = `
         <svg
           aria-hidden="true"
           aria-label="Test icon tooltip"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-mui-internal-clone-element="true"
           data-testid="CheckCircleIcon"
           focusable="false"

--- a/frontend/src/components/__snapshots__/NewRunParameters.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/NewRunParameters.test.tsx.snap
@@ -28,10 +28,10 @@ exports[`NewRunParameters > shows parameters 1`] = `
     </div>
     <div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 textfield_f2qghku css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 textfield_f2qghku css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="newRunPipelineParam0"
           id="newRunPipelineParam0-label"
@@ -39,21 +39,21 @@ exports[`NewRunParameters > shows parameters 1`] = `
           testParam
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="newRunPipelineParam0"
             type="text"
             value="testVal"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 testParam

--- a/frontend/src/components/__snapshots__/PipelinesDialog.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/PipelinesDialog.test.tsx.snap
@@ -10,12 +10,12 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
       aria-hidden="true"
     />
     <div
-      class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+      class="MuiDialog-root MuiModal-root css-1424xw8-MuiModal-root-MuiDialog-root"
       role="presentation"
     >
       <div
         aria-hidden="true"
-        class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+        class="MuiBackdrop-root MuiModal-backdrop MuiDialog-backdrop css-1cennmq-MuiBackdrop-root-MuiDialog-backdrop"
         style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
       />
       <div
@@ -23,19 +23,23 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
         tabindex="0"
       />
       <div
-        class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+        class="MuiDialog-container MuiDialog-scrollPaper css-19do60a-MuiDialog-container"
         role="presentation"
         style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         tabindex="-1"
       >
         <div
           aria-labelledby="_r_0_"
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm css-1t1j96h-MuiPaper-root-MuiDialog-paper"
+          aria-modal="true"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperWidthSm css-uq7k9j-MuiPaper-root-MuiDialog-paper"
+          data-mui-focusable=""
           id="pipelineSelectorDialog"
           role="dialog"
+          style="--Paper-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);"
+          tabindex="-1"
         >
           <div
-            class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+            class="MuiDialogContent-root css-kw13he-MuiDialogContent-root"
           >
             <div
               class="root_f1vld0bw topLevelToolbar_faeji1w"
@@ -76,7 +80,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                 />
                 <button
                   aria-label="Only people who have access to this namespace will be able to view and use these pipelines."
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-mui-internal-clone-element="true"
                   tabindex="0"
                   type="button"
@@ -84,13 +88,10 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   <span>
                     Private
                   </span>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
                 <button
                   aria-label="Everyone in your organization will be able to view and use these pipelines."
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-mui-internal-clone-element="true"
                   tabindex="0"
                   type="button"
@@ -98,9 +99,6 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   <span>
                     Shared
                   </span>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
               <div
@@ -108,12 +106,12 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
               >
                 <div>
                   <div
-                    class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                    class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                     spellcheck="false"
                     style="height: 48px; max-width: 100%; width: 100%;"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
                       for="tableFilterBox"
                       id="tableFilterBox-label"
@@ -121,14 +119,14 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                       Filter pipelines
                     </label>
                     <div
-                      class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                      class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
                     >
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                           data-testid="FilterListIcon"
                           focusable="false"
                           style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -141,17 +139,17 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                       </div>
                       <input
                         aria-invalid="false"
-                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                        class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                         id="tableFilterBox"
                         type="text"
                         value=""
                       />
                       <fieldset
                         aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                        class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="css-sl37lx-MuiNotchedOutlined-root"
+                          class="css-ex8a5f-MuiNotchedOutlined-root"
                         >
                           <span>
                             Filter pipelines
@@ -178,7 +176,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   >
                     <span
                       aria-label="Sort"
-                      class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                      class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                       data-mui-internal-clone-element="true"
                       role="button"
                       tabindex="0"
@@ -186,7 +184,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                       Pipeline name
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                         data-testid="ArrowDownwardIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -204,7 +202,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   >
                     <span
                       aria-label="Cannot sort by this column"
-                      class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                      class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                       data-mui-internal-clone-element="true"
                       role="button"
                       tabindex="0"
@@ -219,7 +217,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   >
                     <span
                       aria-label="Sort"
-                      class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                      class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                       data-mui-internal-clone-element="true"
                       role="button"
                       tabindex="0"
@@ -227,7 +225,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                       Uploaded on
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                         data-testid="ArrowDownwardIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -258,18 +256,18 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                         class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                       >
                         <span
-                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
                         >
                           <input
-                            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                             type="radio"
                           />
                           <span
-                            class="css-19y5vkv-MuiRadioButtonIcon-root"
+                            class="css-9oxshb-MuiRadioButtonIcon-root"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonUncheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -280,7 +278,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonCheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -290,9 +288,6 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                               />
                             </svg>
                           </span>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
                         </span>
                       </div>
                       <div
@@ -334,18 +329,18 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                         class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                       >
                         <span
-                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
                         >
                           <input
-                            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                             type="radio"
                           />
                           <span
-                            class="css-19y5vkv-MuiRadioButtonIcon-root"
+                            class="css-9oxshb-MuiRadioButtonIcon-root"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonUncheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -356,7 +351,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonCheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -366,9 +361,6 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                               />
                             </svg>
                           </span>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
                         </span>
                       </div>
                       <div
@@ -405,18 +397,16 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                     Rows per page:
                   </span>
                   <div
-                    class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                    class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="_r_8_"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-labelledby="_r_7_"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                        id="_r_7_"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        id="_r_9_"
                         role="combobox"
                         tabindex="0"
                       >
@@ -425,13 +415,14 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                        id="_r_b_"
                         tabindex="-1"
                         value="10"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -443,7 +434,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                     </div>
                   </div>
                   <button
-                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     data-testid="prev-page-btn"
                     disabled=""
                     tabindex="-1"
@@ -451,7 +442,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ChevronLeftIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -462,7 +453,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                     </svg>
                   </button>
                   <button
-                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     data-testid="next-page-btn"
                     disabled=""
                     tabindex="-1"
@@ -470,7 +461,7 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ChevronRightIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -485,21 +476,18 @@ exports[`PipelinesDialog > it renders correctly in multi user mode 1`] = `
             </div>
           </div>
           <div
-            class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+            class="MuiDialogActions-root MuiDialogActions-spacing css-15fu35s-MuiDialogActions-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="cancelPipelineSelectionBtn"
               tabindex="0"
               type="button"
             >
               Cancel
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="usePipelineBtn"
               tabindex="-1"
@@ -583,12 +571,12 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
       aria-hidden="true"
     />
     <div
-      class="MuiDialog-root MuiModal-root css-zw3mfo-MuiModal-root-MuiDialog-root"
+      class="MuiDialog-root MuiModal-root css-1424xw8-MuiModal-root-MuiDialog-root"
       role="presentation"
     >
       <div
         aria-hidden="true"
-        class="MuiBackdrop-root MuiModal-backdrop css-yiavyu-MuiBackdrop-root-MuiDialog-backdrop"
+        class="MuiBackdrop-root MuiModal-backdrop MuiDialog-backdrop css-1cennmq-MuiBackdrop-root-MuiDialog-backdrop"
         style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
       />
       <div
@@ -596,19 +584,23 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
         tabindex="0"
       />
       <div
-        class="MuiDialog-container MuiDialog-scrollPaper css-hz1bth-MuiDialog-container"
+        class="MuiDialog-container MuiDialog-scrollPaper css-19do60a-MuiDialog-container"
         role="presentation"
         style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         tabindex="-1"
       >
         <div
-          aria-labelledby="_r_b_"
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm css-1t1j96h-MuiPaper-root-MuiDialog-paper"
+          aria-labelledby="_r_i_"
+          aria-modal="true"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation24 MuiDialog-paper MuiDialog-paperWidthSm css-uq7k9j-MuiPaper-root-MuiDialog-paper"
+          data-mui-focusable=""
           id="pipelineSelectorDialog"
           role="dialog"
+          style="--Paper-shadow: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);"
+          tabindex="-1"
         >
           <div
-            class="MuiDialogContent-root css-ypiqx9-MuiDialogContent-root"
+            class="MuiDialogContent-root css-kw13he-MuiDialogContent-root"
           >
             <div
               class="root_f1vld0bw topLevelToolbar_faeji1w"
@@ -642,12 +634,12 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
               >
                 <div>
                   <div
-                    class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                    class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                     spellcheck="false"
                     style="height: 48px; max-width: 100%; width: 100%;"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
                       for="tableFilterBox"
                       id="tableFilterBox-label"
@@ -655,14 +647,14 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                       Filter pipelines
                     </label>
                     <div
-                      class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                      class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
                     >
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                           data-testid="FilterListIcon"
                           focusable="false"
                           style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -675,17 +667,17 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                       </div>
                       <input
                         aria-invalid="false"
-                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                        class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                         id="tableFilterBox"
                         type="text"
                         value=""
                       />
                       <fieldset
                         aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                        class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                       >
                         <legend
-                          class="css-sl37lx-MuiNotchedOutlined-root"
+                          class="css-ex8a5f-MuiNotchedOutlined-root"
                         >
                           <span>
                             Filter pipelines
@@ -712,7 +704,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                   >
                     <span
                       aria-label="Sort"
-                      class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                      class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                       data-mui-internal-clone-element="true"
                       role="button"
                       tabindex="0"
@@ -720,7 +712,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                       Pipeline name
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                         data-testid="ArrowDownwardIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -738,7 +730,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                   >
                     <span
                       aria-label="Cannot sort by this column"
-                      class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                      class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                       data-mui-internal-clone-element="true"
                       role="button"
                       tabindex="0"
@@ -753,7 +745,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                   >
                     <span
                       aria-label="Sort"
-                      class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                      class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                       data-mui-internal-clone-element="true"
                       role="button"
                       tabindex="0"
@@ -761,7 +753,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                       Uploaded on
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                         data-testid="ArrowDownwardIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -792,18 +784,18 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                         class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                       >
                         <span
-                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
                         >
                           <input
-                            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                             type="radio"
                           />
                           <span
-                            class="css-19y5vkv-MuiRadioButtonIcon-root"
+                            class="css-9oxshb-MuiRadioButtonIcon-root"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonUncheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -814,7 +806,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonCheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -824,9 +816,6 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                               />
                             </svg>
                           </span>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
                         </span>
                       </div>
                       <div
@@ -868,18 +857,18 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                         class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                       >
                         <span
-                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+                          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
                         >
                           <input
-                            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                             type="radio"
                           />
                           <span
-                            class="css-19y5vkv-MuiRadioButtonIcon-root"
+                            class="css-9oxshb-MuiRadioButtonIcon-root"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonUncheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -890,7 +879,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                             </svg>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                               data-testid="RadioButtonCheckedIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -900,9 +889,6 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                               />
                             </svg>
                           </span>
-                          <span
-                            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                          />
                         </span>
                       </div>
                       <div
@@ -939,18 +925,16 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                     Rows per page:
                   </span>
                   <div
-                    class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                    class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="_r_h_"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-labelledby="_r_g_"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                        id="_r_g_"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        id="_r_n_"
                         role="combobox"
                         tabindex="0"
                       >
@@ -959,13 +943,14 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                        id="_r_p_"
                         tabindex="-1"
                         value="10"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -977,7 +962,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                     </div>
                   </div>
                   <button
-                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     data-testid="prev-page-btn"
                     disabled=""
                     tabindex="-1"
@@ -985,7 +970,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ChevronLeftIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -996,7 +981,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                     </svg>
                   </button>
                   <button
-                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     data-testid="next-page-btn"
                     disabled=""
                     tabindex="-1"
@@ -1004,7 +989,7 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ChevronRightIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1019,21 +1004,18 @@ exports[`PipelinesDialog > it renders correctly in single user mode 1`] = `
             </div>
           </div>
           <div
-            class="MuiDialogActions-root MuiDialogActions-spacing css-knqc4i-MuiDialogActions-root"
+            class="MuiDialogActions-root MuiDialogActions-spacing css-15fu35s-MuiDialogActions-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="cancelPipelineSelectionBtn"
               tabindex="0"
               type="button"
             >
               Cancel
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="usePipelineBtn"
               tabindex="-1"

--- a/frontend/src/components/__snapshots__/PlotCard.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/PlotCard.test.tsx.snap
@@ -4,7 +4,8 @@ exports[`PlotCard > renders a confusion matrix plot card 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+      style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
     >
       <div
         class="plotHeader_fnedsm"
@@ -17,7 +18,7 @@ exports[`PlotCard > renders a confusion matrix plot card 1`] = `
         </div>
         <div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-testid="pop-out-button"
             style="padding: 4px; min-height: 0; min-width: 0;"
             tabindex="0"
@@ -26,7 +27,7 @@ exports[`PlotCard > renders a confusion matrix plot card 1`] = `
             <svg
               aria-hidden="true"
               aria-label="Pop out"
-              class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-mui-internal-clone-element="true"
               data-testid="LaunchIcon"
               focusable="false"
@@ -36,9 +37,6 @@ exports[`PlotCard > renders a confusion matrix plot card 1`] = `
                 d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
       </div>

--- a/frontend/src/components/__snapshots__/PrivateSharedSelector.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/PrivateSharedSelector.test.tsx.snap
@@ -13,24 +13,24 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
       >
         <label
           aria-label="Only people who have access to this namespace will be able to view and use this pipeline."
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
           data-mui-internal-clone-element="true"
           id="createNewPrivatePipelineBtn"
         >
           <span
-            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               type="radio"
             />
             <span
-              class="css-19y5vkv-MuiRadioButtonIcon-root"
+              class="css-9oxshb-MuiRadioButtonIcon-root"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                 data-testid="RadioButtonUncheckedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -41,7 +41,7 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                 data-testid="RadioButtonCheckedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -51,35 +51,32 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
                 />
               </svg>
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Private
           </span>
         </label>
         <label
           aria-label="Everyone in your organization will be able to view and use this pipeline."
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
           data-mui-internal-clone-element="true"
           id="createNewSharedPipelineBtn"
         >
           <span
-            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               type="radio"
             />
             <span
-              class="css-19y5vkv-MuiRadioButtonIcon-root"
+              class="css-9oxshb-MuiRadioButtonIcon-root"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                 data-testid="RadioButtonUncheckedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -90,7 +87,7 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
               </svg>
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
                 data-testid="RadioButtonCheckedIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -100,12 +97,9 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
                 />
               </svg>
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Shared
           </span>
@@ -122,24 +116,24 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
     >
       <label
         aria-label="Only people who have access to this namespace will be able to view and use this pipeline."
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         data-mui-internal-clone-element="true"
         id="createNewPrivatePipelineBtn"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -150,7 +144,7 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -160,35 +154,32 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Private
         </span>
       </label>
       <label
         aria-label="Everyone in your organization will be able to view and use this pipeline."
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         data-mui-internal-clone-element="true"
         id="createNewSharedPipelineBtn"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -199,7 +190,7 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -209,12 +200,9 @@ exports[`PrivateSharedSelector > it renders correctly 1`] = `
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Shared
         </span>

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Router > initial render 1`] = `
             id="pipelinesBtn"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -92,9 +92,6 @@ exports[`Router > initial render 1`] = `
                   Pipelines
                 </span>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <div
@@ -108,7 +105,7 @@ exports[`Router > initial render 1`] = `
             id="experimentsBtn"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -170,9 +167,6 @@ exports[`Router > initial render 1`] = `
                   Experiments
                 </span>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <div
@@ -186,7 +180,7 @@ exports[`Router > initial render 1`] = `
             id="runsBtn"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -195,7 +189,7 @@ exports[`Router > initial render 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="DirectionsRunIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -210,9 +204,6 @@ exports[`Router > initial render 1`] = `
                   Runs
                 </span>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <div
@@ -226,7 +217,7 @@ exports[`Router > initial render 1`] = `
             id="recurringRunsBtn"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -235,7 +226,7 @@ exports[`Router > initial render 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="AlarmIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -250,9 +241,6 @@ exports[`Router > initial render 1`] = `
                   Recurring Runs
                 </span>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <div
@@ -266,7 +254,7 @@ exports[`Router > initial render 1`] = `
             id="artifactsBtn"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -275,7 +263,7 @@ exports[`Router > initial render 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="BubbleChartIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -302,9 +290,6 @@ exports[`Router > initial render 1`] = `
                   Artifacts
                 </span>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <div
@@ -318,7 +303,7 @@ exports[`Router > initial render 1`] = `
             id="executionsBtn"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -327,7 +312,7 @@ exports[`Router > initial render 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="PlayArrowIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -342,9 +327,6 @@ exports[`Router > initial render 1`] = `
                   Executions
                 </span>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <hr
@@ -359,7 +341,7 @@ exports[`Router > initial render 1`] = `
             target="_blank"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -368,7 +350,7 @@ exports[`Router > initial render 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
                   data-testid="DescriptionIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -384,7 +366,7 @@ exports[`Router > initial render 1`] = `
                 </span>
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
                   data-testid="OpenInNewIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -394,9 +376,6 @@ exports[`Router > initial render 1`] = `
                   />
                 </svg>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <a
@@ -408,7 +387,7 @@ exports[`Router > initial render 1`] = `
             target="_blank"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
@@ -427,7 +406,7 @@ exports[`Router > initial render 1`] = `
                 </span>
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
                   data-testid="OpenInNewIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -437,23 +416,20 @@ exports[`Router > initial render 1`] = `
                   />
                 </svg>
               </div>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </a>
           <hr
             class="separator_furuwhr"
           />
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             data-testid="chevron-toggle"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="ChevronLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -462,9 +438,6 @@ exports[`Router > initial render 1`] = `
                 d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <div
@@ -535,14 +508,14 @@ exports[`Router > initial render 1`] = `
               >
                  
                 <button
-                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                  class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                   disabled=""
                   tabindex="-1"
                   type="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 disabled_fl0don4 css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 disabled_fl0don4 css-1umw9bq-MuiSvgIcon-root"
                     data-testid="ArrowBackIcon"
                     focusable="false"
                     viewBox="0 0 24 24"

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -86,9 +86,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -102,7 +99,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -164,9 +161,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -180,7 +174,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -189,7 +183,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -204,9 +198,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -220,7 +211,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -229,7 +220,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -244,9 +235,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -260,7 +248,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -269,7 +257,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -296,9 +284,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -312,7 +297,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -321,7 +306,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -336,9 +321,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -353,7 +335,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -362,7 +344,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -378,7 +360,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -388,9 +370,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -402,7 +381,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -421,7 +400,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -431,23 +410,20 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -456,9 +432,6 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -538,7 +511,7 @@ exports[`SideNav > populates the display build information using the default pro
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -603,9 +576,6 @@ exports[`SideNav > populates the display build information using the default pro
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -619,7 +589,7 @@ exports[`SideNav > populates the display build information using the default pro
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -681,9 +651,6 @@ exports[`SideNav > populates the display build information using the default pro
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -697,7 +664,7 @@ exports[`SideNav > populates the display build information using the default pro
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -706,7 +673,7 @@ exports[`SideNav > populates the display build information using the default pro
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -721,9 +688,6 @@ exports[`SideNav > populates the display build information using the default pro
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -737,7 +701,7 @@ exports[`SideNav > populates the display build information using the default pro
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -746,7 +710,7 @@ exports[`SideNav > populates the display build information using the default pro
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -761,9 +725,6 @@ exports[`SideNav > populates the display build information using the default pro
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -777,7 +738,7 @@ exports[`SideNav > populates the display build information using the default pro
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -786,7 +747,7 @@ exports[`SideNav > populates the display build information using the default pro
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -813,9 +774,6 @@ exports[`SideNav > populates the display build information using the default pro
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -829,7 +787,7 @@ exports[`SideNav > populates the display build information using the default pro
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -838,7 +796,7 @@ exports[`SideNav > populates the display build information using the default pro
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -853,9 +811,6 @@ exports[`SideNav > populates the display build information using the default pro
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -870,7 +825,7 @@ exports[`SideNav > populates the display build information using the default pro
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -879,7 +834,7 @@ exports[`SideNav > populates the display build information using the default pro
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -895,7 +850,7 @@ exports[`SideNav > populates the display build information using the default pro
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -905,9 +860,6 @@ exports[`SideNav > populates the display build information using the default pro
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -919,7 +871,7 @@ exports[`SideNav > populates the display build information using the default pro
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -938,7 +890,7 @@ exports[`SideNav > populates the display build information using the default pro
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -948,23 +900,20 @@ exports[`SideNav > populates the display build information using the default pro
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -973,9 +922,6 @@ exports[`SideNav > populates the display build information using the default pro
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -1038,7 +984,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1103,9 +1049,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1119,7 +1062,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1181,9 +1124,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1197,7 +1137,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1206,7 +1146,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1221,9 +1161,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1237,7 +1174,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1246,7 +1183,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1261,9 +1198,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1277,7 +1211,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1286,7 +1220,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1313,9 +1247,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1329,7 +1260,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1338,7 +1269,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1353,9 +1284,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -1370,7 +1298,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1379,7 +1307,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1395,7 +1323,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1405,9 +1333,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -1419,7 +1344,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1438,7 +1363,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1448,23 +1373,20 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1473,9 +1395,6 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -1538,7 +1457,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1603,9 +1522,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1619,7 +1535,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1681,9 +1597,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1697,7 +1610,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1706,7 +1619,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1721,9 +1634,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1737,7 +1647,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1746,7 +1656,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1761,9 +1671,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1777,7 +1684,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1786,7 +1693,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1813,9 +1720,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -1829,7 +1733,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1838,7 +1742,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1853,9 +1757,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -1870,7 +1771,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1879,7 +1780,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1895,7 +1796,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1905,9 +1806,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -1919,7 +1817,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -1938,7 +1836,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1948,23 +1846,20 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1973,9 +1868,6 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -2038,7 +1930,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2103,9 +1995,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2119,7 +2008,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2181,9 +2070,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2197,7 +2083,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2206,7 +2092,7 @@ exports[`SideNav > renders collapsed state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2221,9 +2107,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2237,7 +2120,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2246,7 +2129,7 @@ exports[`SideNav > renders collapsed state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2261,9 +2144,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2277,7 +2157,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2286,7 +2166,7 @@ exports[`SideNav > renders collapsed state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2313,9 +2193,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2329,7 +2206,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2338,7 +2215,7 @@ exports[`SideNav > renders collapsed state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2353,9 +2230,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -2370,7 +2244,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2379,7 +2253,7 @@ exports[`SideNav > renders collapsed state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2395,7 +2269,7 @@ exports[`SideNav > renders collapsed state 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2405,9 +2279,6 @@ exports[`SideNav > renders collapsed state 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -2419,7 +2290,7 @@ exports[`SideNav > renders collapsed state 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2438,7 +2309,7 @@ exports[`SideNav > renders collapsed state 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2448,23 +2319,20 @@ exports[`SideNav > renders collapsed state 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr collapsedSeparator_f1umkwuk"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj collapsedChevron_f18a0vkk css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj collapsedChevron_f18a0vkk css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2473,9 +2341,6 @@ exports[`SideNav > renders collapsed state 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -2538,7 +2403,7 @@ exports[`SideNav > renders expanded state 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2603,9 +2468,6 @@ exports[`SideNav > renders expanded state 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2619,7 +2481,7 @@ exports[`SideNav > renders expanded state 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2681,9 +2543,6 @@ exports[`SideNav > renders expanded state 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2697,7 +2556,7 @@ exports[`SideNav > renders expanded state 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2706,7 +2565,7 @@ exports[`SideNav > renders expanded state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2721,9 +2580,6 @@ exports[`SideNav > renders expanded state 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2737,7 +2593,7 @@ exports[`SideNav > renders expanded state 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2746,7 +2602,7 @@ exports[`SideNav > renders expanded state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2761,9 +2617,6 @@ exports[`SideNav > renders expanded state 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2777,7 +2630,7 @@ exports[`SideNav > renders expanded state 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2786,7 +2639,7 @@ exports[`SideNav > renders expanded state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2813,9 +2666,6 @@ exports[`SideNav > renders expanded state 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -2829,7 +2679,7 @@ exports[`SideNav > renders expanded state 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2838,7 +2688,7 @@ exports[`SideNav > renders expanded state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2853,9 +2703,6 @@ exports[`SideNav > renders expanded state 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -2870,7 +2717,7 @@ exports[`SideNav > renders expanded state 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2879,7 +2726,7 @@ exports[`SideNav > renders expanded state 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2895,7 +2742,7 @@ exports[`SideNav > renders expanded state 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2905,9 +2752,6 @@ exports[`SideNav > renders expanded state 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -2919,7 +2763,7 @@ exports[`SideNav > renders expanded state 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -2938,7 +2782,7 @@ exports[`SideNav > renders expanded state 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2948,23 +2792,20 @@ exports[`SideNav > renders expanded state 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2973,9 +2814,6 @@ exports[`SideNav > renders expanded state 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3038,7 +2876,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3103,9 +2941,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3119,7 +2954,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3181,9 +3016,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3197,7 +3029,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3206,7 +3038,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3221,9 +3053,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3237,7 +3066,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3246,7 +3075,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3261,9 +3090,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3277,7 +3103,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3286,7 +3112,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3313,9 +3139,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3329,7 +3152,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3338,7 +3161,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3353,9 +3176,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -3370,7 +3190,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3379,7 +3199,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3395,7 +3215,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3405,9 +3225,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -3419,7 +3236,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3438,7 +3255,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3448,23 +3265,20 @@ exports[`SideNav > renders experiments as active page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3473,9 +3287,6 @@ exports[`SideNav > renders experiments as active page 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3538,7 +3349,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3603,9 +3414,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3619,7 +3427,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3681,9 +3489,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3697,7 +3502,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3706,7 +3511,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3721,9 +3526,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3737,7 +3539,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3746,7 +3548,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3761,9 +3563,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3777,7 +3576,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3786,7 +3585,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3813,9 +3612,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -3829,7 +3625,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3838,7 +3634,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3853,9 +3649,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -3870,7 +3663,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3879,7 +3672,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3895,7 +3688,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3905,9 +3698,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -3919,7 +3709,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -3938,7 +3728,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3948,23 +3738,20 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3973,9 +3760,6 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -4038,7 +3822,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4103,9 +3887,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4119,7 +3900,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4181,9 +3962,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4197,7 +3975,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4206,7 +3984,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4221,9 +3999,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4237,7 +4012,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4246,7 +4021,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4261,9 +4036,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4277,7 +4049,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4286,7 +4058,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4313,9 +4085,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4329,7 +4098,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4338,7 +4107,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4353,9 +4122,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -4370,7 +4136,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4379,7 +4145,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4395,7 +4161,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4405,9 +4171,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -4419,7 +4182,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4438,7 +4201,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4448,23 +4211,20 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -4473,9 +4233,6 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -4538,7 +4295,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4603,9 +4360,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4619,7 +4373,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4681,9 +4435,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4697,7 +4448,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4706,7 +4457,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4721,9 +4472,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4737,7 +4485,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4746,7 +4494,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4761,9 +4509,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4777,7 +4522,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4786,7 +4531,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4813,9 +4558,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -4829,7 +4571,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4838,7 +4580,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4853,9 +4595,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -4870,7 +4609,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4879,7 +4618,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4895,7 +4634,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4905,9 +4644,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -4919,7 +4655,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -4938,7 +4674,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4948,23 +4684,20 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -4973,9 +4706,6 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5038,7 +4768,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5103,9 +4833,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5119,7 +4846,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5181,9 +4908,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5197,7 +4921,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5206,7 +4930,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5221,9 +4945,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5237,7 +4958,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5246,7 +4967,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5261,9 +4982,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5277,7 +4995,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5286,7 +5004,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5313,9 +5031,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5329,7 +5044,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5338,7 +5053,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5353,9 +5068,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -5370,7 +5082,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5379,7 +5091,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5395,7 +5107,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5405,9 +5117,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -5419,7 +5128,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5438,7 +5147,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5448,23 +5157,20 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5473,9 +5179,6 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5538,7 +5241,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5603,9 +5306,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5619,7 +5319,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5681,9 +5381,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5697,7 +5394,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5706,7 +5403,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5721,9 +5418,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5737,7 +5431,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5746,7 +5440,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5761,9 +5455,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5777,7 +5468,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5786,7 +5477,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5813,9 +5504,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -5829,7 +5517,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5838,7 +5526,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5853,9 +5541,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -5870,7 +5555,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5879,7 +5564,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5895,7 +5580,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5905,9 +5590,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -5919,7 +5601,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -5938,7 +5620,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -5948,23 +5630,20 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5973,9 +5652,6 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -6038,7 +5714,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6103,9 +5779,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6119,7 +5792,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6181,9 +5854,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6197,7 +5867,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6206,7 +5876,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6221,9 +5891,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6237,7 +5904,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6246,7 +5913,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6261,9 +5928,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6277,7 +5941,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6286,7 +5950,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6313,9 +5977,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6329,7 +5990,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6338,7 +5999,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6353,9 +6014,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -6370,7 +6028,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6379,7 +6037,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6395,7 +6053,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6405,9 +6063,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -6419,7 +6074,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6438,7 +6093,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6448,23 +6103,20 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -6473,9 +6125,6 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -6538,7 +6187,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6603,9 +6252,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6619,7 +6265,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6681,9 +6327,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6697,7 +6340,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6706,7 +6349,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6721,9 +6364,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6737,7 +6377,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6746,7 +6386,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6761,9 +6401,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6777,7 +6414,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6786,7 +6423,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6813,9 +6450,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -6829,7 +6463,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6838,7 +6472,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6853,9 +6487,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -6870,7 +6501,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6879,7 +6510,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6895,7 +6526,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6905,9 +6536,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -6919,7 +6547,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -6938,7 +6566,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -6948,23 +6576,20 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -6973,9 +6598,6 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -7038,7 +6660,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7103,9 +6725,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7119,7 +6738,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7181,9 +6800,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7197,7 +6813,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7206,7 +6822,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7221,9 +6837,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7237,7 +6850,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7246,7 +6859,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7261,9 +6874,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7277,7 +6887,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7286,7 +6896,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7313,9 +6923,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7329,7 +6936,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7338,7 +6945,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7353,9 +6960,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -7370,7 +6974,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7379,7 +6983,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7395,7 +6999,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7405,9 +7009,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -7419,7 +7020,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7438,7 +7039,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7448,23 +7049,20 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -7473,9 +7071,6 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -7538,7 +7133,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7603,9 +7198,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7619,7 +7211,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7681,9 +7273,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7697,7 +7286,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7706,7 +7295,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7721,9 +7310,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7737,7 +7323,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7746,7 +7332,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7761,9 +7347,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7777,7 +7360,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7786,7 +7369,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7813,9 +7396,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -7829,7 +7409,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7838,7 +7418,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7853,9 +7433,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -7870,7 +7447,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7879,7 +7456,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7895,7 +7472,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7905,9 +7482,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -7919,7 +7493,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -7938,7 +7512,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -7948,23 +7522,20 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -7973,9 +7544,6 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -8038,7 +7606,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         id="pipelinesBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8103,9 +7671,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               Pipelines
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -8119,7 +7684,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         id="experimentsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8181,9 +7746,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               Experiments
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -8197,7 +7759,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         id="runsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d active_f17ohq9e css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8206,7 +7768,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="DirectionsRunIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8221,9 +7783,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -8237,7 +7796,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         id="recurringRunsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8246,7 +7805,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="AlarmIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8261,9 +7820,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               Recurring Runs
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -8277,7 +7833,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         id="artifactsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8286,7 +7842,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="BubbleChartIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8313,9 +7869,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               Artifacts
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <div
@@ -8329,7 +7882,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         id="executionsBtn"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8338,7 +7891,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="PlayArrowIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8353,9 +7906,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               Executions
             </span>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -8368,7 +7918,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8377,7 +7927,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CodeIcon"
               focusable="false"
               style="height: 20px; width: 20px;"
@@ -8394,7 +7944,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8404,9 +7954,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
@@ -8421,7 +7968,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8430,7 +7977,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1e8lhs7 css-1umw9bq-MuiSvgIcon-root"
               data-testid="DescriptionIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8446,7 +7993,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8456,9 +8003,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <a
@@ -8470,7 +8014,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
         target="_blank"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorInherit button_f17w3f2d css-fz451c-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
@@ -8489,7 +8033,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium openInNewTabIcon_fiish9a css-1umw9bq-MuiSvgIcon-root"
               data-testid="OpenInNewIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -8499,23 +8043,20 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
               />
             </svg>
           </div>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </a>
       <hr
         class="separator_furuwhr"
       />
       <button
-        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-sravn7-MuiButtonBase-root-MuiIconButton-root"
         data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ChevronLeftIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -8524,9 +8065,6 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
             d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div

--- a/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Toolbar.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Toolbar > renders outlined action buttons 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-1umw9bq-MuiSvgIcon-root"
             data-testid="ChevronRightIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -55,13 +55,13 @@ exports[`Toolbar > renders outlined action buttons 1`] = `
         >
            
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-1umw9bq-MuiSvgIcon-root"
               data-testid="ArrowBackIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -70,9 +70,6 @@ exports[`Toolbar > renders outlined action buttons 1`] = `
                 d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <span
@@ -90,7 +87,7 @@ exports[`Toolbar > renders outlined action buttons 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="test outlined id"
           tabindex="0"
           type="button"
@@ -98,9 +95,6 @@ exports[`Toolbar > renders outlined action buttons 1`] = `
           <span>
             test outlined title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
     </div>
@@ -136,7 +130,7 @@ exports[`Toolbar > renders primary action buttons 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-1umw9bq-MuiSvgIcon-root"
             data-testid="ChevronRightIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -163,13 +157,13 @@ exports[`Toolbar > renders primary action buttons 1`] = `
         >
            
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-1umw9bq-MuiSvgIcon-root"
               data-testid="ArrowBackIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -178,9 +172,6 @@ exports[`Toolbar > renders primary action buttons 1`] = `
                 d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <span
@@ -198,7 +189,7 @@ exports[`Toolbar > renders primary action buttons 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test primary id"
           tabindex="0"
           type="button"
@@ -206,9 +197,6 @@ exports[`Toolbar > renders primary action buttons 1`] = `
           <span>
             test primary title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
     </div>
@@ -244,7 +232,7 @@ exports[`Toolbar > renders primary action buttons without outline, even if outli
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-1umw9bq-MuiSvgIcon-root"
             data-testid="ChevronRightIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -271,13 +259,13 @@ exports[`Toolbar > renders primary action buttons without outline, even if outli
         >
            
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-1umw9bq-MuiSvgIcon-root"
               data-testid="ArrowBackIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -286,9 +274,6 @@ exports[`Toolbar > renders primary action buttons without outline, even if outli
                 d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <span
@@ -306,7 +291,7 @@ exports[`Toolbar > renders primary action buttons without outline, even if outli
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test id"
           tabindex="0"
           type="button"
@@ -314,9 +299,6 @@ exports[`Toolbar > renders primary action buttons without outline, even if outli
           <span>
             test title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
     </div>
@@ -352,7 +334,7 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium chevron_fin4unf css-1umw9bq-MuiSvgIcon-root"
             data-testid="ChevronRightIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -379,13 +361,13 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
         >
            
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-1umw9bq-MuiSvgIcon-root"
               data-testid="ArrowBackIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -394,9 +376,6 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
                 d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <span
@@ -414,14 +393,14 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test id"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -433,9 +412,6 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
           <span>
             test title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -444,7 +420,7 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="test id2"
           tabindex="-1"
@@ -452,7 +428,7 @@ exports[`Toolbar > renders with two breadcrumbs and two actions 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="InfoIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -504,13 +480,13 @@ exports[`Toolbar > renders without actions and one breadcrumb 1`] = `
         >
            
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-1umw9bq-MuiSvgIcon-root"
               data-testid="ArrowBackIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -519,9 +495,6 @@ exports[`Toolbar > renders without actions and one breadcrumb 1`] = `
                 d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <span
@@ -572,13 +545,13 @@ exports[`Toolbar > renders without actions, one breadcrumb, and a page name 1`] 
         >
            
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge backLink_fxaclcu css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium backIcon_f116wd06 enabled_fep5z4h css-1umw9bq-MuiSvgIcon-root"
               data-testid="ArrowBackIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -587,9 +560,6 @@ exports[`Toolbar > renders without actions, one breadcrumb, and a page name 1`] 
                 d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <span
@@ -642,14 +612,14 @@ exports[`Toolbar > renders without breadcrumbs and a component page title 1`] = 
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test id"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -661,9 +631,6 @@ exports[`Toolbar > renders without breadcrumbs and a component page title 1`] = 
           <span>
             test title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -672,7 +639,7 @@ exports[`Toolbar > renders without breadcrumbs and a component page title 1`] = 
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="test id2"
           tabindex="-1"
@@ -680,7 +647,7 @@ exports[`Toolbar > renders without breadcrumbs and a component page title 1`] = 
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="InfoIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -730,14 +697,14 @@ exports[`Toolbar > renders without breadcrumbs and a string page title 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test id"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -749,9 +716,6 @@ exports[`Toolbar > renders without breadcrumbs and a string page title 1`] = `
           <span>
             test title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -760,7 +724,7 @@ exports[`Toolbar > renders without breadcrumbs and a string page title 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="test id2"
           tabindex="-1"
@@ -768,7 +732,7 @@ exports[`Toolbar > renders without breadcrumbs and a string page title 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="InfoIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -818,14 +782,14 @@ exports[`Toolbar > renders without breadcrumbs and one action 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test id"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -837,9 +801,6 @@ exports[`Toolbar > renders without breadcrumbs and one action 1`] = `
           <span>
             test title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
     </div>
@@ -878,14 +839,14 @@ exports[`Toolbar > renders without breadcrumbs and two actions 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           id="test id"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -897,9 +858,6 @@ exports[`Toolbar > renders without breadcrumbs and two actions 1`] = `
           <span>
             test title
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -908,7 +866,7 @@ exports[`Toolbar > renders without breadcrumbs and two actions 1`] = `
         data-mui-internal-clone-element="true"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="test id2"
           tabindex="-1"
@@ -916,7 +874,7 @@ exports[`Toolbar > renders without breadcrumbs and two actions 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
             data-testid="InfoIcon"
             focusable="false"
             viewBox="0 0 24 24"

--- a/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
@@ -4,34 +4,33 @@ exports[`Trigger > enables a single day on click 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      <div
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="_r_1f_"
-        id="_r_1f_-label"
+        id="react-use-id-0-label"
       >
         Trigger type
         <span
           aria-hidden="true"
-          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
         >
            *
         </span>
-      </label>
+      </div>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <div
-          aria-controls="_r_1g_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="_r_1f_-label _r_1f_"
-          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_1f_"
+          aria-labelledby="react-use-id-0-label"
+          aria-required="true"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          id="react-use-id-0"
           role="combobox"
           tabindex="0"
         >
@@ -40,14 +39,15 @@ exports[`Trigger > enables a single day on click 1`] = `
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+          id="react-use-id-1"
           required=""
           tabindex="-1"
           value="1"
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -58,10 +58,10 @@ exports[`Trigger > enables a single day on click 1`] = `
         </svg>
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-sl37lx-MuiNotchedOutlined-root"
+            class="css-ex8a5f-MuiNotchedOutlined-root"
           >
             <span>
               Trigger type *
@@ -72,41 +72,41 @@ exports[`Trigger > enables a single day on click 1`] = `
     </div>
     <div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_1h_"
-          id="_r_1h_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Maximum concurrent runs
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_1h_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-2"
             required=""
             type="text"
             value="10"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Maximum concurrent runs *
@@ -119,19 +119,19 @@ exports[`Trigger > enables a single day on click 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -140,45 +140,42 @@ exports[`Trigger > enables a single day on click 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has start date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_1i_"
-            id="_r_1i_-label"
+            for="react-use-id-3"
+            id="react-use-id-3-label"
           >
             Start date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1i_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-3"
               type="date"
               value="2018-12-21"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start date
@@ -191,34 +188,34 @@ exports[`Trigger > enables a single day on click 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_1j_"
-            id="_r_1j_-label"
+            for="react-use-id-4"
+            id="react-use-id-4-label"
           >
             Start time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1j_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start time
@@ -237,19 +234,19 @@ exports[`Trigger > enables a single day on click 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -258,45 +255,42 @@ exports[`Trigger > enables a single day on click 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has end date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_1k_"
-            id="_r_1k_-label"
+            for="react-use-id-5"
+            id="react-use-id-5-label"
           >
             End date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1k_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-5"
               type="date"
               value="2018-12-28"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End date
@@ -309,34 +303,34 @@ exports[`Trigger > enables a single day on click 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_1l_"
-            id="_r_1l_-label"
+            for="react-use-id-6"
+            id="react-use-id-6-label"
           >
             End time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1l_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-6"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End time
@@ -355,20 +349,20 @@ exports[`Trigger > enables a single day on click 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -377,25 +371,22 @@ exports[`Trigger > enables a single day on click 1`] = `
                 d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Catchup
           </span>
         </label>
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -404,9 +395,6 @@ exports[`Trigger > enables a single day on click 1`] = `
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </span>
       <span
@@ -417,20 +405,19 @@ exports[`Trigger > enables a single day on click 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 30px; max-width: 600px; width: 95px;"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_1p_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_1o_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1o_"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-7"
               role="combobox"
               tabindex="0"
             >
@@ -439,14 +426,15 @@ exports[`Trigger > enables a single day on click 1`] = `
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-8"
               required=""
               tabindex="-1"
               value="Week"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -457,12 +445,13 @@ exports[`Trigger > enables a single day on click 1`] = `
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-1whs34k-MuiNotchedOutlined-root"
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
               >
                 <span
+                  aria-hidden="true"
                   class="notranslate"
                 >
                   ​
@@ -479,20 +468,20 @@ exports[`Trigger > enables a single day on click 1`] = `
           On:
         </span>
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -501,12 +490,9 @@ exports[`Trigger > enables a single day on click 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             All
           </span>
@@ -515,93 +501,72 @@ exports[`Trigger > enables a single day on click 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           S
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           M
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           T
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           W
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           T
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           F
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           S
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -610,12 +575,9 @@ exports[`Trigger > enables a single day on click 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <span>
               Allow editing cron expression. (format is specified 
@@ -633,35 +595,35 @@ exports[`Trigger > enables a single day on click 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 300px;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_1q_"
-          id="_r_1q_-label"
+          for="react-use-id-9"
+          id="react-use-id-9-label"
         >
           cron expression
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_1q_"
+            id="react-use-id-9"
             type="text"
             value="0 0 0 ? * 0,2,4,5,6"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 cron expression
@@ -682,34 +644,33 @@ exports[`Trigger > renders all week days enabled 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      <div
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="_r_13_"
-        id="_r_13_-label"
+        id="react-use-id-0-label"
       >
         Trigger type
         <span
           aria-hidden="true"
-          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
         >
            *
         </span>
-      </label>
+      </div>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <div
-          aria-controls="_r_14_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="_r_13_-label _r_13_"
-          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_13_"
+          aria-labelledby="react-use-id-0-label"
+          aria-required="true"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          id="react-use-id-0"
           role="combobox"
           tabindex="0"
         >
@@ -718,14 +679,15 @@ exports[`Trigger > renders all week days enabled 1`] = `
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+          id="react-use-id-1"
           required=""
           tabindex="-1"
           value="1"
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -736,10 +698,10 @@ exports[`Trigger > renders all week days enabled 1`] = `
         </svg>
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-sl37lx-MuiNotchedOutlined-root"
+            class="css-ex8a5f-MuiNotchedOutlined-root"
           >
             <span>
               Trigger type *
@@ -750,41 +712,41 @@ exports[`Trigger > renders all week days enabled 1`] = `
     </div>
     <div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_15_"
-          id="_r_15_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Maximum concurrent runs
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_15_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-2"
             required=""
             type="text"
             value="10"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Maximum concurrent runs *
@@ -797,19 +759,19 @@ exports[`Trigger > renders all week days enabled 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -818,45 +780,42 @@ exports[`Trigger > renders all week days enabled 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has start date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_16_"
-            id="_r_16_-label"
+            for="react-use-id-3"
+            id="react-use-id-3-label"
           >
             Start date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_16_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-3"
               type="date"
               value="2018-12-21"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start date
@@ -869,34 +828,34 @@ exports[`Trigger > renders all week days enabled 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_17_"
-            id="_r_17_-label"
+            for="react-use-id-4"
+            id="react-use-id-4-label"
           >
             Start time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_17_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start time
@@ -915,19 +874,19 @@ exports[`Trigger > renders all week days enabled 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -936,45 +895,42 @@ exports[`Trigger > renders all week days enabled 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has end date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_18_"
-            id="_r_18_-label"
+            for="react-use-id-5"
+            id="react-use-id-5-label"
           >
             End date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_18_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-5"
               type="date"
               value="2018-12-28"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End date
@@ -987,34 +943,34 @@ exports[`Trigger > renders all week days enabled 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_19_"
-            id="_r_19_-label"
+            for="react-use-id-6"
+            id="react-use-id-6-label"
           >
             End time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_19_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-6"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End time
@@ -1033,20 +989,20 @@ exports[`Trigger > renders all week days enabled 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1055,25 +1011,22 @@ exports[`Trigger > renders all week days enabled 1`] = `
                 d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Catchup
           </span>
         </label>
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -1082,9 +1035,6 @@ exports[`Trigger > renders all week days enabled 1`] = `
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </span>
       <span
@@ -1095,20 +1045,19 @@ exports[`Trigger > renders all week days enabled 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 30px; max-width: 600px; width: 95px;"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_1d_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_1c_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_1c_"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-7"
               role="combobox"
               tabindex="0"
             >
@@ -1117,14 +1066,15 @@ exports[`Trigger > renders all week days enabled 1`] = `
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-8"
               required=""
               tabindex="-1"
               value="Week"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1135,12 +1085,13 @@ exports[`Trigger > renders all week days enabled 1`] = `
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-1whs34k-MuiNotchedOutlined-root"
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
               >
                 <span
+                  aria-hidden="true"
                   class="notranslate"
                 >
                   ​
@@ -1157,20 +1108,20 @@ exports[`Trigger > renders all week days enabled 1`] = `
           On:
         </span>
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1179,12 +1130,9 @@ exports[`Trigger > renders all week days enabled 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             All
           </span>
@@ -1193,93 +1141,72 @@ exports[`Trigger > renders all week days enabled 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           S
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           M
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           T
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           W
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           T
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           F
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-9rrh7h-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-secondary css-hmh56-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           S
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1288,12 +1215,9 @@ exports[`Trigger > renders all week days enabled 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <span>
               Allow editing cron expression. (format is specified 
@@ -1311,35 +1235,35 @@ exports[`Trigger > renders all week days enabled 1`] = `
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 300px;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_1e_"
-          id="_r_1e_-label"
+          for="react-use-id-9"
+          id="react-use-id-9-label"
         >
           cron expression
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_1e_"
+            id="react-use-id-9"
             type="text"
             value="0 0 0 ? *"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 cron expression
@@ -1360,34 +1284,33 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
 <DocumentFragment>
   <div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      <div
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="_r_0_"
-        id="_r_0_-label"
+        id="react-use-id-0-label"
       >
         Trigger type
         <span
           aria-hidden="true"
-          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
         >
            *
         </span>
-      </label>
+      </div>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <div
-          aria-controls="_r_1_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="_r_0_-label _r_0_"
-          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_0_"
+          aria-labelledby="react-use-id-0-label"
+          aria-required="true"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          id="react-use-id-0"
           role="combobox"
           tabindex="0"
         >
@@ -1396,14 +1319,15 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+          id="react-use-id-1"
           required=""
           tabindex="-1"
           value="0"
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1414,10 +1338,10 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
         </svg>
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-sl37lx-MuiNotchedOutlined-root"
+            class="css-ex8a5f-MuiNotchedOutlined-root"
           >
             <span>
               Trigger type *
@@ -1428,41 +1352,41 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
     </div>
     <div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_2_"
-          id="_r_2_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Maximum concurrent runs
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_2_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-2"
             required=""
             type="text"
             value="10"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Maximum concurrent runs *
@@ -1475,19 +1399,19 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1496,45 +1420,42 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has start date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_3_"
-            id="_r_3_-label"
+            for="react-use-id-3"
+            id="react-use-id-3-label"
           >
             Start date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_3_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-3"
               type="date"
               value="2018-12-21"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start date
@@ -1547,34 +1468,34 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_4_"
-            id="_r_4_-label"
+            for="react-use-id-4"
+            id="react-use-id-4-label"
           >
             Start time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_4_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start time
@@ -1593,19 +1514,19 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1614,45 +1535,42 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has end date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_5_"
-            id="_r_5_-label"
+            for="react-use-id-5"
+            id="react-use-id-5-label"
           >
             End date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_5_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-5"
               type="date"
               value="2018-12-28"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End date
@@ -1665,34 +1583,34 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_6_"
-            id="_r_6_-label"
+            for="react-use-id-6"
+            id="react-use-id-6-label"
           >
             End time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_6_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-6"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End time
@@ -1711,20 +1629,20 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1733,25 +1651,22 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
                 d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Catchup
           </span>
         </label>
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -1760,9 +1675,6 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </span>
       <span
@@ -1776,17 +1688,17 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
             style="display: inline-block; min-width: 10px; width: 10px;"
           />
           <div
-            class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             spellcheck="false"
             style="height: 30px; max-width: 600px; width: 65px;"
           >
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_8_"
+                class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                id="react-use-id-7"
                 min="1"
                 required=""
                 type="number"
@@ -1794,12 +1706,13 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
               />
               <fieldset
                 aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="css-1whs34k-MuiNotchedOutlined-root"
+                  class="css-1nf2c5d-MuiNotchedOutlined-root"
                 >
                   <span
+                    aria-hidden="true"
                     class="notranslate"
                   >
                     ​
@@ -1813,20 +1726,19 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 30px; max-width: 600px; width: 95px;"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_a_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_9_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_9_"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-8"
               role="combobox"
               tabindex="0"
             >
@@ -1835,14 +1747,15 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-9"
               required=""
               tabindex="-1"
               value="Hour"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1853,12 +1766,13 @@ exports[`Trigger > renders periodic schedule controls for initial render 1`] = `
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-1whs34k-MuiNotchedOutlined-root"
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
               >
                 <span
+                  aria-hidden="true"
                   class="notranslate"
                 >
                   ​
@@ -1877,34 +1791,33 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
 <DocumentFragment>
   <div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      <div
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="_r_b_"
-        id="_r_b_-label"
+        id="react-use-id-0-label"
       >
         Trigger type
         <span
           aria-hidden="true"
-          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
         >
            *
         </span>
-      </label>
+      </div>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <div
-          aria-controls="_r_c_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="_r_b_-label _r_b_"
-          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_b_"
+          aria-labelledby="react-use-id-0-label"
+          aria-required="true"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          id="react-use-id-0"
           role="combobox"
           tabindex="0"
         >
@@ -1913,14 +1826,15 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+          id="react-use-id-1"
           required=""
           tabindex="-1"
           value="1"
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1931,10 +1845,10 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         </svg>
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-sl37lx-MuiNotchedOutlined-root"
+            class="css-ex8a5f-MuiNotchedOutlined-root"
           >
             <span>
               Trigger type *
@@ -1945,41 +1859,41 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
     </div>
     <div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_d_"
-          id="_r_d_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Maximum concurrent runs
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_d_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-2"
             required=""
             type="text"
             value="10"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Maximum concurrent runs *
@@ -1992,19 +1906,19 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2013,45 +1927,42 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has start date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_e_"
-            id="_r_e_-label"
+            for="react-use-id-3"
+            id="react-use-id-3-label"
           >
             Start date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_e_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-3"
               type="date"
               value="2018-12-21"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start date
@@ -2064,34 +1975,34 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_f_"
-            id="_r_f_-label"
+            for="react-use-id-4"
+            id="react-use-id-4-label"
           >
             Start time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_f_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start time
@@ -2110,19 +2021,19 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2131,45 +2042,42 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has end date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_g_"
-            id="_r_g_-label"
+            for="react-use-id-5"
+            id="react-use-id-5-label"
           >
             End date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_g_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-5"
               type="date"
               value="2018-12-28"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End date
@@ -2182,34 +2090,34 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_h_"
-            id="_r_h_-label"
+            for="react-use-id-6"
+            id="react-use-id-6-label"
           >
             End time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_h_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-6"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End time
@@ -2228,20 +2136,20 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2250,25 +2158,22 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
                 d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Catchup
           </span>
         </label>
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -2277,9 +2182,6 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </span>
       <span
@@ -2290,20 +2192,19 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 30px; max-width: 600px; width: 95px;"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_l_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_k_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_k_"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-7"
               role="combobox"
               tabindex="0"
             >
@@ -2312,14 +2213,15 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-8"
               required=""
               tabindex="-1"
               value="Hour"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2330,12 +2232,13 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-1whs34k-MuiNotchedOutlined-root"
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
               >
                 <span
+                  aria-hidden="true"
                   class="notranslate"
                 >
                   ​
@@ -2351,19 +2254,19 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2372,12 +2275,9 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <span>
               Allow editing cron expression. (format is specified 
@@ -2395,35 +2295,35 @@ exports[`Trigger > renders periodic schedule controls if the trigger type is CRO
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 300px;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_m_"
-          id="_r_m_-label"
+          for="react-use-id-9"
+          id="react-use-id-9-label"
         >
           cron expression
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_m_"
+            id="react-use-id-9"
             type="text"
             value="0 0 * * * ?"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 cron expression
@@ -2444,34 +2344,33 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
 <DocumentFragment>
   <div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
-      <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+      <div
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="_r_n_"
-        id="_r_n_-label"
+        id="react-use-id-0-label"
       >
         Trigger type
         <span
           aria-hidden="true"
-          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
         >
            *
         </span>
-      </label>
+      </div>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <div
-          aria-controls="_r_o_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="_r_n_-label _r_n_"
-          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_n_"
+          aria-labelledby="react-use-id-0-label"
+          aria-required="true"
+          class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+          id="react-use-id-0"
           role="combobox"
           tabindex="0"
         >
@@ -2480,14 +2379,15 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+          id="react-use-id-1"
           required=""
           tabindex="-1"
           value="1"
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2498,10 +2398,10 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
         </svg>
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-sl37lx-MuiNotchedOutlined-root"
+            class="css-ex8a5f-MuiNotchedOutlined-root"
           >
             <span>
               Trigger type *
@@ -2512,41 +2412,41 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
     </div>
     <div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_p_"
-          id="_r_p_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Maximum concurrent runs
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_p_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-2"
             required=""
             type="text"
             value="10"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Maximum concurrent runs *
@@ -2559,19 +2459,19 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2580,45 +2480,42 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has start date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_q_"
-            id="_r_q_-label"
+            for="react-use-id-3"
+            id="react-use-id-3-label"
           >
             Start date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_q_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-3"
               type="date"
               value="2018-12-21"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start date
@@ -2631,34 +2528,34 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_r_"
-            id="_r_r_-label"
+            for="react-use-id-4"
+            id="react-use-id-4-label"
           >
             Start time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_r_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Start time
@@ -2677,19 +2574,19 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2698,45 +2595,42 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Has end date
           </span>
         </label>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_s_"
-            id="_r_s_-label"
+            for="react-use-id-5"
+            id="react-use-id-5-label"
           >
             End date
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_s_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-5"
               type="date"
               value="2018-12-28"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End date
@@ -2749,34 +2643,34 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="visibility: hidden;"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_t_"
-            id="_r_t_-label"
+            for="react-use-id-6"
+            id="react-use-id-6-label"
           >
             End time
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <input
               aria-invalid="false"
-              class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_t_"
+              class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-6"
               type="time"
               value="07:53"
             />
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   End time
@@ -2795,20 +2689,20 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2817,25 +2711,22 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
                 d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             Catchup
           </span>
         </label>
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -2844,9 +2735,6 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </span>
       <span
@@ -2857,20 +2745,19 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 30px; max-width: 600px; width: 95px;"
         >
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_11_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_10_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_10_"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-7"
               role="combobox"
               tabindex="0"
             >
@@ -2879,14 +2766,15 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-8"
               required=""
               tabindex="-1"
               value="Week"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2897,12 +2785,13 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-1whs34k-MuiNotchedOutlined-root"
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
               >
                 <span
+                  aria-hidden="true"
                   class="notranslate"
                 >
                   ​
@@ -2919,20 +2808,20 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
           On:
         </span>
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
               checked=""
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2941,12 +2830,9 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
                 d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             All
           </span>
@@ -2955,93 +2841,72 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
           style="display: inline-block; min-width: 10px; width: 10px;"
         />
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           S
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           M
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           T
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           W
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           T
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           F
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
-          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-qize55-MuiButtonBase-root-MuiFab-root"
+          class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-primary css-4mx1ug-MuiButtonBase-root-MuiFab-root"
           tabindex="0"
           type="button"
         >
           S
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
         class="flex_f16jawj4"
       >
         <label
-          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         >
           <span
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
           >
             <input
-              class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
               data-indeterminate="false"
               type="checkbox"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="CheckBoxOutlineBlankIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3050,12 +2915,9 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
                 d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </span>
           <span
-            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
           >
             <span>
               Allow editing cron expression. (format is specified 
@@ -3073,35 +2935,35 @@ exports[`Trigger > renders week days if the trigger type is CRON and interval is
         </label>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 300px;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_12_"
-          id="_r_12_-label"
+          for="react-use-id-9"
+          id="react-use-id-9-label"
         >
           cron expression
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_12_"
+            id="react-use-id-9"
             type="text"
             value="0 0 0 ? * *"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 cron expression

--- a/frontend/src/components/graph/ExecutionNode.tsx
+++ b/frontend/src/components/graph/ExecutionNode.tsx
@@ -19,7 +19,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import RemoveCircleOutlinedIcon from '@mui/icons-material/RemoveCircleOutlined';
 import { ReactElement } from 'react';
 import StopCircle from 'src/icons/StopCircle';
 import { Execution } from 'src/third_party/mlmd';
@@ -113,7 +113,7 @@ export function getIcon(state: Execution.State | undefined) {
       );
     default:
       console.error('Unknown exeuction state: ' + state);
-      return getStateIconWrapper(<RemoveCircleOutlineIcon className='text-white' />, 'bg-black');
+      return getStateIconWrapper(<RemoveCircleOutlinedIcon className='text-white' />, 'bg-black');
   }
 }
 

--- a/frontend/src/components/viewers/Tensorboard.test.tsx
+++ b/frontend/src/components/viewers/Tensorboard.test.tsx
@@ -70,6 +70,7 @@ describe('Tensorboard', () => {
     vi.spyOn(Apis, 'getTensorboardApp').mockResolvedValue(GET_APP_NOT_FOUND);
     const { asFragment } = render(<TensorboardViewer configs={[]} />);
     await flushPromisesInAct();
+    expect(screen.getByRole('combobox', { name: 'TF Image' })).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/frontend/src/components/viewers/Tensorboard.tsx
+++ b/frontend/src/components/viewers/Tensorboard.tsx
@@ -211,8 +211,9 @@ class TensorboardViewer extends Viewer<TensorboardViewerProps, TensorboardViewer
           <div>
             <div className={padding(30, 'b')}>
               <FormControl variant='standard' className={css.formControl}>
-                <InputLabel htmlFor='viewer-tb-image-select'>TF Image</InputLabel>
+                <InputLabel id='viewer-tb-image-label'>TF Image</InputLabel>
                 <Select
+                  labelId='viewer-tb-image-label'
                   variant='standard'
                   className={css.select}
                   value={this.state.tfImage}

--- a/frontend/src/components/viewers/VisualizationCreator.test.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.test.tsx
@@ -89,6 +89,7 @@ describe('VisualizationCreator', () => {
       type: PlotType.VISUALIZATION_CREATOR,
     };
     const { asFragment } = render(<VisualizationCreator configs={[config]} />);
+    expect(screen.getByRole('combobox', { name: 'Type' })).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -332,7 +333,7 @@ describe('VisualizationCreator', () => {
       type: PlotType.VISUALIZATION_CREATOR,
     };
     render(<VisualizationCreator configs={[config]} />);
-    expect(screen.getByLabelText('Type')).toBeDisabled();
+    expect(screen.getByRole('combobox', { name: 'Type' })).toHaveAttribute('aria-disabled', 'true');
     expect(
       screen.getByPlaceholderText('File path or path pattern of data within GCS.'),
     ).toBeDisabled();

--- a/frontend/src/components/viewers/VisualizationCreator.tsx
+++ b/frontend/src/components/viewers/VisualizationCreator.tsx
@@ -101,8 +101,9 @@ class VisualizationCreator extends Viewer<VisualizationCreatorProps, Visualizati
         }}
       >
         <FormControl variant='standard' style={{ width: '100%' }}>
-          <InputLabel htmlFor='visualization-type-selector'>Type</InputLabel>
+          <InputLabel id='visualization-type-label'>Type</InputLabel>
           <Select
+            labelId='visualization-type-label'
             variant='standard'
             value={selectedType || ''}
             inputProps={{

--- a/frontend/src/components/viewers/__snapshots__/PagedTable.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/PagedTable.test.tsx.snap
@@ -7,54 +7,53 @@ exports[`PagedTable > does not break on empty data 1`] = `
     style="width: 100%;"
   >
     <table
-      class="MuiTable-root css-rqglhn-MuiTable-root"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
       style="display: block; overflow: auto;"
     >
       <thead
-        class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
         />
       </thead>
       <tbody
-        class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
       >
         <tr
-          class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
           style="height: 300px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
             colspan="6"
           />
         </tr>
       </tbody>
     </table>
     <div
-      class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+      class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
     >
       <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
       >
         <div
-          class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+          class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
         />
         <p
-          class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+          class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
           id="react-use-id-0"
         >
           Rows per page:
         </p>
         <div
-          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
         >
           <div
-            aria-controls="react-use-id-2"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="react-use-id-0 react-use-id-1"
-            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+            aria-labelledby="react-use-id-0"
+            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
             id="react-use-id-1"
             role="combobox"
             tabindex="0"
@@ -64,13 +63,14 @@ exports[`PagedTable > does not break on empty data 1`] = `
           <input
             aria-hidden="true"
             aria-invalid="false"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            id="react-use-id-2"
             tabindex="-1"
             value="10"
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
             data-testid="ArrowDropDownIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -81,16 +81,16 @@ exports[`PagedTable > does not break on empty data 1`] = `
           </svg>
         </div>
         <p
-          class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+          class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
         >
           0–0 of 0
         </p>
         <div
-          class="MuiTablePagination-actions"
+          class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
         >
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to previous page"
@@ -98,7 +98,7 @@ exports[`PagedTable > does not break on empty data 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -110,7 +110,7 @@ exports[`PagedTable > does not break on empty data 1`] = `
           </button>
           <button
             aria-label="Go to next page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to next page"
@@ -118,7 +118,7 @@ exports[`PagedTable > does not break on empty data 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowRightIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -144,23 +144,23 @@ exports[`PagedTable > renders simple data 1`] = `
     style="width: 100%;"
   >
     <table
-      class="MuiTable-root css-rqglhn-MuiTable-root"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
       style="display: block; overflow: auto;"
     >
       <thead
-        class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
         >
           <th
             aria-sort="ascending"
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -168,7 +168,7 @@ exports[`PagedTable > renders simple data 1`] = `
               field1
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -180,12 +180,12 @@ exports[`PagedTable > renders simple data 1`] = `
             </span>
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -193,7 +193,7 @@ exports[`PagedTable > renders simple data 1`] = `
               field2
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -205,12 +205,12 @@ exports[`PagedTable > renders simple data 1`] = `
             </span>
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -218,7 +218,7 @@ exports[`PagedTable > renders simple data 1`] = `
               field3
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -232,83 +232,82 @@ exports[`PagedTable > renders simple data 1`] = `
         </tr>
       </thead>
       <tbody
-        class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col1
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col2
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col3
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col4
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col5
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col6
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
           style="height: 240px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
             colspan="6"
           />
         </tr>
       </tbody>
     </table>
     <div
-      class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+      class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
     >
       <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
       >
         <div
-          class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+          class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
         />
         <p
-          class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+          class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
           id="react-use-id-0"
         >
           Rows per page:
         </p>
         <div
-          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
         >
           <div
-            aria-controls="react-use-id-2"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="react-use-id-0 react-use-id-1"
-            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+            aria-labelledby="react-use-id-0"
+            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
             id="react-use-id-1"
             role="combobox"
             tabindex="0"
@@ -318,13 +317,14 @@ exports[`PagedTable > renders simple data 1`] = `
           <input
             aria-hidden="true"
             aria-invalid="false"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            id="react-use-id-2"
             tabindex="-1"
             value="10"
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
             data-testid="ArrowDropDownIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -335,16 +335,16 @@ exports[`PagedTable > renders simple data 1`] = `
           </svg>
         </div>
         <p
-          class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+          class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
         >
           1–2 of 2
         </p>
         <div
-          class="MuiTablePagination-actions"
+          class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
         >
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to previous page"
@@ -352,7 +352,7 @@ exports[`PagedTable > renders simple data 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -364,7 +364,7 @@ exports[`PagedTable > renders simple data 1`] = `
           </button>
           <button
             aria-label="Go to next page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to next page"
@@ -372,7 +372,7 @@ exports[`PagedTable > renders simple data 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowRightIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -396,94 +396,93 @@ exports[`PagedTable > renders simple data without labels 1`] = `
     style="width: 100%;"
   >
     <table
-      class="MuiTable-root css-rqglhn-MuiTable-root"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
       style="display: block; overflow: auto;"
     >
       <thead
-        class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
         />
       </thead>
       <tbody
-        class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col1
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col2
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col3
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col4
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col5
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col6
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
           style="height: 240px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
             colspan="6"
           />
         </tr>
       </tbody>
     </table>
     <div
-      class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+      class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
     >
       <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
       >
         <div
-          class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+          class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
         />
         <p
-          class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+          class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
           id="react-use-id-0"
         >
           Rows per page:
         </p>
         <div
-          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
         >
           <div
-            aria-controls="react-use-id-2"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="react-use-id-0 react-use-id-1"
-            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+            aria-labelledby="react-use-id-0"
+            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
             id="react-use-id-1"
             role="combobox"
             tabindex="0"
@@ -493,13 +492,14 @@ exports[`PagedTable > renders simple data without labels 1`] = `
           <input
             aria-hidden="true"
             aria-invalid="false"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            id="react-use-id-2"
             tabindex="-1"
             value="10"
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
             data-testid="ArrowDropDownIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -510,16 +510,16 @@ exports[`PagedTable > renders simple data without labels 1`] = `
           </svg>
         </div>
         <p
-          class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+          class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
         >
           1–2 of 2
         </p>
         <div
-          class="MuiTablePagination-actions"
+          class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
         >
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to previous page"
@@ -527,7 +527,7 @@ exports[`PagedTable > renders simple data without labels 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -539,7 +539,7 @@ exports[`PagedTable > renders simple data without labels 1`] = `
           </button>
           <button
             aria-label="Go to next page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to next page"
@@ -547,7 +547,7 @@ exports[`PagedTable > renders simple data without labels 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowRightIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -571,23 +571,23 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
     style="width: 100%;"
   >
     <table
-      class="MuiTable-root css-rqglhn-MuiTable-root"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
       style="display: block; overflow: auto;"
     >
       <thead
-        class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
         >
           <th
             aria-sort="ascending"
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -595,7 +595,7 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
               field1
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -607,12 +607,12 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
             </span>
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -620,7 +620,7 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
               field2
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -632,12 +632,12 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
             </span>
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -645,7 +645,7 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
               field3
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -659,83 +659,82 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
         </tr>
       </thead>
       <tbody
-        class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col1
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col2
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col3
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col4
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col5
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col6
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
           style="height: 240px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
             colspan="6"
           />
         </tr>
       </tbody>
     </table>
     <div
-      class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+      class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
     >
       <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
       >
         <div
-          class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+          class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
         />
         <p
-          class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+          class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
           id="react-use-id-0"
         >
           Rows per page:
         </p>
         <div
-          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
         >
           <div
-            aria-controls="react-use-id-2"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="react-use-id-0 react-use-id-1"
-            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+            aria-labelledby="react-use-id-0"
+            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
             id="react-use-id-1"
             role="combobox"
             tabindex="0"
@@ -745,13 +744,14 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
           <input
             aria-hidden="true"
             aria-invalid="false"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            id="react-use-id-2"
             tabindex="-1"
             value="10"
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
             data-testid="ArrowDropDownIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -762,16 +762,16 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
           </svg>
         </div>
         <p
-          class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+          class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
         >
           1–2 of 2
         </p>
         <div
-          class="MuiTablePagination-actions"
+          class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
         >
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to previous page"
@@ -779,7 +779,7 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -791,7 +791,7 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
           </button>
           <button
             aria-label="Go to next page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to next page"
@@ -799,7 +799,7 @@ exports[`PagedTable > sorts on first column ascending 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowRightIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -823,23 +823,23 @@ exports[`PagedTable > sorts on first column descending 1`] = `
     style="width: 100%;"
   >
     <table
-      class="MuiTable-root css-rqglhn-MuiTable-root"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
       style="display: block; overflow: auto;"
     >
       <thead
-        class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
         >
           <th
             aria-sort="descending"
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -847,7 +847,7 @@ exports[`PagedTable > sorts on first column descending 1`] = `
               field1
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -859,12 +859,12 @@ exports[`PagedTable > sorts on first column descending 1`] = `
             </span>
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -872,7 +872,7 @@ exports[`PagedTable > sorts on first column descending 1`] = `
               field2
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -884,12 +884,12 @@ exports[`PagedTable > sorts on first column descending 1`] = `
             </span>
           </th>
           <th
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -897,7 +897,7 @@ exports[`PagedTable > sorts on first column descending 1`] = `
               field3
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -911,83 +911,82 @@ exports[`PagedTable > sorts on first column descending 1`] = `
         </tr>
       </thead>
       <tbody
-        class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col4
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col5
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col6
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col1
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col2
           </td>
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             col3
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
           style="height: 240px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
             colspan="6"
           />
         </tr>
       </tbody>
     </table>
     <div
-      class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+      class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
     >
       <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
       >
         <div
-          class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+          class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
         />
         <p
-          class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+          class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
           id="react-use-id-0"
         >
           Rows per page:
         </p>
         <div
-          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
         >
           <div
-            aria-controls="react-use-id-2"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="react-use-id-0 react-use-id-1"
-            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+            aria-labelledby="react-use-id-0"
+            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
             id="react-use-id-1"
             role="combobox"
             tabindex="0"
@@ -997,13 +996,14 @@ exports[`PagedTable > sorts on first column descending 1`] = `
           <input
             aria-hidden="true"
             aria-invalid="false"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            id="react-use-id-2"
             tabindex="-1"
             value="10"
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
             data-testid="ArrowDropDownIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -1014,16 +1014,16 @@ exports[`PagedTable > sorts on first column descending 1`] = `
           </svg>
         </div>
         <p
-          class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+          class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
         >
           1–2 of 2
         </p>
         <div
-          class="MuiTablePagination-actions"
+          class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
         >
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to previous page"
@@ -1031,7 +1031,7 @@ exports[`PagedTable > sorts on first column descending 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1043,7 +1043,7 @@ exports[`PagedTable > sorts on first column descending 1`] = `
           </button>
           <button
             aria-label="Go to next page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to next page"
@@ -1051,7 +1051,7 @@ exports[`PagedTable > sorts on first column descending 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowRightIcon"
               focusable="false"
               viewBox="0 0 24 24"

--- a/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/Tensorboard.test.tsx.snap
@@ -8,23 +8,23 @@ exports[`Tensorboard > base component snapshot 1`] = `
         class="f104cl0n"
       >
         <div
-          class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+          class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="viewer-tb-image-select"
+            id="viewer-tb-image-label"
           >
             TF Image
           </label>
           <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
           >
             <div
-              aria-controls="_r_0_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              aria-labelledby="viewer-tb-image-label"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
               role="combobox"
               tabindex="0"
             >
@@ -33,14 +33,14 @@ exports[`Tensorboard > base component snapshot 1`] = `
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
               id="viewer-tb-image-select"
               tabindex="-1"
               value="tensorflow/tensorflow:2.2.2"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -54,16 +54,13 @@ exports[`Tensorboard > base component snapshot 1`] = `
       </div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
         >
           <span>
             Start Tensorboard
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
     </div>

--- a/frontend/src/components/viewers/__snapshots__/ViewerContainer.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/ViewerContainer.test.tsx.snap
@@ -2047,23 +2047,23 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
     style="width: 100%;"
   >
     <table
-      class="MuiTable-root css-rqglhn-MuiTable-root"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
       style="display: block; overflow: auto;"
     >
       <thead
-        class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
         >
           <th
             aria-sort="ascending"
-            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1ygcj2i-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_ft4szt2 css-1orzuox-MuiTableCell-root"
             scope="col"
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -2071,7 +2071,7 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
               col
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -2085,53 +2085,52 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
         </tr>
       </thead>
       <tbody
-        class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
       >
         <tr
-          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root MuiTableRow-hover row_ftg8rvr css-1xtozoh-MuiTableRow-root"
           tabindex="-1"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_f1gb9as5 css-1dc80h3-MuiTableCell-root"
           >
             cell
           </td>
         </tr>
         <tr
-          class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+          class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
           style="height: 270px;"
         >
           <td
-            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
             colspan="6"
           />
         </tr>
       </tbody>
     </table>
     <div
-      class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+      class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
     >
       <div
-        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+        class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
       >
         <div
-          class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+          class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
         />
         <p
-          class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+          class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
           id="react-use-id-0"
         >
           Rows per page:
         </p>
         <div
-          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+          class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
         >
           <div
-            aria-controls="react-use-id-2"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="react-use-id-0 react-use-id-1"
-            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+            aria-labelledby="react-use-id-0"
+            class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
             id="react-use-id-1"
             role="combobox"
             tabindex="0"
@@ -2141,13 +2140,14 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
           <input
             aria-hidden="true"
             aria-invalid="false"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+            id="react-use-id-2"
             tabindex="-1"
             value="10"
           />
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
             data-testid="ArrowDropDownIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -2158,16 +2158,16 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
           </svg>
         </div>
         <p
-          class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+          class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
         >
           1–1 of 1
         </p>
         <div
-          class="MuiTablePagination-actions"
+          class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
         >
           <button
             aria-label="Go to previous page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to previous page"
@@ -2175,7 +2175,7 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2187,7 +2187,7 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
           </button>
           <button
             aria-label="Go to next page"
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
             disabled=""
             tabindex="-1"
             title="Go to next page"
@@ -2195,7 +2195,7 @@ exports[`ViewerContainer > renders a viewer of type TABLE 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="KeyboardArrowRightIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2220,23 +2220,23 @@ exports[`ViewerContainer > renders a viewer of type TENSORBOARD 1`] = `
         class="f104cl0n"
       >
         <div
-          class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+          class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="viewer-tb-image-select"
+            id="viewer-tb-image-label"
           >
             TF Image
           </label>
           <div
-            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+            class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
           >
             <div
-              aria-controls="react-use-id-0"
               aria-expanded="false"
               aria-haspopup="listbox"
-              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+              aria-labelledby="viewer-tb-image-label"
+              class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
               role="combobox"
               tabindex="0"
             >
@@ -2245,14 +2245,14 @@ exports[`ViewerContainer > renders a viewer of type TENSORBOARD 1`] = `
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
               id="viewer-tb-image-select"
               tabindex="-1"
               value="tensorflow/tensorflow:2.2.2"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2266,7 +2266,7 @@ exports[`ViewerContainer > renders a viewer of type TENSORBOARD 1`] = `
       </div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 rootBusy_fronhm5 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 rootBusy_fronhm5 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           tabindex="-1"
           type="button"
@@ -2275,16 +2275,16 @@ exports[`ViewerContainer > renders a viewer of type TENSORBOARD 1`] = `
             Start Tensorboard
           </span>
           <span
-            class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary spinner_fiqr0h3 spinnerBusy_f1wemlvb css-18lrjg1-MuiCircularProgress-root"
+            class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary spinner_fiqr0h3 spinnerBusy_f1wemlvb css-1wxecgq-MuiCircularProgress-root"
             role="progressbar"
             style="width: 15px; height: 15px;"
           >
             <svg
-              class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+              class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
               viewBox="22 22 44 44"
             >
               <circle
-                class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                class="MuiCircularProgress-circle css-19t5dcl-MuiCircularProgress-circle"
                 cx="44"
                 cy="44"
                 fill="none"
@@ -2306,31 +2306,31 @@ exports[`ViewerContainer > renders a viewer of type VISUALIZATION_CREATOR 1`] = 
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-2hy7sk-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="react-use-id-1"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-id-0"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -2339,7 +2339,7 @@ exports[`ViewerContainer > renders a viewer of type VISUALIZATION_CREATOR 1`] = 
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -2347,7 +2347,7 @@ exports[`ViewerContainer > renders a viewer of type VISUALIZATION_CREATOR 1`] = 
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2359,24 +2359,24 @@ exports[`ViewerContainer > renders a viewer of type VISUALIZATION_CREATOR 1`] = 
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
         for="react-use-id-0"
-        id="_r_7_-label"
+        id="react-use-id-0-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
           id="react-use-id-0"
           placeholder="File path or path pattern of data within GCS."
           type="text"
@@ -2384,10 +2384,10 @@ exports[`ViewerContainer > renders a viewer of type VISUALIZATION_CREATOR 1`] = 
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -2397,7 +2397,7 @@ exports[`ViewerContainer > renders a viewer of type VISUALIZATION_CREATOR 1`] = 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"

--- a/frontend/src/components/viewers/__snapshots__/VisualizationCreator.test.tsx.snap
+++ b/frontend/src/components/viewers/__snapshots__/VisualizationCreator.test.tsx.snap
@@ -6,26 +6,25 @@ exports[`VisualizationCreator > renders an Editor component if a visualization t
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_a_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
@@ -35,7 +34,7 @@ exports[`VisualizationCreator > renders an Editor component if a visualization t
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -43,7 +42,7 @@ exports[`VisualizationCreator > renders an Editor component if a visualization t
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -55,35 +54,35 @@ exports[`VisualizationCreator > renders an Editor component if a visualization t
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_b_"
-        id="_r_b_-label"
+        for="_r_m_"
+        id="_r_m_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_b_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_m_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -94,7 +93,7 @@ exports[`VisualizationCreator > renders an Editor component if a visualization t
     </div>
     <div>
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-9npbnl-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-1tkmop-MuiFormLabel-root-MuiInputLabel-root"
       >
         Arguments (Optional)
       </label>
@@ -104,7 +103,7 @@ exports[`VisualizationCreator > renders an Editor component if a visualization t
       />
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -123,31 +122,31 @@ exports[`VisualizationCreator > renders component when all parameters in config 
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-2hy7sk-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_6_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -156,7 +155,7 @@ exports[`VisualizationCreator > renders component when all parameters in config 
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -164,7 +163,7 @@ exports[`VisualizationCreator > renders component when all parameters in config 
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -176,35 +175,35 @@ exports[`VisualizationCreator > renders component when all parameters in config 
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_7_"
-        id="_r_7_-label"
+        for="_r_e_"
+        id="_r_e_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_7_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_e_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -214,7 +213,7 @@ exports[`VisualizationCreator > renders component when all parameters in config 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -233,31 +232,31 @@ exports[`VisualizationCreator > renders component when empty config is provided 
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-2hy7sk-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_0_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -266,7 +265,7 @@ exports[`VisualizationCreator > renders component when empty config is provided 
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -274,7 +273,7 @@ exports[`VisualizationCreator > renders component when empty config is provided 
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -286,35 +285,35 @@ exports[`VisualizationCreator > renders component when empty config is provided 
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_1_"
-        id="_r_1_-label"
+        for="_r_2_"
+        id="_r_2_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_1_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_2_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -324,7 +323,7 @@ exports[`VisualizationCreator > renders component when empty config is provided 
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -343,31 +342,31 @@ exports[`VisualizationCreator > renders component when isBusy is not provided 1`
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-2hy7sk-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_2_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -376,7 +375,7 @@ exports[`VisualizationCreator > renders component when isBusy is not provided 1`
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -384,7 +383,7 @@ exports[`VisualizationCreator > renders component when isBusy is not provided 1`
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -396,35 +395,35 @@ exports[`VisualizationCreator > renders component when isBusy is not provided 1`
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_3_"
-        id="_r_3_-label"
+        for="_r_6_"
+        id="_r_6_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_3_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_6_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -434,7 +433,7 @@ exports[`VisualizationCreator > renders component when isBusy is not provided 1`
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -453,31 +452,31 @@ exports[`VisualizationCreator > renders component when onGenerate is not provide
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-2hy7sk-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_4_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -486,7 +485,7 @@ exports[`VisualizationCreator > renders component when onGenerate is not provide
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -494,7 +493,7 @@ exports[`VisualizationCreator > renders component when onGenerate is not provide
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -506,35 +505,35 @@ exports[`VisualizationCreator > renders component when onGenerate is not provide
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_5_"
-        id="_r_5_-label"
+        for="_r_a_"
+        id="_r_a_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_5_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_a_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -544,7 +543,7 @@ exports[`VisualizationCreator > renders component when onGenerate is not provide
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -563,31 +562,31 @@ exports[`VisualizationCreator > renders the custom type when it is allowed 1`] =
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-standard css-aqpgxn-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-standard css-2hy7sk-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_12_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -596,7 +595,7 @@ exports[`VisualizationCreator > renders the custom type when it is allowed 1`] =
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -604,7 +603,7 @@ exports[`VisualizationCreator > renders the custom type when it is allowed 1`] =
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -616,35 +615,35 @@ exports[`VisualizationCreator > renders the custom type when it is allowed 1`] =
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_13_"
-        id="_r_13_-label"
+        for="_r_26_"
+        id="_r_26_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_13_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_26_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -654,7 +653,7 @@ exports[`VisualizationCreator > renders the custom type when it is allowed 1`] =
       </div>
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -673,26 +672,25 @@ exports[`VisualizationCreator > renders the provided arguments 1`] = `
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_s_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
@@ -702,7 +700,7 @@ exports[`VisualizationCreator > renders the provided arguments 1`] = `
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -710,7 +708,7 @@ exports[`VisualizationCreator > renders the provided arguments 1`] = `
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -722,35 +720,35 @@ exports[`VisualizationCreator > renders the provided arguments 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_t_"
-        id="_r_t_-label"
+        for="_r_1q_"
+        id="_r_1q_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_t_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_1q_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -761,7 +759,7 @@ exports[`VisualizationCreator > renders the provided arguments 1`] = `
     </div>
     <div>
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-9npbnl-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-1tkmop-MuiFormLabel-root-MuiInputLabel-root"
       >
         Arguments (Optional)
       </label>
@@ -771,7 +769,7 @@ exports[`VisualizationCreator > renders the provided arguments 1`] = `
       />
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -790,26 +788,25 @@ exports[`VisualizationCreator > renders the selected visualization type 1`] = `
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_10_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
@@ -819,7 +816,7 @@ exports[`VisualizationCreator > renders the selected visualization type 1`] = `
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -827,7 +824,7 @@ exports[`VisualizationCreator > renders the selected visualization type 1`] = `
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -839,35 +836,35 @@ exports[`VisualizationCreator > renders the selected visualization type 1`] = `
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_11_"
-        id="_r_11_-label"
+        for="_r_22_"
+        id="_r_22_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_11_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_22_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -878,7 +875,7 @@ exports[`VisualizationCreator > renders the selected visualization type 1`] = `
     </div>
     <div>
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-9npbnl-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-1tkmop-MuiFormLabel-root-MuiInputLabel-root"
       >
         Arguments (Optional)
       </label>
@@ -888,7 +885,7 @@ exports[`VisualizationCreator > renders the selected visualization type 1`] = `
       />
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"
@@ -907,31 +904,31 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
     style="width: 600px;"
   >
     <div
-      class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+      class="MuiFormControl-root css-1iw3t7y-MuiFormControl-root"
       style="width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="true"
-        for="visualization-type-selector"
+        id="visualization-type-label"
       >
         Type
       </label>
       <div
-        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl css-n70jm4-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-1x351wq-MuiInputBase-root-MuiInput-root-MuiSelect-root"
         style="min-height: 60px; width: 100%;"
       >
         <div
-          aria-controls="_r_c_"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="mui-component-select-Visualization Type"
-          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+          aria-labelledby="visualization-type-label"
+          class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
           id="mui-component-select-Visualization Type"
           role="combobox"
           tabindex="0"
         >
           <span
+            aria-hidden="true"
             class="notranslate"
           >
             ​
@@ -940,7 +937,7 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
         <input
           aria-hidden="true"
           aria-invalid="false"
-          class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+          class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
           id="visualization-type-selector"
           name="Visualization Type"
           tabindex="-1"
@@ -948,7 +945,7 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
         />
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
           data-testid="ArrowDropDownIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -960,35 +957,35 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
       </div>
     </div>
     <div
-      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
       spellcheck="false"
       style="height: 40px; max-width: 600px; width: 100%;"
     >
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
         data-shrink="false"
-        for="_r_d_"
-        id="_r_d_-label"
+        for="_r_q_"
+        id="_r_q_-label"
       >
         Source
       </label>
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
       >
         <input
           aria-invalid="false"
-          class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-          id="_r_d_"
+          class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+          id="_r_q_"
           placeholder="File path or path pattern of data within GCS."
           type="text"
           value=""
         />
         <fieldset
           aria-hidden="true"
-          class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
         >
           <legend
-            class="css-njhac4-MuiNotchedOutlined-root"
+            class="css-1n64csd-MuiNotchedOutlined-root"
           >
             <span>
               Source
@@ -999,7 +996,7 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
     </div>
     <div>
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-9npbnl-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-1tkmop-MuiFormLabel-root-MuiInputLabel-root"
       >
         Custom Visualization Code
       </label>
@@ -1010,7 +1007,7 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
     </div>
     <div>
       <label
-        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-9npbnl-MuiFormLabel-root-MuiInputLabel-root"
+        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-animated css-1tkmop-MuiFormLabel-root-MuiInputLabel-root"
       >
         Arguments (Optional)
       </label>
@@ -1020,7 +1017,7 @@ exports[`VisualizationCreator > renders two Editor components if the CUSTOM visu
       />
     </div>
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+      class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
       disabled=""
       tabindex="-1"
       type="button"

--- a/frontend/src/mlmd/Css.tsx
+++ b/frontend/src/mlmd/Css.tsx
@@ -189,20 +189,20 @@ export const theme = createTheme({
     MuiButton: {
       styleOverrides: {
         text: {
+          '&.MuiButton-colorPrimary': {
+            border: '1px solid #ddd',
+            cursor: 'pointer',
+            fontSize: fontsize.base,
+            marginRight: 10,
+            textTransform: 'none',
+          },
+          '&.MuiButton-colorSecondary': {
+            color: color.theme,
+          },
           fontSize: fontsize.base,
           fontWeight: 'bold',
           minHeight: dimension.tiny,
           textTransform: 'none',
-        },
-        textPrimary: {
-          border: '1px solid #ddd',
-          cursor: 'pointer',
-          fontSize: fontsize.base,
-          marginRight: 10,
-          textTransform: 'none',
-        },
-        textSecondary: {
-          color: color.theme,
         },
         root: {
           '&.Mui-disabled': {

--- a/frontend/src/mlmd/__snapshots__/LineageActionBar.test.tsx.snap
+++ b/frontend/src/mlmd/__snapshots__/LineageActionBar.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`LineageActionBar > adds a breadcrumb when pushHistory() is called 1`] =
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium breadcrumbSeparator_f1an3f47 f1n4zav9 css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium breadcrumbSeparator_f1an3f47 f1n4zav9 css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowRightAltIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -45,13 +45,13 @@ exports[`LineageActionBar > adds a breadcrumb when pushHistory() is called 1`] =
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary actionButton_fapsfk6 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary actionButton_fapsfk6 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ReplayIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -61,9 +61,6 @@ exports[`LineageActionBar > adds a breadcrumb when pushHistory() is called 1`] =
           />
         </svg>
          Reset
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>
@@ -95,13 +92,13 @@ exports[`LineageActionBar > calls setLineageViewTarget when an inactive breadcru
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary actionButton_fapsfk6 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary actionButton_fapsfk6 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ReplayIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -111,9 +108,6 @@ exports[`LineageActionBar > calls setLineageViewTarget when an inactive breadcru
           />
         </svg>
          Reset
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>
@@ -145,13 +139,13 @@ exports[`LineageActionBar > renders the initial breadcrumb as active and shows t
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary actionButton_fapsfk6 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary actionButton_fapsfk6 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="ReplayIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -161,9 +155,6 @@ exports[`LineageActionBar > renders the initial breadcrumb as active and shows t
           />
         </svg>
          Reset
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>

--- a/frontend/src/pages/AllExperimentsAndArchive.test.tsx
+++ b/frontend/src/pages/AllExperimentsAndArchive.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import AllExperimentsAndArchive, {
@@ -38,14 +39,14 @@ describe('ExperimentsAndArchive', () => {
 
   it('renders experiments page', () => {
     const { asFragment } = render(<AllExperimentsAndArchive {...(generateProps() as any)} />);
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('renders archive page', () => {
     const props = generateProps();
     props.view = AllExperimentsAndArchiveTab.ARCHIVE;
     const { asFragment } = render(<AllExperimentsAndArchive {...(props as any)} />);
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('switches to clicked page by pushing to history', () => {

--- a/frontend/src/pages/AllRunsAndArchive.test.tsx
+++ b/frontend/src/pages/AllRunsAndArchive.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import AllRunsAndArchive, {
@@ -38,14 +39,14 @@ describe('RunsAndArchive', () => {
 
   it('renders runs page', () => {
     const { asFragment } = render(<AllRunsAndArchive {...(generateProps() as any)} />);
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('renders archive page', () => {
     const props = generateProps();
     props.view = AllRunsAndArchiveTab.ARCHIVE;
     const { asFragment } = render(<AllRunsAndArchive {...(props as any)} />);
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('switches to clicked page by pushing to history', () => {

--- a/frontend/src/pages/ExperimentDetails.test.tsx
+++ b/frontend/src/pages/ExperimentDetails.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 import EnhancedExperimentDetails, { ExperimentDetails } from './ExperimentDetails';
 import TestUtils, { flushPromisesInAct, invokeAndFlush } from 'src/TestUtils';
 import { V2beta1Experiment, V2beta1ExperimentStorageState } from 'src/apisv2beta1/experiment';
@@ -150,7 +151,7 @@ describe('ExperimentDetails', () => {
     await waitForExperimentLoad();
     await screen.findByText('No available runs found for this experiment.');
     expect(updateBannerSpy).toHaveBeenLastCalledWith({});
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('uses the experiment ID in props as the page title if the experiment has no name', async () => {
@@ -199,7 +200,7 @@ describe('ExperimentDetails', () => {
     const { asFragment } = await renderExperimentDetails();
     await waitForExperimentLoad();
     await screen.findByText('No available runs found for this experiment.');
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
   it('removes all description text after second newline and replaces with an ellipsis', async () => {
@@ -297,7 +298,7 @@ describe('ExperimentDetails', () => {
     );
     screen.getByText('1 active');
     await screen.findByText('No available runs found for this experiment.');
-    expect(asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   }, 20000);
 
   it("shows an error banner if fetching the experiment's recurring runs fails", async () => {

--- a/frontend/src/pages/FrontendFeatures.tsx
+++ b/frontend/src/pages/FrontendFeatures.tsx
@@ -79,7 +79,7 @@ const FrontendFeatures: React.FC<FrontendFeaturesProps> = () => {
                     onChange={toggleChange}
                     color='primary'
                     name={f.name}
-                    inputProps={{ 'aria-label': 'primary checkbox' }}
+                    slotProps={{ input: { 'aria-label': 'primary checkbox' } }}
                   />
                 </TableCell>
               </TableRow>

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -309,21 +309,23 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
                 variant='outlined'
                 inputRef={this._pipelineNameRef}
                 onChange={this.handleChange('pipelineName')}
-                InputProps={{
-                  classes: { disabled: css.nonEditableInput },
-                  endAdornment: (
-                    <InputAdornment position='end'>
-                      <Button
-                        color='secondary'
-                        id='choosePipelineBtn'
-                        onClick={() => this.setStateSafe({ pipelineSelectorOpen: true })}
-                        style={{ padding: '3px 5px', margin: 0 }}
-                      >
-                        Choose
-                      </Button>
-                    </InputAdornment>
-                  ),
-                  readOnly: true,
+                slotProps={{
+                  input: {
+                    classes: { disabled: css.nonEditableInput },
+                    endAdornment: (
+                      <InputAdornment position='end'>
+                        <Button
+                          color='secondary'
+                          id='choosePipelineBtn'
+                          onClick={() => this.setStateSafe({ pipelineSelectorOpen: true })}
+                          style={{ padding: '3px 5px', margin: 0 }}
+                        >
+                          Choose
+                        </Button>
+                      </InputAdornment>
+                    ),
+                    readOnly: true,
+                  },
                 }}
               />
 
@@ -427,23 +429,25 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
                 variant='outlined'
                 disabled={importMethod === ImportMethod.URL}
                 // Find a better to align this input box with others
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position='end'>
-                      <Button
-                        color='secondary'
-                        onClick={() => this._dropzoneRef.current!.open()}
-                        style={{ padding: '3px 5px', margin: 0, whiteSpace: 'nowrap' }}
-                        disabled={importMethod === ImportMethod.URL}
-                      >
-                        Choose file
-                      </Button>
-                    </InputAdornment>
-                  ),
-                  readOnly: true,
-                  style: {
-                    maxWidth: 2000,
-                    width: 455,
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position='end'>
+                        <Button
+                          color='secondary'
+                          onClick={() => this._dropzoneRef.current!.open()}
+                          style={{ padding: '3px 5px', margin: 0, whiteSpace: 'nowrap' }}
+                          disabled={importMethod === ImportMethod.URL}
+                        >
+                          Choose file
+                        </Button>
+                      </InputAdornment>
+                    ),
+                    readOnly: true,
+                    style: {
+                      maxWidth: 2000,
+                      width: 455,
+                    },
                   },
                 }}
               />

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { NewRun } from 'src/pages/NewRun';
@@ -449,7 +450,7 @@ describe('NewRun', () => {
     tree = await renderNewRunElement(<TestNewRun {...generateProps()} />);
     await flushPromisesInAct();
 
-    expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
   });
 
   it('does not include any action buttons in the toolbar', async () => {
@@ -544,7 +545,7 @@ describe('NewRun', () => {
 
     await updateRecurringRunStateAndFlush(tree.instance() as TestNewRun, true);
 
-    expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
   });
 
   it('changes title and form to default state if the new run is a one-off, based on the radio buttons', async () => {
@@ -556,7 +557,7 @@ describe('NewRun', () => {
 
     await updateRecurringRunStateAndFlush(tree.instance() as TestNewRun, false);
 
-    expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
   });
 
   it('exits to the AllRuns page if there is no associated experiment', async () => {
@@ -590,7 +591,7 @@ describe('NewRun', () => {
 
     expect(tree.state()).toHaveProperty('experiment', MOCK_EXPERIMENT);
     expect(tree.state()).toHaveProperty('experimentName', MOCK_EXPERIMENT.name);
-    expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
   });
 
   it('updates the breadcrumb with the associated experiment if one is present in the query params', async () => {
@@ -638,7 +639,7 @@ describe('NewRun', () => {
     tree = await renderNewRunElement(<TestNewRun {...props} />);
     await flushPromisesInAct();
 
-    expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+    expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
   });
 
   it('shows a page error if getExperiment fails', async () => {
@@ -1521,7 +1522,7 @@ describe('NewRun', () => {
 
       expect(tree.state('useWorkflowFromRun')).toBe(true);
       expect(tree.state('usePipelineFromRunLabel')).toBe('Using pipeline from previous page.');
-      expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+      expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
     });
 
     it('retrieves the run with the embedded pipeline', async () => {
@@ -2132,7 +2133,7 @@ describe('NewRun', () => {
       tree = await renderNewRunElement(<TestNewRun {...props} />);
       await flushPromisesInAct();
 
-      expect(tree.getRenderResult().asFragment()).toMatchSnapshot();
+      expect(stableMuiSnapshotFragment(tree.getRenderResult().asFragment())).toMatchSnapshot();
     });
 
     it("sends a request to start a new recurring run with default periodic schedule when 'Start' is clicked", async () => {

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -259,22 +259,24 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
               label='Pipeline'
               disabled={true}
               variant='outlined'
-              InputProps={{
-                classes: { disabled: css.nonEditableInput },
-                endAdornment: (
-                  <InputAdornment position='end'>
-                    <Button
-                      color='secondary'
-                      id='choosePipelineBtn'
-                      aria-label='Choose pipeline'
-                      onClick={() => this.setStateSafe({ pipelineSelectorOpen: true })}
-                      style={{ padding: '3px 5px', margin: 0 }}
-                    >
-                      Choose
-                    </Button>
-                  </InputAdornment>
-                ),
-                readOnly: true,
+              slotProps={{
+                input: {
+                  classes: { disabled: css.nonEditableInput },
+                  endAdornment: (
+                    <InputAdornment position='end'>
+                      <Button
+                        color='secondary'
+                        id='choosePipelineBtn'
+                        aria-label='Choose pipeline'
+                        onClick={() => this.setStateSafe({ pipelineSelectorOpen: true })}
+                        style={{ padding: '3px 5px', margin: 0 }}
+                      >
+                        Choose
+                      </Button>
+                    </InputAdornment>
+                  ),
+                  readOnly: true,
+                },
               }}
             />
           )}
@@ -285,23 +287,25 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
               label='Pipeline Version'
               disabled={true}
               variant='outlined'
-              InputProps={{
-                classes: { disabled: css.nonEditableInput },
-                endAdornment: (
-                  <InputAdornment position='end'>
-                    <Button
-                      color='secondary'
-                      id='choosePipelineVersionBtn'
-                      aria-label='Choose pipeline version'
-                      onClick={() => this.setStateSafe({ pipelineVersionSelectorOpen: true })}
-                      style={{ padding: '3px 5px', margin: 0 }}
-                      disabled={!unconfirmedSelectedPipeline}
-                    >
-                      Choose
-                    </Button>
-                  </InputAdornment>
-                ),
-                readOnly: true,
+              slotProps={{
+                input: {
+                  classes: { disabled: css.nonEditableInput },
+                  endAdornment: (
+                    <InputAdornment position='end'>
+                      <Button
+                        color='secondary'
+                        id='choosePipelineVersionBtn'
+                        aria-label='Choose pipeline version'
+                        onClick={() => this.setStateSafe({ pipelineVersionSelectorOpen: true })}
+                        style={{ padding: '3px 5px', margin: 0 }}
+                        disabled={!unconfirmedSelectedPipeline}
+                      >
+                        Choose
+                      </Button>
+                    </InputAdornment>
+                  ),
+                  readOnly: true,
+                },
               }}
             />
           )}
@@ -329,7 +333,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
             open={pipelineVersionSelectorOpen}
             classes={{ paper: css.selectorDialog }}
             onClose={() => this._pipelineVersionSelectorClosed(false)}
-            PaperProps={{ id: 'pipelineVersionSelectorDialog' }}
+            slotProps={{ paper: { id: 'pipelineVersionSelectorDialog' } }}
           >
             <DialogContent>
               <ResourceSelector
@@ -399,7 +403,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
             open={experimentSelectorOpen}
             classes={{ paper: css.selectorDialog }}
             onClose={() => this._experimentSelectorClosed(false)}
-            PaperProps={{ id: 'experimentSelectorDialog' }}
+            slotProps={{ paper: { id: 'experimentSelectorDialog' } }}
           >
             <DialogContent>
               <ResourceSelector
@@ -495,21 +499,23 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
             label='Experiment'
             disabled={true}
             variant='outlined'
-            InputProps={{
-              classes: { disabled: css.nonEditableInput },
-              endAdornment: (
-                <InputAdornment position='end'>
-                  <Button
-                    color='secondary'
-                    id='chooseExperimentBtn'
-                    onClick={() => this.setStateSafe({ experimentSelectorOpen: true })}
-                    style={{ padding: '3px 5px', margin: 0 }}
-                  >
-                    Choose
-                  </Button>
-                </InputAdornment>
-              ),
-              readOnly: true,
+            slotProps={{
+              input: {
+                classes: { disabled: css.nonEditableInput },
+                endAdornment: (
+                  <InputAdornment position='end'>
+                    <Button
+                      color='secondary'
+                      id='chooseExperimentBtn'
+                      onClick={() => this.setStateSafe({ experimentSelectorOpen: true })}
+                      style={{ padding: '3px 5px', margin: 0 }}
+                    >
+                      Choose
+                    </Button>
+                  </InputAdornment>
+                ),
+                readOnly: true,
+              },
             }}
           />
 

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -825,21 +825,23 @@ function PipelineSelector(props: PipelineSelectorProps) {
         label='Pipeline'
         disabled={true}
         variant='outlined'
-        InputProps={{
-          classes: { disabled: css.nonEditableInput },
-          endAdornment: (
-            <InputAdornment position='end'>
-              <Button
-                color='secondary'
-                id='choosePipelineBtn'
-                onClick={() => setPipelineSelectorOpen(true)}
-                style={{ padding: '3px 5px', margin: 0 }}
-              >
-                Choose
-              </Button>
-            </InputAdornment>
-          ),
-          readOnly: true,
+        slotProps={{
+          input: {
+            classes: { disabled: css.nonEditableInput },
+            endAdornment: (
+              <InputAdornment position='end'>
+                <Button
+                  color='secondary'
+                  id='choosePipelineBtn'
+                  onClick={() => setPipelineSelectorOpen(true)}
+                  style={{ padding: '3px 5px', margin: 0 }}
+                >
+                  Choose
+                </Button>
+              </InputAdornment>
+            ),
+            readOnly: true,
+          },
         }}
       />
 
@@ -884,23 +886,25 @@ function PipelineVersionSelector(props: PipelineVersionSelectorProps) {
         label={'Pipeline Version'}
         disabled={true}
         variant='outlined'
-        InputProps={{
-          classes: { disabled: css.nonEditableInput },
-          inputProps: { 'data-testid': 'pipeline-version-input-field' },
-          endAdornment: (
-            <InputAdornment position='end'>
-              <Button
-                color='secondary'
-                id='choosePipelineVersionBtn'
-                onClick={() => setPipelineVersionSelectorOpen(true)}
-                style={{ padding: '3px 5px', margin: 0 }}
-                disabled={!props.pipeline || props.useLatestVersion}
-              >
-                Choose
-              </Button>
-            </InputAdornment>
-          ),
-          readOnly: true,
+        slotProps={{
+          input: {
+            classes: { disabled: css.nonEditableInput },
+            inputProps: { 'data-testid': 'pipeline-version-input-field' },
+            endAdornment: (
+              <InputAdornment position='end'>
+                <Button
+                  color='secondary'
+                  id='choosePipelineVersionBtn'
+                  onClick={() => setPipelineVersionSelectorOpen(true)}
+                  style={{ padding: '3px 5px', margin: 0 }}
+                  disabled={!props.pipeline || props.useLatestVersion}
+                >
+                  Choose
+                </Button>
+              </InputAdornment>
+            ),
+            readOnly: true,
+          },
         }}
       />
       {/* Pipeline version selector dialog */}
@@ -908,7 +912,7 @@ function PipelineVersionSelector(props: PipelineVersionSelectorProps) {
         open={pipelineVersionSelectorOpen}
         classes={{ paper: css.selectorDialog }}
         onClose={() => setPipelineVersionSelectorOpen(false)}
-        PaperProps={{ id: 'pipelineVersionSelectorDialog' }}
+        slotProps={{ paper: { id: 'pipelineVersionSelectorDialog' } }}
       >
         <DialogContent>
           <ResourceSelector
@@ -996,21 +1000,23 @@ function ExperimentSelector(props: ExperimentSelectorProps) {
         label='Experiment'
         disabled={true}
         variant='outlined'
-        InputProps={{
-          classes: { disabled: css.nonEditableInput },
-          endAdornment: (
-            <InputAdornment position='end'>
-              <Button
-                color='secondary'
-                id='chooseExperimentBtn'
-                onClick={() => setExperimentSelectorOpen(true)}
-                style={{ padding: '3px 5px', margin: 0 }}
-              >
-                Choose
-              </Button>
-            </InputAdornment>
-          ),
-          readOnly: true,
+        slotProps={{
+          input: {
+            classes: { disabled: css.nonEditableInput },
+            endAdornment: (
+              <InputAdornment position='end'>
+                <Button
+                  color='secondary'
+                  id='chooseExperimentBtn'
+                  onClick={() => setExperimentSelectorOpen(true)}
+                  style={{ padding: '3px 5px', margin: 0 }}
+                >
+                  Choose
+                </Button>
+              </InputAdornment>
+            ),
+            readOnly: true,
+          },
         }}
       />
 
@@ -1019,7 +1025,7 @@ function ExperimentSelector(props: ExperimentSelectorProps) {
         open={experimentSelectorOpen}
         classes={{ paper: css.selectorDialog }}
         onClose={() => setExperimentSelectorOpen(false)}
-        PaperProps={{ id: 'experimentSelectorDialog' }}
+        slotProps={{ paper: { id: 'experimentSelectorDialog' } }}
       >
         {props.isOpenNewExperiment ? (
           <NewExperimentFC onCancel={props.onCancelNewExperiment} {...props} />

--- a/frontend/src/pages/__snapshots__/AllExperimentsAndArchive.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllExperimentsAndArchive.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
       />
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -24,13 +24,10 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
         <span>
           Active
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -38,9 +35,6 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
         <span>
           Archived
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -52,12 +46,12 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -65,14 +59,14 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
                 Filter experiments
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -85,17 +79,17 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter experiments
@@ -122,7 +116,7 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -130,7 +124,7 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
                 Experiment name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -148,7 +142,7 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -165,16 +159,16 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
               class="busyOverlay_f1wbdc3s"
             />
             <span
-              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-18lrjg1-MuiCircularProgress-root"
+              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-1wxecgq-MuiCircularProgress-root"
               role="progressbar"
               style="width: 25px; height: 25px; z-index: 2;"
             >
               <svg
-                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                  class="MuiCircularProgress-circle css-19t5dcl-MuiCircularProgress-circle"
                   cx="44"
                   cy="44"
                   fill="none"
@@ -193,18 +187,16 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
               Rows per page:
             </span>
             <div
-              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
               >
                 <div
-                  aria-controls="_r_e_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_d_"
-                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                  id="_r_d_"
+                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                  id="react-use-id-0"
                   role="combobox"
                   tabindex="0"
                 >
@@ -213,13 +205,14 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="react-use-id-1"
                   tabindex="-1"
                   value="10"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -231,7 +224,7 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
               </div>
             </div>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="prev-page-btn"
               disabled=""
               tabindex="-1"
@@ -239,7 +232,7 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronLeftIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -250,14 +243,14 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
               </svg>
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="next-page-btn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronRightIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -266,9 +259,6 @@ exports[`ExperimentsAndArchive > renders archive page 1`] = `
                   d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
         </div>
@@ -294,7 +284,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
       />
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -302,13 +292,10 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
         <span>
           Active
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -316,9 +303,6 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
         <span>
           Archived
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -329,12 +313,12 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
       >
         <div>
           <div
-            class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             spellcheck="false"
             style="height: 48px; max-width: 100%; width: 100%;"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+              class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
               for="tableFilterBox"
               id="tableFilterBox-label"
@@ -342,14 +326,14 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
               Filter experiments
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="FilterListIcon"
                   focusable="false"
                   style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -362,17 +346,17 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
               </div>
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                 id="tableFilterBox"
                 type="text"
                 value=""
               />
               <fieldset
                 aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="css-sl37lx-MuiNotchedOutlined-root"
+                  class="css-ex8a5f-MuiNotchedOutlined-root"
                 >
                   <span>
                     Filter experiments
@@ -399,7 +383,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -407,7 +391,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
               Experiment name
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -425,7 +409,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
           >
             <span
               aria-label="Cannot sort by this column"
-              class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -440,7 +424,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -448,7 +432,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
               Last 5 runs
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -468,16 +452,16 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
             class="busyOverlay_f1wbdc3s"
           />
           <span
-            class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-18lrjg1-MuiCircularProgress-root"
+            class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-1wxecgq-MuiCircularProgress-root"
             role="progressbar"
             style="width: 25px; height: 25px; z-index: 2;"
           >
             <svg
-              class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+              class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
               viewBox="22 22 44 44"
             >
               <circle
-                class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                class="MuiCircularProgress-circle css-19t5dcl-MuiCircularProgress-circle"
                 cx="44"
                 cy="44"
                 fill="none"
@@ -496,18 +480,16 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
             Rows per page:
           </span>
           <div
-            class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+              class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
             >
               <div
-                aria-controls="_r_7_"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-labelledby="_r_6_"
-                class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                id="_r_6_"
+                class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                id="react-use-id-0"
                 role="combobox"
                 tabindex="0"
               >
@@ -516,13 +498,14 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
               <input
                 aria-hidden="true"
                 aria-invalid="false"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                id="react-use-id-1"
                 tabindex="-1"
                 value="10"
               />
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                 data-testid="ArrowDropDownIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -534,7 +517,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
             </div>
           </div>
           <button
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             data-testid="prev-page-btn"
             disabled=""
             tabindex="-1"
@@ -542,7 +525,7 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="ChevronLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -553,14 +536,14 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
             </svg>
           </button>
           <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             data-testid="next-page-btn"
             tabindex="0"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="ChevronRightIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -569,9 +552,6 @@ exports[`ExperimentsAndArchive > renders experiments page 1`] = `
                 d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
               />
             </svg>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
       </div>

--- a/frontend/src/pages/__snapshots__/AllRunsAndArchive.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/AllRunsAndArchive.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
       />
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -24,13 +24,10 @@ exports[`RunsAndArchive > renders archive page 1`] = `
         <span>
           Active
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -38,9 +35,6 @@ exports[`RunsAndArchive > renders archive page 1`] = `
         <span>
           Archived
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -52,12 +46,12 @@ exports[`RunsAndArchive > renders archive page 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -65,14 +59,14 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -85,17 +79,17 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -112,17 +106,17 @@ exports[`RunsAndArchive > renders archive page 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxOutlineBlankIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -131,9 +125,6 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                     d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -143,7 +134,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -151,7 +142,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -169,7 +160,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -184,7 +175,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -199,7 +190,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -214,7 +205,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -229,7 +220,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -244,7 +235,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -252,7 +243,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -272,16 +263,16 @@ exports[`RunsAndArchive > renders archive page 1`] = `
               class="busyOverlay_f1wbdc3s"
             />
             <span
-              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-18lrjg1-MuiCircularProgress-root"
+              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-1wxecgq-MuiCircularProgress-root"
               role="progressbar"
               style="width: 25px; height: 25px; z-index: 2;"
             >
               <svg
-                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                  class="MuiCircularProgress-circle css-19t5dcl-MuiCircularProgress-circle"
                   cx="44"
                   cy="44"
                   fill="none"
@@ -300,18 +291,16 @@ exports[`RunsAndArchive > renders archive page 1`] = `
               Rows per page:
             </span>
             <div
-              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
               >
                 <div
-                  aria-controls="_r_n_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_m_"
-                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                  id="_r_m_"
+                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                  id="react-use-id-0"
                   role="combobox"
                   tabindex="0"
                 >
@@ -320,13 +309,14 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="react-use-id-1"
                   tabindex="-1"
                   value="10"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -338,7 +328,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
               </div>
             </div>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="prev-page-btn"
               disabled=""
               tabindex="-1"
@@ -346,7 +336,7 @@ exports[`RunsAndArchive > renders archive page 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronLeftIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -357,14 +347,14 @@ exports[`RunsAndArchive > renders archive page 1`] = `
               </svg>
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="next-page-btn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronRightIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -373,9 +363,6 @@ exports[`RunsAndArchive > renders archive page 1`] = `
                   d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
         </div>
@@ -401,7 +388,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
       />
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -409,13 +396,10 @@ exports[`RunsAndArchive > renders runs page 1`] = `
         <span>
           Active
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
       <button
         aria-label=""
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
         data-mui-internal-clone-element="true"
         tabindex="0"
         type="button"
@@ -423,9 +407,6 @@ exports[`RunsAndArchive > renders runs page 1`] = `
         <span>
           Archived
         </span>
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -437,12 +418,12 @@ exports[`RunsAndArchive > renders runs page 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -450,14 +431,14 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -470,17 +451,17 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -497,17 +478,17 @@ exports[`RunsAndArchive > renders runs page 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxOutlineBlankIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -516,9 +497,6 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                     d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -528,7 +506,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -536,7 +514,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -554,7 +532,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -569,7 +547,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -584,7 +562,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -599,7 +577,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -614,7 +592,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -629,7 +607,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -637,7 +615,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -657,16 +635,16 @@ exports[`RunsAndArchive > renders runs page 1`] = `
               class="busyOverlay_f1wbdc3s"
             />
             <span
-              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-18lrjg1-MuiCircularProgress-root"
+              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary absoluteCenter_f1g3o41t css-1wxecgq-MuiCircularProgress-root"
               role="progressbar"
               style="width: 25px; height: 25px; z-index: 2;"
             >
               <svg
-                class="MuiCircularProgress-svg css-1idz92c-MuiCircularProgress-svg"
+                class="MuiCircularProgress-svg css-54pwck-MuiCircularProgress-svg"
                 viewBox="22 22 44 44"
               >
                 <circle
-                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-176wh8e-MuiCircularProgress-circle"
+                  class="MuiCircularProgress-circle css-19t5dcl-MuiCircularProgress-circle"
                   cx="44"
                   cy="44"
                   fill="none"
@@ -685,18 +663,16 @@ exports[`RunsAndArchive > renders runs page 1`] = `
               Rows per page:
             </span>
             <div
-              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
               >
                 <div
-                  aria-controls="_r_b_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_a_"
-                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                  id="_r_a_"
+                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                  id="react-use-id-0"
                   role="combobox"
                   tabindex="0"
                 >
@@ -705,13 +681,14 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="react-use-id-1"
                   tabindex="-1"
                   value="10"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -723,7 +700,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
               </div>
             </div>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="prev-page-btn"
               disabled=""
               tabindex="-1"
@@ -731,7 +708,7 @@ exports[`RunsAndArchive > renders runs page 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronLeftIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -742,14 +719,14 @@ exports[`RunsAndArchive > renders runs page 1`] = `
               </svg>
             </button>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="next-page-btn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronRightIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -758,9 +735,6 @@ exports[`RunsAndArchive > renders runs page 1`] = `
                   d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
         </div>

--- a/frontend/src/pages/__snapshots__/CompareV1.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/CompareV1.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`CompareV1 > collapses all sections 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -24,9 +24,6 @@ exports[`CompareV1 > collapses all sections 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <span
@@ -34,14 +31,14 @@ exports[`CompareV1 > collapses all sections 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -51,21 +48,18 @@ exports[`CompareV1 > collapses all sections 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -75,9 +69,6 @@ exports[`CompareV1 > collapses all sections 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <span
@@ -86,14 +77,14 @@ exports[`CompareV1 > collapses all sections 1`] = `
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -103,9 +94,6 @@ exports[`CompareV1 > collapses all sections 1`] = `
             />
           </svg>
           Tensorboard
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <span
@@ -115,14 +103,14 @@ exports[`CompareV1 > collapses all sections 1`] = `
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d collapsed_f18a0vkk css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -132,9 +120,6 @@ exports[`CompareV1 > collapses all sections 1`] = `
             />
           </svg>
           Table
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <span
@@ -152,14 +137,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -169,9 +154,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -183,12 +165,12 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -196,14 +178,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -216,17 +198,17 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -243,17 +225,17 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -262,9 +244,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -274,7 +253,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -282,7 +261,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -300,7 +279,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -315,7 +294,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -330,7 +309,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -345,7 +324,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -360,7 +339,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -375,7 +354,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -383,7 +362,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -414,17 +393,17 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -433,9 +412,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -464,7 +440,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -526,14 +502,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -543,9 +519,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -560,14 +533,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -577,9 +550,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -598,14 +568,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -615,9 +585,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             />
           </svg>
           Tensorboard
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -625,7 +592,8 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
       >
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -638,7 +606,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -647,7 +615,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -657,9 +625,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -674,23 +639,23 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-2"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -699,14 +664,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -720,16 +685,13 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -750,14 +712,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -767,9 +729,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
             />
           </svg>
           Table
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -777,7 +736,8 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
       >
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -790,7 +750,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -799,7 +759,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -809,9 +769,6 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -820,23 +777,23 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
               style="width: 100%;"
             >
               <table
-                class="MuiTable-root css-rqglhn-MuiTable-root"
+                class="MuiTable-root css-1xwxv7r-MuiTable-root"
                 style="display: block; overflow: auto;"
               >
                 <thead
-                  class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
                   >
                     <th
                       aria-sort="ascending"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_f1k7d8nc css-1ygcj2i-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_f1k7d8nc css-1orzuox-MuiTableCell-root"
                       scope="col"
                     >
                       <span
                         aria-label="Sort"
-                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                         data-mui-internal-clone-element="true"
                         role="button"
                         tabindex="0"
@@ -844,7 +801,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                         col1, col2
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                           data-testid="ArrowDownwardIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -858,53 +815,52 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-hover row_fkbq4lf css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-hover row_fkbq4lf css-1xtozoh-MuiTableRow-root"
                     tabindex="-1"
                   >
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_fv9x3vv css-1ex1afd-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium cell_fv9x3vv css-1dc80h3-MuiTableCell-root"
                     >
                       test
                     </td>
                   </tr>
                   <tr
-                    class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
                     style="height: 270px;"
                   >
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
                       colspan="6"
                     />
                   </tr>
                 </tbody>
               </table>
               <div
-                class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+                class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
               >
                 <div
-                  class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+                  class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
                 >
                   <div
-                    class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+                    class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
                   />
                   <p
-                    class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+                    class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
                     id="react-use-id-0"
                   >
                     Rows per page:
                   </p>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
                   >
                     <div
-                      aria-controls="react-use-id-3"
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      aria-labelledby="react-use-id-0 react-use-id-1"
-                      class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+                      aria-labelledby="react-use-id-0"
+                      class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
                       id="react-use-id-1"
                       role="combobox"
                       tabindex="0"
@@ -914,13 +870,14 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                     <input
                       aria-hidden="true"
                       aria-invalid="false"
-                      class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      id="react-use-id-2"
                       tabindex="-1"
                       value="10"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -931,16 +888,16 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                     </svg>
                   </div>
                   <p
-                    class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+                    class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
                   >
                     1–1 of 1
                   </p>
                   <div
-                    class="MuiTablePagination-actions"
+                    class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
                   >
                     <button
                       aria-label="Go to previous page"
-                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
                       disabled=""
                       tabindex="-1"
                       title="Go to previous page"
@@ -948,7 +905,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="KeyboardArrowLeftIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -960,7 +917,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                     </button>
                     <button
                       aria-label="Go to next page"
-                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
                       disabled=""
                       tabindex="-1"
                       title="Go to next page"
@@ -968,7 +925,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="KeyboardArrowRightIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -1006,14 +963,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1023,9 +980,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -1037,12 +991,12 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -1050,14 +1004,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -1070,17 +1024,17 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -1097,17 +1051,17 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1116,9 +1070,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -1128,7 +1079,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1136,7 +1087,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1154,7 +1105,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1169,7 +1120,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1184,7 +1135,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1199,7 +1150,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1214,7 +1165,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1229,7 +1180,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1237,7 +1188,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1268,17 +1219,17 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1287,9 +1238,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -1318,7 +1266,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -1386,17 +1334,17 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1405,9 +1353,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -1436,7 +1381,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -1498,14 +1443,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1515,9 +1460,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -1532,14 +1474,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -1549,9 +1491,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -1570,14 +1509,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -1587,9 +1526,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             />
           </svg>
           Tensorboard
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -1597,7 +1533,8 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
       >
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -1610,7 +1547,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -1619,7 +1556,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -1629,9 +1566,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -1646,23 +1580,23 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-0"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -1671,14 +1605,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -1692,16 +1626,13 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Combined Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -1710,7 +1641,8 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -1723,7 +1655,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -1732,7 +1664,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -1742,9 +1674,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -1759,23 +1688,23 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-1"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -1784,14 +1713,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -1805,16 +1734,13 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -1823,7 +1749,8 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -1836,7 +1763,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -1845,7 +1772,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -1855,9 +1782,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -1872,23 +1796,23 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-2"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -1897,14 +1821,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -1918,16 +1842,13 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -1948,14 +1869,14 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -1965,9 +1886,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
             />
           </svg>
           ROC Curve
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -1975,7 +1893,8 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
       >
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -1988,7 +1907,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -1997,7 +1916,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -2007,9 +1926,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -2262,7 +2178,8 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -2275,7 +2192,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -2284,7 +2201,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -2294,9 +2211,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -2518,7 +2432,8 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -2531,7 +2446,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -2540,7 +2455,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -2550,9 +2465,6 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -2794,14 +2706,14 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -2811,9 +2723,6 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -2825,12 +2734,12 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -2838,14 +2747,14 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -2858,17 +2767,17 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -2885,17 +2794,17 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -2904,9 +2813,6 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -2916,7 +2822,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -2924,7 +2830,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -2942,7 +2848,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -2957,7 +2863,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -2972,7 +2878,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -2987,7 +2893,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3002,7 +2908,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3017,7 +2923,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3025,7 +2931,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3056,17 +2962,17 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -3075,9 +2981,6 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -3106,7 +3009,7 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -3168,14 +3071,14 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3185,9 +3088,6 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3202,14 +3102,14 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3219,9 +3119,6 @@ exports[`CompareV1 > displays a run's metrics if the run has any 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3299,14 +3196,14 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3316,9 +3213,6 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3330,12 +3224,12 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -3343,14 +3237,14 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -3363,17 +3257,17 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -3390,17 +3284,17 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3409,9 +3303,6 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -3421,7 +3312,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3429,7 +3320,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3447,7 +3338,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3462,7 +3353,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3477,7 +3368,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3492,7 +3383,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3507,7 +3398,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3522,7 +3413,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -3530,7 +3421,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3561,17 +3452,17 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -3580,9 +3471,6 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -3611,7 +3499,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -3679,17 +3567,17 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -3698,9 +3586,6 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -3729,7 +3614,7 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -3791,14 +3676,14 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3808,9 +3693,6 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3825,14 +3707,14 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3842,9 +3724,6 @@ exports[`CompareV1 > displays metrics from multiple runs 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3938,14 +3817,14 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -3955,9 +3834,6 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -3969,12 +3845,12 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -3982,14 +3858,14 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -4002,17 +3878,17 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -4029,17 +3905,17 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -4048,9 +3924,6 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -4060,7 +3933,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4068,7 +3941,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -4086,7 +3959,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4101,7 +3974,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4116,7 +3989,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4131,7 +4004,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4146,7 +4019,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4161,7 +4034,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4169,7 +4042,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -4200,17 +4073,17 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -4219,9 +4092,6 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -4250,7 +4120,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -4318,17 +4188,17 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -4337,9 +4207,6 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -4368,7 +4235,7 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -4430,14 +4297,14 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -4447,9 +4314,6 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -4551,14 +4415,14 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -4568,9 +4432,6 @@ exports[`CompareV1 > displays parameters from multiple runs 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -4597,14 +4458,14 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -4614,9 +4475,6 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -4628,12 +4486,12 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -4641,14 +4499,14 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -4661,17 +4519,17 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -4688,17 +4546,17 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -4707,9 +4565,6 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -4719,7 +4574,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4727,7 +4582,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -4745,7 +4600,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4760,7 +4615,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4775,7 +4630,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4790,7 +4645,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4805,7 +4660,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4820,7 +4675,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -4828,7 +4683,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -4859,17 +4714,17 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -4878,9 +4733,6 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -4909,7 +4761,7 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -4971,14 +4823,14 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -4988,9 +4840,6 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5056,14 +4905,14 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5073,9 +4922,6 @@ exports[`CompareV1 > displays run's parameters if the run has any 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5102,14 +4948,14 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5119,9 +4965,6 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5133,12 +4976,12 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -5146,14 +4989,14 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -5166,17 +5009,17 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -5193,17 +5036,17 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxOutlineBlankIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -5212,9 +5055,6 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                     d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -5224,7 +5064,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5232,7 +5072,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -5250,7 +5090,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5265,7 +5105,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5280,7 +5120,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5295,7 +5135,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5310,7 +5150,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5325,7 +5165,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5333,7 +5173,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -5364,17 +5204,17 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxOutlineBlankIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -5383,9 +5223,6 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                         d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -5414,7 +5251,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -5482,17 +5319,17 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxOutlineBlankIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -5501,9 +5338,6 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                         d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -5532,7 +5366,7 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -5594,14 +5428,14 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5611,9 +5445,6 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5628,14 +5459,14 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5645,9 +5476,6 @@ exports[`CompareV1 > does not show viewers for deselected runs 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5674,14 +5502,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -5691,9 +5519,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -5705,12 +5530,12 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -5718,14 +5543,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -5738,17 +5563,17 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -5765,17 +5590,17 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -5784,9 +5609,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -5796,7 +5618,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5804,7 +5626,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -5822,7 +5644,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5837,7 +5659,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5852,7 +5674,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5867,7 +5689,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5882,7 +5704,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5897,7 +5719,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -5905,7 +5727,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -5936,17 +5758,17 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -5955,9 +5777,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -5986,7 +5805,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -6054,17 +5873,17 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -6073,9 +5892,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -6104,7 +5920,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -6166,14 +5982,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -6183,9 +5999,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -6200,14 +6013,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -6217,9 +6030,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -6238,14 +6048,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -6255,9 +6065,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             />
           </svg>
           Tensorboard
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -6265,7 +6072,8 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
       >
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -6278,7 +6086,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -6287,7 +6095,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -6297,9 +6105,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -6314,23 +6119,23 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-4"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -6339,14 +6144,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -6360,16 +6165,13 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Combined Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -6378,7 +6180,8 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -6391,7 +6194,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -6400,7 +6203,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -6410,9 +6213,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -6427,23 +6227,23 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-5"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -6452,14 +6252,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -6473,16 +6273,13 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -6491,7 +6288,8 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -6504,7 +6302,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -6513,7 +6311,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -6523,9 +6321,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -6540,23 +6335,23 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   class="f104cl0n"
                 >
                   <div
-                    class="MuiFormControl-root formControl_f59g3c5 css-1nrlq1o-MuiFormControl-root"
+                    class="MuiFormControl-root formControl_f59g3c5 css-1iw3t7y-MuiFormControl-root"
                   >
                     <label
-                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-standard css-1c2i806-MuiFormLabel-root-MuiInputLabel-root"
+                      class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-standard css-1ew92b2-MuiFormLabel-root-MuiInputLabel-root"
                       data-shrink="true"
-                      for="viewer-tb-image-select"
+                      id="viewer-tb-image-label"
                     >
                       TF Image
                     </label>
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju css-1eed5fa-MuiInputBase-root-MuiInput-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select_fczmju MuiSelect-root css-1vgb3kf-MuiInputBase-root-MuiInput-root"
                     >
                       <div
-                        aria-controls="react-use-id-6"
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        aria-labelledby="viewer-tb-image-label"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         role="combobox"
                         tabindex="0"
                       >
@@ -6565,14 +6360,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       <input
                         aria-hidden="true"
                         aria-invalid="false"
-                        class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                        class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
                         id="viewer-tb-image-select"
                         tabindex="-1"
                         value="tensorflow/tensorflow:2.2.2"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                         data-testid="ArrowDropDownIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -6586,16 +6381,13 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                 </div>
                 <div>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <span>
                       Start Tensorboard
                     </span>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
               </div>
@@ -6616,14 +6408,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
     <div>
       <div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           title="Expand/Collapse this section"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
             data-testid="ArrowDropUpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -6633,9 +6425,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
             />
           </svg>
           Table
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -6643,7 +6432,8 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
       >
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -6656,7 +6446,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -6665,7 +6455,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -6675,9 +6465,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -6686,23 +6473,23 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               style="width: 100%;"
             >
               <table
-                class="MuiTable-root css-rqglhn-MuiTable-root"
+                class="MuiTable-root css-1xwxv7r-MuiTable-root"
                 style="display: block; overflow: auto;"
               >
                 <thead
-                  class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
                   >
                     <th
                       aria-sort="ascending"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_f1k7d8nc css-1ygcj2i-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_f1k7d8nc css-1orzuox-MuiTableCell-root"
                       scope="col"
                     >
                       <span
                         aria-label="Sort"
-                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                         data-mui-internal-clone-element="true"
                         role="button"
                         tabindex="0"
@@ -6710,7 +6497,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                         col1, col2
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                           data-testid="ArrowDownwardIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -6724,47 +6511,46 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-hover row_fkbq4lf css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-hover row_fkbq4lf css-1xtozoh-MuiTableRow-root"
                     tabindex="-1"
                   />
                   <tr
-                    class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
                     style="height: 270px;"
                   >
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
                       colspan="6"
                     />
                   </tr>
                 </tbody>
               </table>
               <div
-                class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+                class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
               >
                 <div
-                  class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+                  class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
                 >
                   <div
-                    class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+                    class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
                   />
                   <p
-                    class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
+                    class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
                     id="react-use-id-0"
                   >
                     Rows per page:
                   </p>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
                   >
                     <div
-                      aria-controls="react-use-id-7"
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      aria-labelledby="react-use-id-0 react-use-id-1"
-                      class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
+                      aria-labelledby="react-use-id-0"
+                      class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
                       id="react-use-id-1"
                       role="combobox"
                       tabindex="0"
@@ -6774,13 +6560,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     <input
                       aria-hidden="true"
                       aria-invalid="false"
-                      class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      id="react-use-id-2"
                       tabindex="-1"
                       value="10"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -6791,16 +6578,16 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     </svg>
                   </div>
                   <p
-                    class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+                    class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
                   >
                     1–1 of 1
                   </p>
                   <div
-                    class="MuiTablePagination-actions"
+                    class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
                   >
                     <button
                       aria-label="Go to previous page"
-                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
                       disabled=""
                       tabindex="-1"
                       title="Go to previous page"
@@ -6808,7 +6595,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="KeyboardArrowLeftIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -6820,7 +6607,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     </button>
                     <button
                       aria-label="Go to next page"
-                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
                       disabled=""
                       tabindex="-1"
                       title="Go to next page"
@@ -6828,7 +6615,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="KeyboardArrowRightIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -6846,7 +6633,8 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
         </div>
         <div>
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1ps6pg7-MuiPaper-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 plotCard_f19uaync plotCard css-1gtchvp-MuiPaper-root"
+            style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
           >
             <div
               class="plotHeader_fnedsm"
@@ -6859,7 +6647,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               </div>
               <div>
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
                   data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
@@ -6868,7 +6656,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   <svg
                     aria-hidden="true"
                     aria-label="Pop out"
-                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root popoutIcon_f4cg11h MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-mui-internal-clone-element="true"
                     data-testid="LaunchIcon"
                     focusable="false"
@@ -6878,9 +6666,6 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                       d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
             </div>
@@ -6889,23 +6674,23 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               style="width: 100%;"
             >
               <table
-                class="MuiTable-root css-rqglhn-MuiTable-root"
+                class="MuiTable-root css-1xwxv7r-MuiTable-root"
                 style="display: block; overflow: auto;"
               >
                 <thead
-                  class="MuiTableHead-root css-15wwp11-MuiTableHead-root"
+                  class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-head css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
                   >
                     <th
                       aria-sort="ascending"
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_f1k7d8nc css-1ygcj2i-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium columnName_f1k7d8nc css-1orzuox-MuiTableCell-root"
                       scope="col"
                     >
                       <span
                         aria-label="Sort"
-                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                        class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionAsc css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                         data-mui-internal-clone-element="true"
                         role="button"
                         tabindex="0"
@@ -6913,7 +6698,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                         col1, col2
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-7ojauk-MuiSvgIcon-root-MuiTableSortLabel-icon"
                           data-testid="ArrowDownwardIcon"
                           focusable="false"
                           viewBox="0 0 24 24"
@@ -6927,48 +6712,47 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                   </tr>
                 </thead>
                 <tbody
-                  class="MuiTableBody-root css-apqrd9-MuiTableBody-root"
+                  class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
                 >
                   <tr
-                    class="MuiTableRow-root MuiTableRow-hover row_fkbq4lf css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root MuiTableRow-hover row_fkbq4lf css-1xtozoh-MuiTableRow-root"
                     tabindex="-1"
                   />
                   <tr
-                    class="MuiTableRow-root css-1q1u3t4-MuiTableRow-root"
+                    class="MuiTableRow-root css-1xtozoh-MuiTableRow-root"
                     style="height: 270px;"
                   >
                     <td
-                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1ex1afd-MuiTableCell-root"
+                      class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeMedium css-1dc80h3-MuiTableCell-root"
                       colspan="6"
                     />
                   </tr>
                 </tbody>
               </table>
               <div
-                class="MuiTablePagination-root css-jtlhu6-MuiTablePagination-root"
+                class="MuiTablePagination-root css-7mt0f-MuiTablePagination-root"
               >
                 <div
-                  class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-78c6dr-MuiToolbar-root-MuiTablePagination-toolbar"
+                  class="MuiToolbar-root MuiToolbar-gutters MuiToolbar-regular MuiTablePagination-toolbar css-1gak8h1-MuiToolbar-root-MuiTablePagination-toolbar"
                 >
                   <div
-                    class="MuiTablePagination-spacer css-1psng7p-MuiTablePagination-spacer"
+                    class="MuiTablePagination-spacer css-1wtxofq-MuiTablePagination-spacer"
                   />
                   <p
-                    class="MuiTablePagination-selectLabel css-pdct74-MuiTablePagination-selectLabel"
-                    id="react-use-id-2"
+                    class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
+                    id="react-use-id-3"
                   >
                     Rows per page:
                   </p>
                   <div
-                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-input css-16c50h-MuiInputBase-root-MuiTablePagination-select"
+                    class="MuiInputBase-root MuiInputBase-colorPrimary MuiTablePagination-select MuiSelect-root MuiTablePagination-input css-1bw1xoo-MuiInputBase-root-MuiTablePagination-select"
                   >
                     <div
-                      aria-controls="react-use-id-8"
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      aria-labelledby="react-use-id-2 react-use-id-3"
-                      class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-194a1fa-MuiSelect-select-MuiInputBase-input"
-                      id="react-use-id-3"
+                      aria-labelledby="react-use-id-3"
+                      class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-gxx9cp-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
+                      id="react-use-id-4"
                       role="combobox"
                       tabindex="0"
                     >
@@ -6977,13 +6761,14 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     <input
                       aria-hidden="true"
                       aria-invalid="false"
-                      class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                      class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                      id="react-use-id-5"
                       tabindex="-1"
                       value="10"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiTablePagination-selectIcon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                       data-testid="ArrowDropDownIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -6994,16 +6779,16 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     </svg>
                   </div>
                   <p
-                    class="MuiTablePagination-displayedRows css-levciy-MuiTablePagination-displayedRows"
+                    class="MuiTablePagination-displayedRows css-11cfq65-MuiTablePagination-displayedRows"
                   >
                     1–1 of 1
                   </p>
                   <div
-                    class="MuiTablePagination-actions"
+                    class="MuiTablePaginationActions-root MuiTablePagination-actions css-sjsoon-MuiTablePaginationActions-root"
                   >
                     <button
                       aria-label="Go to previous page"
-                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
                       disabled=""
                       tabindex="-1"
                       title="Go to previous page"
@@ -7011,7 +6796,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="KeyboardArrowLeftIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -7023,7 +6808,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     </button>
                     <button
                       aria-label="Go to next page"
-                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-zylse7-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-colorInherit MuiIconButton-sizeMedium css-e9aoga-MuiButtonBase-root-MuiIconButton-root"
                       disabled=""
                       tabindex="-1"
                       title="Go to next page"
@@ -7031,7 +6816,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="KeyboardArrowRightIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -7069,14 +6854,14 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -7086,9 +6871,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -7100,12 +6882,12 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -7113,14 +6895,14 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -7133,17 +6915,17 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -7160,17 +6942,17 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -7179,9 +6961,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -7191,7 +6970,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7199,7 +6978,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -7217,7 +6996,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7232,7 +7011,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7247,7 +7026,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7262,7 +7041,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7277,7 +7056,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7292,7 +7071,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7300,7 +7079,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -7331,17 +7110,17 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -7350,9 +7129,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -7381,7 +7157,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -7449,17 +7225,17 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -7468,9 +7244,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -7499,7 +7272,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -7567,17 +7340,17 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
                       checked=""
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -7586,9 +7359,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                         d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                 </div>
                 <div
@@ -7617,7 +7387,7 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="node-status-sign"
                       focusable="false"
                       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -7679,14 +7449,14 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -7696,9 +7466,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -7713,14 +7480,14 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -7730,9 +7497,6 @@ exports[`CompareV1 > renders a page with multiple runs 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -7759,14 +7523,14 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
   >
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -7776,9 +7540,6 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
           />
         </svg>
         Run overview
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -7790,12 +7551,12 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -7803,14 +7564,14 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
                 Filter runs
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -7823,17 +7584,17 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter runs
@@ -7850,17 +7611,17 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxOutlineBlankIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -7869,9 +7630,6 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
                     d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
             </div>
             <div
@@ -7881,7 +7639,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7889,7 +7647,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
                 Run name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -7907,7 +7665,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7922,7 +7680,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7937,7 +7695,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7952,7 +7710,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7967,7 +7725,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7982,7 +7740,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -7990,7 +7748,7 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
                 Start time
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -8020,14 +7778,14 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
     />
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -8037,9 +7795,6 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
           />
         </svg>
         Parameters
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div
@@ -8054,14 +7809,14 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
     </div>
     <div>
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary collapseBtn_flpzte2 css-dizc30-MuiButtonBase-root-MuiButton-root"
         tabindex="0"
         title="Expand/Collapse this section"
         type="button"
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f12h700d css-1umw9bq-MuiSvgIcon-root"
           data-testid="ArrowDropUpIcon"
           focusable="false"
           viewBox="0 0 24 24"
@@ -8071,9 +7826,6 @@ exports[`CompareV1 > renders a page with no runs 1`] = `
           />
         </svg>
         Metrics
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
       </button>
     </div>
     <div

--- a/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/ExperimentDetails.test.tsx.snap
@@ -12,8 +12,9 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
         class="cardRow_ff0uehn"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 recurringRunsCard_folh6x0 cardActive_fk7v9nw css-ee20y-MuiPaper-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 recurringRunsCard_folh6x0 cardActive_fk7v9nw css-1gtchvp-MuiPaper-root"
           id="recurringRunsCard"
+          style="--Paper-shadow: none;"
         >
           <div>
             <div
@@ -23,7 +24,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                 Recurring run configs
               </span>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary cardBtn_fvbhv23 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary cardBtn_fvbhv23 css-dizc30-MuiButtonBase-root-MuiButton-root"
                 id="manageExperimentRecurringRunsBtn"
                 tabindex="0"
                 type="button"
@@ -39,8 +40,9 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
           </div>
         </div>
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 runStatsCard_folh6x0 css-ee20y-MuiPaper-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 runStatsCard_folh6x0 css-1gtchvp-MuiPaper-root"
           id="experimentDescriptionCard"
+          style="--Paper-shadow: none;"
         >
           <div
             class="cardTitle_fhfhxfi"
@@ -49,7 +51,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
               Experiment description
             </span>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutIcon_fr5sfkk popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutIcon_fr5sfkk popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
               id="expandExperimentDescriptionBtn"
               tabindex="0"
               type="button"
@@ -57,7 +59,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
               <svg
                 aria-hidden="true"
                 aria-label="Read more"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-mui-internal-clone-element="true"
                 data-testid="LaunchIcon"
                 focusable="false"
@@ -68,9 +70,6 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                   d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -110,14 +109,14 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             style="min-width: 130px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="createNewRunBtn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
                 data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -129,9 +128,6 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
               <span>
                 Create run
               </span>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -141,14 +137,14 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             style="min-width: 195px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-dizc30-MuiButtonBase-root-MuiButton-root"
               id="createNewRecurringRunBtn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
                 data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -160,9 +156,6 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
               <span>
                 Create recurring run
               </span>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -172,7 +165,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             style="min-width: 125px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="compareBtn"
               tabindex="-1"
@@ -190,7 +183,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             style="min-width: 100px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="cloneBtn"
               tabindex="-1"
@@ -207,7 +200,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             data-mui-internal-clone-element="true"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="archiveBtn"
               tabindex="-1"
@@ -235,7 +228,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
           />
           <button
             aria-label=""
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -243,13 +236,10 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             <span>
               Active
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
           <button
             aria-label=""
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -257,9 +247,6 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
             <span>
               Archived
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <div>
@@ -268,12 +255,12 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
           >
             <div>
               <div
-                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                 spellcheck="false"
                 style="height: 48px; max-width: 100%; width: 100%;"
               >
                 <label
-                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                   data-shrink="true"
                   for="tableFilterBox"
                   id="tableFilterBox-label"
@@ -281,14 +268,14 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                   Filter runs
                 </label>
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
                 >
                   <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="FilterListIcon"
                       focusable="false"
                       style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -301,17 +288,17 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                   </div>
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                     id="tableFilterBox"
                     type="text"
                     value=""
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="css-sl37lx-MuiNotchedOutlined-root"
+                      class="css-ex8a5f-MuiNotchedOutlined-root"
                     >
                       <span>
                         Filter runs
@@ -328,17 +315,17 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                 class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
               >
                 <span
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-testid="select-all-checkbox"
                 >
                   <input
-                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="CheckBoxOutlineBlankIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -347,9 +334,6 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                       d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </span>
               </div>
               <div
@@ -414,18 +398,16 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                 Rows per page:
               </span>
               <div
-                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               >
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
                 >
                   <div
-                    aria-controls="_r_41_"
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    aria-labelledby="_r_40_"
-                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                    id="_r_40_"
+                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                    id="react-use-id-0"
                     role="combobox"
                     tabindex="0"
                   >
@@ -434,13 +416,14 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                   <input
                     aria-hidden="true"
                     aria-invalid="false"
-                    class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                    class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                    id="react-use-id-1"
                     tabindex="-1"
                     value="10"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                     data-testid="ArrowDropDownIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -452,7 +435,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="prev-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -460,7 +443,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronLeftIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -471,7 +454,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
                 </svg>
               </button>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="next-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -479,7 +462,7 @@ exports[`ExperimentDetails > fetches this experiment's recurring runs 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronRightIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -510,8 +493,9 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
         class="cardRow_ff0uehn"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 recurringRunsCard_folh6x0 css-ee20y-MuiPaper-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 recurringRunsCard_folh6x0 css-1gtchvp-MuiPaper-root"
           id="recurringRunsCard"
+          style="--Paper-shadow: none;"
         >
           <div>
             <div
@@ -521,7 +505,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                 Recurring run configs
               </span>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary cardBtn_fvbhv23 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary cardBtn_fvbhv23 css-dizc30-MuiButtonBase-root-MuiButton-root"
                 id="manageExperimentRecurringRunsBtn"
                 tabindex="0"
                 type="button"
@@ -537,8 +521,9 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
           </div>
         </div>
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 runStatsCard_folh6x0 css-ee20y-MuiPaper-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 runStatsCard_folh6x0 css-1gtchvp-MuiPaper-root"
           id="experimentDescriptionCard"
+          style="--Paper-shadow: none;"
         >
           <div
             class="cardTitle_fhfhxfi"
@@ -547,7 +532,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
               Experiment description
             </span>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutIcon_fr5sfkk popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutIcon_fr5sfkk popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
               id="expandExperimentDescriptionBtn"
               tabindex="0"
               type="button"
@@ -555,7 +540,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
               <svg
                 aria-hidden="true"
                 aria-label="Read more"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-mui-internal-clone-element="true"
                 data-testid="LaunchIcon"
                 focusable="false"
@@ -566,9 +551,6 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                   d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -608,14 +590,14 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             style="min-width: 130px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="createNewRunBtn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
                 data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -627,9 +609,6 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
               <span>
                 Create run
               </span>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -639,14 +618,14 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             style="min-width: 195px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-dizc30-MuiButtonBase-root-MuiButton-root"
               id="createNewRecurringRunBtn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
                 data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -658,9 +637,6 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
               <span>
                 Create recurring run
               </span>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -670,7 +646,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             style="min-width: 125px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="compareBtn"
               tabindex="-1"
@@ -688,7 +664,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             style="min-width: 100px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="cloneBtn"
               tabindex="-1"
@@ -705,7 +681,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             data-mui-internal-clone-element="true"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="archiveBtn"
               tabindex="-1"
@@ -733,7 +709,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
           />
           <button
             aria-label=""
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -741,13 +717,10 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             <span>
               Active
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
           <button
             aria-label=""
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -755,9 +728,6 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
             <span>
               Archived
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <div>
@@ -766,12 +736,12 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
           >
             <div>
               <div
-                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                 spellcheck="false"
                 style="height: 48px; max-width: 100%; width: 100%;"
               >
                 <label
-                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                   data-shrink="true"
                   for="tableFilterBox"
                   id="tableFilterBox-label"
@@ -779,14 +749,14 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                   Filter runs
                 </label>
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
                 >
                   <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="FilterListIcon"
                       focusable="false"
                       style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -799,17 +769,17 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                   </div>
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                     id="tableFilterBox"
                     type="text"
                     value=""
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="css-sl37lx-MuiNotchedOutlined-root"
+                      class="css-ex8a5f-MuiNotchedOutlined-root"
                     >
                       <span>
                         Filter runs
@@ -826,17 +796,17 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                 class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
               >
                 <span
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-testid="select-all-checkbox"
                 >
                   <input
-                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="CheckBoxOutlineBlankIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -845,9 +815,6 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                       d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </span>
               </div>
               <div
@@ -912,18 +879,16 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                 Rows per page:
               </span>
               <div
-                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               >
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
                 >
                   <div
-                    aria-controls="_r_9_"
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    aria-labelledby="_r_8_"
-                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                    id="_r_8_"
+                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                    id="react-use-id-0"
                     role="combobox"
                     tabindex="0"
                   >
@@ -932,13 +897,14 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                   <input
                     aria-hidden="true"
                     aria-invalid="false"
-                    class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                    class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                    id="react-use-id-1"
                     tabindex="-1"
                     value="10"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                     data-testid="ArrowDropDownIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -950,7 +916,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="prev-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -958,7 +924,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronLeftIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -969,7 +935,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
                 </svg>
               </button>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="next-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -977,7 +943,7 @@ exports[`ExperimentDetails > renders a page with no runs or recurring runs 1`] =
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronRightIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1008,8 +974,9 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
         class="cardRow_ff0uehn"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 recurringRunsCard_folh6x0 css-ee20y-MuiPaper-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 recurringRunsCard_folh6x0 css-1gtchvp-MuiPaper-root"
           id="recurringRunsCard"
+          style="--Paper-shadow: none;"
         >
           <div>
             <div
@@ -1019,7 +986,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                 Recurring run configs
               </span>
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary cardBtn_fvbhv23 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary cardBtn_fvbhv23 css-dizc30-MuiButtonBase-root-MuiButton-root"
                 id="manageExperimentRecurringRunsBtn"
                 tabindex="0"
                 type="button"
@@ -1035,8 +1002,9 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
           </div>
         </div>
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 runStatsCard_folh6x0 css-ee20y-MuiPaper-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 card_f5jobr4 runStatsCard_folh6x0 css-1gtchvp-MuiPaper-root"
           id="experimentDescriptionCard"
+          style="--Paper-shadow: none;"
         >
           <div
             class="cardTitle_fhfhxfi"
@@ -1045,7 +1013,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
               Experiment description
             </span>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutIcon_fr5sfkk popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary popOutIcon_fr5sfkk popOutButton css-dizc30-MuiButtonBase-root-MuiButton-root"
               id="expandExperimentDescriptionBtn"
               tabindex="0"
               type="button"
@@ -1053,7 +1021,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
               <svg
                 aria-hidden="true"
                 aria-label="Read more"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-mui-internal-clone-element="true"
                 data-testid="LaunchIcon"
                 focusable="false"
@@ -1064,9 +1032,6 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                   d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -1104,14 +1069,14 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             style="min-width: 130px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="createNewRunBtn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
                 data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1123,9 +1088,6 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
               <span>
                 Create run
               </span>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -1135,14 +1097,14 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             style="min-width: 195px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary root_f1gmzqw4 css-dizc30-MuiButtonBase-root-MuiButton-root"
               id="createNewRecurringRunBtn"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium icon_f1ojihnt css-1umw9bq-MuiSvgIcon-root"
                 data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1154,9 +1116,6 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
               <span>
                 Create recurring run
               </span>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <div
@@ -1166,7 +1125,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             style="min-width: 125px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="compareBtn"
               tabindex="-1"
@@ -1184,7 +1143,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             style="min-width: 100px;"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="cloneBtn"
               tabindex="-1"
@@ -1201,7 +1160,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             data-mui-internal-clone-element="true"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="archiveBtn"
               tabindex="-1"
@@ -1229,7 +1188,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
           />
           <button
             aria-label=""
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -1237,13 +1196,10 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             <span>
               Active
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
           <button
             aria-label=""
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -1251,9 +1207,6 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
             <span>
               Archived
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <div>
@@ -1262,12 +1215,12 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
           >
             <div>
               <div
-                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                 spellcheck="false"
                 style="height: 48px; max-width: 100%; width: 100%;"
               >
                 <label
-                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                   data-shrink="true"
                   for="tableFilterBox"
                   id="tableFilterBox-label"
@@ -1275,14 +1228,14 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                   Filter runs
                 </label>
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
                 >
                   <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="FilterListIcon"
                       focusable="false"
                       style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -1295,17 +1248,17 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                   </div>
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                     id="tableFilterBox"
                     type="text"
                     value=""
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="css-sl37lx-MuiNotchedOutlined-root"
+                      class="css-ex8a5f-MuiNotchedOutlined-root"
                     >
                       <span>
                         Filter runs
@@ -1322,17 +1275,17 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                 class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
               >
                 <span
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-testid="select-all-checkbox"
                 >
                   <input
-                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="CheckBoxOutlineBlankIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -1341,9 +1294,6 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                       d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </span>
               </div>
               <div
@@ -1408,18 +1358,16 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                 Rows per page:
               </span>
               <div
-                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               >
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
                 >
                   <div
-                    aria-controls="_r_1d_"
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    aria-labelledby="_r_1c_"
-                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                    id="_r_1c_"
+                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                    id="react-use-id-0"
                     role="combobox"
                     tabindex="0"
                   >
@@ -1428,13 +1376,14 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                   <input
                     aria-hidden="true"
                     aria-invalid="false"
-                    class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                    class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                    id="react-use-id-1"
                     tabindex="-1"
                     value="10"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                     data-testid="ArrowDropDownIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -1446,7 +1395,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="prev-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -1454,7 +1403,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronLeftIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1465,7 +1414,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
                 </svg>
               </button>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="next-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -1473,7 +1422,7 @@ exports[`ExperimentDetails > uses an empty string if the experiment has no descr
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronRightIcon"
                   focusable="false"
                   viewBox="0 0 24 24"

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -31,12 +31,12 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -44,17 +44,17 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
           Run name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -62,10 +62,10 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Run name *
@@ -75,12 +75,12 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -88,27 +88,27 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -121,59 +121,56 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_ls_"
-          id="_r_ls_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_ls_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -185,14 +182,14 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -201,40 +198,37 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_lu_"
-          id="_r_lu_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_lu_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-1"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -249,23 +243,23 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -276,7 +270,7 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -286,33 +280,30 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -323,7 +314,7 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -333,12 +324,9 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -357,7 +345,7 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -368,15 +356,12 @@ exports[`NewRun > arriving from pipeline details page > indicates that a pipelin
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Cancel
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"
@@ -404,60 +389,57 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         Run details
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_5g_"
-          id="_r_5g_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Pipeline
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_5g_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="choosePipelineBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline *
@@ -467,43 +449,43 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_5h_"
-          id="_r_5h_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Pipeline Version
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_5h_"
+            id="react-use-id-1"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline version"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="choosePipelineVersionBtn"
               style="padding: 3px 5px; margin: 0px;"
@@ -515,10 +497,10 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline Version *
@@ -528,12 +510,12 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -541,17 +523,17 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
           Run name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -559,10 +541,10 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Run name *
@@ -572,12 +554,12 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -585,27 +567,27 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -618,59 +600,56 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_5o_"
-          id="_r_5o_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_5o_"
+            id="react-use-id-2"
             readonly=""
             required=""
             type="text"
             value="some mock experiment name"
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -682,14 +661,14 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -698,40 +677,37 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_5q_"
-          id="_r_5q_-label"
+          for="react-use-id-3"
+          id="react-use-id-3-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_5q_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-3"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -746,23 +722,23 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -773,7 +749,7 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -783,33 +759,30 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -820,7 +793,7 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -830,12 +803,9 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -854,7 +824,7 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -865,15 +835,12 @@ exports[`NewRun > changes the exit button's text if query params indicate this i
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Skip this step
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"
@@ -901,60 +868,57 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         Run details
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_2d_"
-          id="_r_2d_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Pipeline
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_2d_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="choosePipelineBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline *
@@ -964,43 +928,43 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_2e_"
-          id="_r_2e_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Pipeline Version
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_2e_"
+            id="react-use-id-1"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline version"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="choosePipelineVersionBtn"
               style="padding: 3px 5px; margin: 0px;"
@@ -1012,10 +976,10 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline Version *
@@ -1025,12 +989,12 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -1038,17 +1002,17 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
           Recurring run config name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -1056,10 +1020,10 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Recurring run config name *
@@ -1069,12 +1033,12 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -1082,27 +1046,27 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -1115,59 +1079,56 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_2l_"
-          id="_r_2l_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_2l_"
+            id="react-use-id-2"
             readonly=""
             required=""
             type="text"
             value="some mock experiment name"
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -1179,14 +1140,14 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -1195,40 +1156,37 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_2n_"
-          id="_r_2n_-label"
+          for="react-use-id-3"
+          id="react-use-id-3-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_2n_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-3"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -1243,23 +1201,23 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1270,7 +1228,7 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1280,33 +1238,30 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1317,7 +1272,7 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1327,12 +1282,9 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -1347,34 +1299,33 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
       </div>
       <div>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 40px; max-width: 600px; width: 100%;"
         >
-          <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          <div
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_2o_"
-            id="_r_2o_-label"
+            id="react-use-id-4-label"
           >
             Trigger type
             <span
               aria-hidden="true"
-              class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+              class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
             >
                *
             </span>
-          </label>
+          </div>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_2p_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_2o_-label _r_2o_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_2o_"
+              aria-labelledby="react-use-id-4-label"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               role="combobox"
               tabindex="0"
             >
@@ -1383,14 +1334,15 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-5"
               required=""
               tabindex="-1"
               value="0"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1401,10 +1353,10 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Trigger type *
@@ -1415,41 +1367,41 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         </div>
         <div>
           <div
-            class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             spellcheck="false"
             style="height: 40px; max-width: 600px; width: 100%;"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for="_r_2q_"
-              id="_r_2q_-label"
+              for="react-use-id-6"
+              id="react-use-id-6-label"
             >
               Maximum concurrent runs
               <span
                 aria-hidden="true"
-                class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
               >
                  *
               </span>
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_2q_"
+                class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                id="react-use-id-6"
                 required=""
                 type="text"
                 value="10"
               />
               <fieldset
                 aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="css-sl37lx-MuiNotchedOutlined-root"
+                  class="css-ex8a5f-MuiNotchedOutlined-root"
                 >
                   <span>
                     Maximum concurrent runs *
@@ -1462,20 +1414,20 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             class="flex_f16jawj4"
           >
             <label
-              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1484,45 +1436,42 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
               >
                 Has start date
               </span>
             </label>
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_2r_"
-                id="_r_2r_-label"
+                for="react-use-id-7"
+                id="react-use-id-7-label"
               >
                 Start date
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_2r_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-7"
                   type="date"
                   value="2026-01-17"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Start date
@@ -1535,34 +1484,34 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
               style="display: inline-block; min-width: 10px; width: 10px;"
             />
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_2s_"
-                id="_r_2s_-label"
+                for="react-use-id-8"
+                id="react-use-id-8-label"
               >
                 Start time
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_2s_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-8"
                   type="time"
                   value="23:58"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Start time
@@ -1581,20 +1530,20 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             class="flex_f16jawj4"
           >
             <label
-              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1603,45 +1552,42 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
               >
                 Has end date
               </span>
             </label>
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_2t_"
-                id="_r_2t_-label"
+                for="react-use-id-9"
+                id="react-use-id-9-label"
               >
                 End date
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_2t_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-9"
                   type="date"
                   value="2026-01-24"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       End date
@@ -1654,34 +1600,34 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
               style="display: inline-block; min-width: 10px; width: 10px;"
             />
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_2u_"
-                id="_r_2u_-label"
+                for="react-use-id-10"
+                id="react-use-id-10-label"
               >
                 End time
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_2u_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-10"
                   type="time"
                   value="23:58"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       End time
@@ -1700,20 +1646,20 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
             class="flex_f16jawj4"
           >
             <label
-              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1722,25 +1668,22 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
               >
                 Catchup
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="HelpIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1749,9 +1692,6 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                   d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </span>
           <span
@@ -1765,17 +1705,17 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                 style="display: inline-block; min-width: 10px; width: 10px;"
               />
               <div
-                class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                 spellcheck="false"
                 style="height: 30px; max-width: 600px; width: 65px;"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                 >
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                    id="_r_30_"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="react-use-id-11"
                     min="1"
                     required=""
                     type="number"
@@ -1783,12 +1723,13 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="css-1whs34k-MuiNotchedOutlined-root"
+                      class="css-1nf2c5d-MuiNotchedOutlined-root"
                     >
                       <span
+                        aria-hidden="true"
                         class="notranslate"
                       >
                         ​
@@ -1802,20 +1743,19 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
               style="display: inline-block; min-width: 10px; width: 10px;"
             />
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 30px; max-width: 600px; width: 95px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  aria-controls="_r_32_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_31_"
-                  class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_31_"
+                  aria-required="true"
+                  class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-12"
                   role="combobox"
                   tabindex="0"
                 >
@@ -1824,14 +1764,15 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="react-use-id-13"
                   required=""
                   tabindex="-1"
                   value="Hour"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1842,12 +1783,13 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-1whs34k-MuiNotchedOutlined-root"
+                    class="css-1nf2c5d-MuiNotchedOutlined-root"
                   >
                     <span
+                      aria-hidden="true"
                       class="notranslate"
                     >
                       ​
@@ -1873,7 +1815,7 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -1884,15 +1826,12 @@ exports[`NewRun > changes title and form if the new run will recur, based on the
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Cancel
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"
@@ -1920,60 +1859,57 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         Run details
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_33_"
-          id="_r_33_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Pipeline
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_33_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="choosePipelineBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline *
@@ -1983,43 +1919,43 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_34_"
-          id="_r_34_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Pipeline Version
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_34_"
+            id="react-use-id-1"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline version"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="choosePipelineVersionBtn"
               style="padding: 3px 5px; margin: 0px;"
@@ -2031,10 +1967,10 @@ exports[`NewRun > changes title and form to default state if the new run is a on
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline Version *
@@ -2044,12 +1980,12 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -2057,17 +1993,17 @@ exports[`NewRun > changes title and form to default state if the new run is a on
           Run name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -2075,10 +2011,10 @@ exports[`NewRun > changes title and form to default state if the new run is a on
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Run name *
@@ -2088,12 +2024,12 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -2101,27 +2037,27 @@ exports[`NewRun > changes title and form to default state if the new run is a on
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -2134,59 +2070,56 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_3b_"
-          id="_r_3b_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_3b_"
+            id="react-use-id-2"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -2198,14 +2131,14 @@ exports[`NewRun > changes title and form to default state if the new run is a on
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -2214,40 +2147,37 @@ exports[`NewRun > changes title and form to default state if the new run is a on
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_3d_"
-          id="_r_3d_-label"
+          for="react-use-id-3"
+          id="react-use-id-3-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_3d_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-3"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -2262,23 +2192,23 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2289,7 +2219,7 @@ exports[`NewRun > changes title and form to default state if the new run is a on
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2299,33 +2229,30 @@ exports[`NewRun > changes title and form to default state if the new run is a on
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2336,7 +2263,7 @@ exports[`NewRun > changes title and form to default state if the new run is a on
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2346,12 +2273,9 @@ exports[`NewRun > changes title and form to default state if the new run is a on
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -2370,7 +2294,7 @@ exports[`NewRun > changes title and form to default state if the new run is a on
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -2381,15 +2305,12 @@ exports[`NewRun > changes title and form to default state if the new run is a on
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Cancel
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"
@@ -2417,60 +2338,57 @@ exports[`NewRun > renders the new run page 1`] = `
         Run details
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_0_"
-          id="_r_0_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Pipeline
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_0_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="choosePipelineBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline *
@@ -2480,43 +2398,43 @@ exports[`NewRun > renders the new run page 1`] = `
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_1_"
-          id="_r_1_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Pipeline Version
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_1_"
+            id="react-use-id-1"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline version"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="choosePipelineVersionBtn"
               style="padding: 3px 5px; margin: 0px;"
@@ -2528,10 +2446,10 @@ exports[`NewRun > renders the new run page 1`] = `
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline Version *
@@ -2541,12 +2459,12 @@ exports[`NewRun > renders the new run page 1`] = `
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -2554,17 +2472,17 @@ exports[`NewRun > renders the new run page 1`] = `
           Run name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -2572,10 +2490,10 @@ exports[`NewRun > renders the new run page 1`] = `
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Run name *
@@ -2585,12 +2503,12 @@ exports[`NewRun > renders the new run page 1`] = `
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -2598,27 +2516,27 @@ exports[`NewRun > renders the new run page 1`] = `
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -2631,59 +2549,56 @@ exports[`NewRun > renders the new run page 1`] = `
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_8_"
-          id="_r_8_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_8_"
+            id="react-use-id-2"
             readonly=""
             required=""
             type="text"
             value="some mock experiment name"
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -2695,14 +2610,14 @@ exports[`NewRun > renders the new run page 1`] = `
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -2711,40 +2626,37 @@ exports[`NewRun > renders the new run page 1`] = `
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_a_"
-          id="_r_a_-label"
+          for="react-use-id-3"
+          id="react-use-id-3-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_a_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-3"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -2759,23 +2671,23 @@ exports[`NewRun > renders the new run page 1`] = `
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2786,7 +2698,7 @@ exports[`NewRun > renders the new run page 1`] = `
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2796,33 +2708,30 @@ exports[`NewRun > renders the new run page 1`] = `
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2833,7 +2742,7 @@ exports[`NewRun > renders the new run page 1`] = `
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -2843,12 +2752,9 @@ exports[`NewRun > renders the new run page 1`] = `
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -2867,7 +2773,7 @@ exports[`NewRun > renders the new run page 1`] = `
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -2878,15 +2784,12 @@ exports[`NewRun > renders the new run page 1`] = `
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Cancel
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"
@@ -2914,60 +2817,57 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         Run details
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_uj_"
-          id="_r_uj_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Pipeline
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_uj_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="choosePipelineBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline *
@@ -2977,43 +2877,43 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_uk_"
-          id="_r_uk_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Pipeline Version
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_uk_"
+            id="react-use-id-1"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline version"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="choosePipelineVersionBtn"
               style="padding: 3px 5px; margin: 0px;"
@@ -3025,10 +2925,10 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline Version *
@@ -3038,12 +2938,12 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -3051,17 +2951,17 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
           Recurring run config name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -3069,10 +2969,10 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Recurring run config name *
@@ -3082,12 +2982,12 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -3095,27 +2995,27 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -3128,59 +3028,56 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_ur_"
-          id="_r_ur_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_ur_"
+            id="react-use-id-2"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -3192,14 +3089,14 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -3208,40 +3105,37 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_ut_"
-          id="_r_ut_-label"
+          for="react-use-id-3"
+          id="react-use-id-3-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_ut_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-3"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -3256,23 +3150,23 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3283,7 +3177,7 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3293,33 +3187,30 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3330,7 +3221,7 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3340,12 +3231,9 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -3360,34 +3248,33 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
       </div>
       <div>
         <div
-          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           spellcheck="false"
           style="height: 40px; max-width: 600px; width: 100%;"
         >
-          <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          <div
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
-            for="_r_uu_"
-            id="_r_uu_-label"
+            id="react-use-id-4-label"
           >
             Trigger type
             <span
               aria-hidden="true"
-              class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+              class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
             >
                *
             </span>
-          </label>
+          </div>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
           >
             <div
-              aria-controls="_r_uv_"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="_r_uu_-label _r_uu_"
-              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-              id="_r_uu_"
+              aria-labelledby="react-use-id-4-label"
+              aria-required="true"
+              class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+              id="react-use-id-4"
               role="combobox"
               tabindex="0"
             >
@@ -3396,14 +3283,15 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             <input
               aria-hidden="true"
               aria-invalid="false"
-              class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+              class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+              id="react-use-id-5"
               required=""
               tabindex="-1"
               value="0"
             />
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
               data-testid="ArrowDropDownIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -3414,10 +3302,10 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             </svg>
             <fieldset
               aria-hidden="true"
-              class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
             >
               <legend
-                class="css-sl37lx-MuiNotchedOutlined-root"
+                class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
                   Trigger type *
@@ -3428,41 +3316,41 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         </div>
         <div>
           <div
-            class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             spellcheck="false"
             style="height: 40px; max-width: 600px; width: 100%;"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
-              for="_r_v0_"
-              id="_r_v0_-label"
+              for="react-use-id-6"
+              id="react-use-id-6-label"
             >
               Maximum concurrent runs
               <span
                 aria-hidden="true"
-                class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+                class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
               >
                  *
               </span>
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_v0_"
+                class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                id="react-use-id-6"
                 required=""
                 type="text"
                 value="10"
               />
               <fieldset
                 aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="css-sl37lx-MuiNotchedOutlined-root"
+                  class="css-ex8a5f-MuiNotchedOutlined-root"
                 >
                   <span>
                     Maximum concurrent runs *
@@ -3475,20 +3363,20 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             class="flex_f16jawj4"
           >
             <label
-              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3497,45 +3385,42 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
               >
                 Has start date
               </span>
             </label>
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_v1_"
-                id="_r_v1_-label"
+                for="react-use-id-7"
+                id="react-use-id-7-label"
               >
                 Start date
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_v1_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-7"
                   type="date"
                   value="2026-01-17"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Start date
@@ -3548,34 +3433,34 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
               style="display: inline-block; min-width: 10px; width: 10px;"
             />
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_v2_"
-                id="_r_v2_-label"
+                for="react-use-id-8"
+                id="react-use-id-8-label"
               >
                 Start time
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_v2_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-8"
                   type="time"
                   value="23:58"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Start time
@@ -3594,20 +3479,20 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             class="flex_f16jawj4"
           >
             <label
-              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3616,45 +3501,42 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
               >
                 Has end date
               </span>
             </label>
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_v3_"
-                id="_r_v3_-label"
+                for="react-use-id-9"
+                id="react-use-id-9-label"
               >
                 End date
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_v3_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-9"
                   type="date"
                   value="2026-01-24"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       End date
@@ -3667,34 +3549,34 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
               style="display: inline-block; min-width: 10px; width: 10px;"
             />
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="visibility: visible;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined noMargin_fl8qkup css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined noMargin_fl8qkup css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
-                for="_r_v4_"
-                id="_r_v4_-label"
+                for="react-use-id-10"
+                id="react-use-id-10-label"
               >
                 End time
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_v4_"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-10"
                   type="time"
                   value="23:58"
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       End time
@@ -3713,20 +3595,20 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
             class="flex_f16jawj4"
           >
             <label
-              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+              class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               >
                 <input
                   checked=""
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3735,25 +3617,22 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                     d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
-                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
               >
                 Catchup
               </span>
             </label>
             <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-mui-internal-clone-element="true"
               tabindex="0"
               type="button"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="HelpIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -3762,9 +3641,6 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                   d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </span>
           <span
@@ -3778,17 +3654,17 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                 style="display: inline-block; min-width: 10px; width: 10px;"
               />
               <div
-                class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                 spellcheck="false"
                 style="height: 30px; max-width: 600px; width: 65px;"
               >
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
                 >
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-                    id="_r_v6_"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+                    id="react-use-id-11"
                     min="1"
                     required=""
                     type="number"
@@ -3796,12 +3672,13 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="css-1whs34k-MuiNotchedOutlined-root"
+                      class="css-1nf2c5d-MuiNotchedOutlined-root"
                     >
                       <span
+                        aria-hidden="true"
                         class="notranslate"
                       >
                         ​
@@ -3815,20 +3692,19 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
               style="display: inline-block; min-width: 10px; width: 10px;"
             />
             <div
-              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 30px; max-width: 600px; width: 95px;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  aria-controls="_r_v8_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_v7_"
-                  class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-                  id="_r_v7_"
+                  aria-required="true"
+                  class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-jbz0k-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                  id="react-use-id-12"
                   role="combobox"
                   tabindex="0"
                 >
@@ -3837,14 +3713,15 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="react-use-id-13"
                   required=""
                   tabindex="-1"
                   value="Hour"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-1rfqz7c-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -3855,12 +3732,13 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
                 </svg>
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-1whs34k-MuiNotchedOutlined-root"
+                    class="css-1nf2c5d-MuiNotchedOutlined-root"
                   >
                     <span
+                      aria-hidden="true"
                       class="notranslate"
                     >
                       ​
@@ -3886,7 +3764,7 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -3897,15 +3775,12 @@ exports[`NewRun > starting a new recurring run > includes additional trigger inp
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Cancel
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"
@@ -3933,60 +3808,57 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         Run details
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_4f_"
-          id="_r_4f_-label"
+          for="react-use-id-0"
+          id="react-use-id-0-label"
         >
           Pipeline
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_4f_"
+            id="react-use-id-0"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="choosePipelineBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline *
@@ -3996,43 +3868,43 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_4g_"
-          id="_r_4g_-label"
+          for="react-use-id-1"
+          id="react-use-id-1-label"
         >
           Pipeline Version
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_4g_"
+            id="react-use-id-1"
             readonly=""
             required=""
             type="text"
             value=""
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
               aria-label="Choose pipeline version"
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               disabled=""
               id="choosePipelineVersionBtn"
               style="padding: 3px 5px; margin: 0px;"
@@ -4044,10 +3916,10 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Pipeline Version *
@@ -4057,12 +3929,12 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
           for="runNameInput"
           id="runNameInput-label"
@@ -4070,17 +3942,17 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
           Run name
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
             id="runNameInput"
             required=""
             type="text"
@@ -4088,10 +3960,10 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Run name *
@@ -4101,12 +3973,12 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         </div>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: auto; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
           for="descriptionInput"
           id="descriptionInput-label"
@@ -4114,27 +3986,27 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
           Description
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-dpjnhs-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline css-xrmkj5-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <textarea
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             id="descriptionInput"
             style="height: 0px; overflow: hidden;"
           />
           <textarea
             aria-hidden="true"
-            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline css-1sqnrkk-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input css-w4nesw-MuiInputBase-input-MuiOutlinedInput-input"
             readonly=""
             style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
             tabindex="-1"
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Description
@@ -4147,59 +4019,56 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         This run will be associated with the following experiment
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-disabled MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_4n_"
-          id="_r_4n_-label"
+          for="react-use-id-2"
+          id="react-use-id-2-label"
         >
           Experiment
           <span
             aria-hidden="true"
-            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-wgai2y-MuiFormLabel-asterisk"
+            class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
           >
              *
           </span>
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-o9k5xi-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-formControl MuiInputBase-adornedEnd Mui-readOnly MuiInputBase-readOnly css-1nosvha-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj MuiInputBase-inputAdornedEnd Mui-readOnly MuiInputBase-readOnly css-nxo287-MuiInputBase-input-MuiOutlinedInput-input"
+            class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled nonEditableInput_f1ej2mlj Mui-readOnly MuiInputBase-readOnly css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
             disabled=""
-            id="_r_4n_"
+            id="react-use-id-2"
             readonly=""
             required=""
             type="text"
             value="some mock experiment name"
           />
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
               id="chooseExperimentBtn"
               style="padding: 3px 5px; margin: 0px;"
               tabindex="0"
               type="button"
             >
               Choose
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </button>
           </div>
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-sl37lx-MuiNotchedOutlined-root"
+              class="css-ex8a5f-MuiNotchedOutlined-root"
             >
               <span>
                 Experiment *
@@ -4211,14 +4080,14 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
       <div>
         This run will use the following Kubernetes service account. 
         <button
-          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
             data-testid="HelpIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -4227,40 +4096,37 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
               d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
             />
           </svg>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
-        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+        class="MuiFormControl-root MuiTextField-root textField_f7kh2f6 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
         spellcheck="false"
         style="height: 40px; max-width: 600px; width: 100%;"
       >
         <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined css-14s5rfu-MuiFormLabel-root-MuiInputLabel-root"
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_4p_"
-          id="_r_4p_-label"
+          for="react-use-id-3"
+          id="react-use-id-3-label"
         >
           Service Account
         </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
         >
           <input
             aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_4p_"
+            class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
+            id="react-use-id-3"
             type="text"
             value=""
           />
           <fieldset
             aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
           >
             <legend
-              class="css-njhac4-MuiNotchedOutlined-root"
+              class="css-1n64csd-MuiNotchedOutlined-root"
             >
               <span>
                 Service Account
@@ -4275,23 +4141,23 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         Run Type
       </div>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="oneOffToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-checked MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
             checked=""
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4302,7 +4168,7 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1jq7105-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pqw2bl-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4312,33 +4178,30 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           One-off
         </span>
       </label>
       <label
-        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
         id="recurringToggle"
       >
         <span
-          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1p3cwfz-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1tpgjhd-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
         >
           <input
-            class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+            class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
             type="radio"
           />
           <span
-            class="css-19y5vkv-MuiRadioButtonIcon-root"
+            class="css-9oxshb-MuiRadioButtonIcon-root"
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nih4k0-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iy8fvg-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonUncheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4349,7 +4212,7 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
             </svg>
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-yve00p-MuiSvgIcon-root-MuiRadioButtonIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-cpa8b4-MuiSvgIcon-root-MuiRadioButtonIcon-root"
               data-testid="RadioButtonCheckedIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -4359,12 +4222,9 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
               />
             </svg>
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </span>
         <span
-          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
         >
           Recurring
         </span>
@@ -4383,7 +4243,7 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
         class="flex_f16jawj4 ffbrxlm"
       >
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary Mui-disabled MuiButton-root MuiButton-text MuiButton-textSecondary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1d3f8j8-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary root_f1gmzqw4 buttonAction_f1olq6uy css-1ffl2lv-MuiButtonBase-root-MuiButton-root"
           disabled=""
           id="startNewRunBtn"
           tabindex="-1"
@@ -4394,15 +4254,12 @@ exports[`NewRun > updates the run's state with the associated experiment if one 
           </span>
         </button>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-dizc30-MuiButtonBase-root-MuiButton-root"
           id="exitNewRunPageBtn"
           tabindex="0"
           type="button"
         >
           Cancel
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <div
           class="f1wn31t5"

--- a/frontend/src/pages/__snapshots__/PrivateAndSharedPipelines.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/PrivateAndSharedPipelines.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
           />
           <button
             aria-label="Only people who have access to this namespace will be able to view and use these pipelines."
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -28,13 +28,10 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             <span>
               Private
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
           <button
             aria-label="Everyone in your organization will be able to view and use these pipelines."
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
             data-mui-internal-clone-element="true"
             tabindex="0"
             type="button"
@@ -42,9 +39,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             <span>
               Shared
             </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
           </button>
         </div>
         <div
@@ -55,12 +49,12 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
           >
             <div>
               <div
-                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
                 spellcheck="false"
                 style="height: 48px; max-width: 100%; width: 100%;"
               >
                 <label
-                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                  class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                   data-shrink="true"
                   for="tableFilterBox"
                   id="tableFilterBox-label"
@@ -68,14 +62,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   Filter pipelines
                 </label>
                 <div
-                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                  class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
                 >
                   <div
-                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                    class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="FilterListIcon"
                       focusable="false"
                       style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -88,17 +82,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   </div>
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                     id="tableFilterBox"
                     type="text"
                     value=""
                   />
                   <fieldset
                     aria-hidden="true"
-                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                    class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                   >
                     <legend
-                      class="css-sl37lx-MuiNotchedOutlined-root"
+                      class="css-ex8a5f-MuiNotchedOutlined-root"
                     >
                       <span>
                         Filter pipelines
@@ -115,17 +109,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
               >
                 <span
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   data-testid="select-all-checkbox"
                 >
                   <input
-                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="CheckBoxOutlineBlankIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -134,9 +128,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                       d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </span>
                 <span
                   style="display: inline-block; min-width: 40px; width: 40px;"
@@ -149,7 +140,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               >
                 <span
                   aria-label="Sort"
-                  class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                  class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                   data-mui-internal-clone-element="true"
                   role="button"
                   tabindex="0"
@@ -157,7 +148,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   Pipeline name
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                     data-testid="ArrowDownwardIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -175,7 +166,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               >
                 <span
                   aria-label="Cannot sort by this column"
-                  class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                  class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                   data-mui-internal-clone-element="true"
                   role="button"
                   tabindex="0"
@@ -190,7 +181,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               >
                 <span
                   aria-label="Sort"
-                  class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                  class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                   data-mui-internal-clone-element="true"
                   role="button"
                   tabindex="0"
@@ -198,7 +189,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   Uploaded on
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                     data-testid="ArrowDownwardIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -229,16 +220,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                     class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                   >
                     <span
-                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                     >
                       <input
-                        class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                        class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                         data-indeterminate="false"
                         type="checkbox"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="CheckBoxOutlineBlankIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -247,19 +238,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                           d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                         />
                       </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
                     </span>
                     <button
                       aria-label="Expand"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="ArrowRightIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -268,9 +256,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                           d="m10 17 5-5-5-5z"
                         />
                       </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
                     </button>
                   </div>
                   <div
@@ -317,16 +302,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                     class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                   >
                     <span
-                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                      class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                     >
                       <input
-                        class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                        class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                         data-indeterminate="false"
                         type="checkbox"
                       />
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="CheckBoxOutlineBlankIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -335,19 +320,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                           d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                         />
                       </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
                     </span>
                     <button
                       aria-label="Expand"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                       tabindex="0"
                       type="button"
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                         data-testid="ArrowRightIcon"
                         focusable="false"
                         viewBox="0 0 24 24"
@@ -356,9 +338,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                           d="m10 17 5-5-5-5z"
                         />
                       </svg>
-                      <span
-                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                      />
                     </button>
                   </div>
                   <div
@@ -400,18 +379,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 Rows per page:
               </span>
               <div
-                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               >
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
                 >
                   <div
-                    aria-controls="_r_7_"
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    aria-labelledby="_r_6_"
-                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                    id="_r_6_"
+                    class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                    id="_r_8_"
                     role="combobox"
                     tabindex="0"
                   >
@@ -420,13 +397,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   <input
                     aria-hidden="true"
                     aria-invalid="false"
-                    class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                    class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                    id="_r_a_"
                     tabindex="-1"
                     value="10"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                     data-testid="ArrowDropDownIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -438,7 +416,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 </div>
               </div>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="prev-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -446,7 +424,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronLeftIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -457,7 +435,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 </svg>
               </button>
               <button
-                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                 data-testid="next-page-btn"
                 disabled=""
                 tabindex="-1"
@@ -465,7 +443,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="ChevronRightIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -497,7 +475,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
         />
         <button
           aria-label="Only people who have access to this namespace will be able to view and use these pipelines."
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i active_fz0wpsl css-dizc30-MuiButtonBase-root-MuiButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -505,13 +483,10 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
           <span>
             Private
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
         <button
           aria-label="Everyone in your organization will be able to view and use these pipelines."
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary button_ff2g68i css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary button_ff2g68i css-dizc30-MuiButtonBase-root-MuiButton-root"
           data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
@@ -519,9 +494,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
           <span>
             Shared
           </span>
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
         </button>
       </div>
       <div
@@ -532,12 +504,12 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -545,14 +517,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 Filter pipelines
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -565,17 +537,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter pipelines
@@ -592,17 +564,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxOutlineBlankIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -611,9 +583,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                     d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
                 style="display: inline-block; min-width: 40px; width: 40px;"
@@ -626,7 +595,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -634,7 +603,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 Pipeline name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -652,7 +621,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -667,7 +636,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -675,7 +644,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 Uploaded on
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -706,16 +675,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxOutlineBlankIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -724,19 +693,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                         d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                   <button
                     aria-label="Expand"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ArrowRightIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -745,9 +711,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                         d="m10 17 5-5-5-5z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
                 <div
@@ -794,16 +757,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxOutlineBlankIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -812,19 +775,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                         d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                   <button
                     aria-label="Expand"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ArrowRightIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -833,9 +793,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                         d="m10 17 5-5-5-5z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
                 <div
@@ -877,18 +834,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               Rows per page:
             </span>
             <div
-              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
               >
                 <div
-                  aria-controls="_r_7_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_6_"
-                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                  id="_r_6_"
+                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                  id="_r_8_"
                   role="combobox"
                   tabindex="0"
                 >
@@ -897,13 +852,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="_r_a_"
                   tabindex="-1"
                   value="10"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -915,7 +871,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               </div>
             </div>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="prev-page-btn"
               disabled=""
               tabindex="-1"
@@ -923,7 +879,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronLeftIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -934,7 +890,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
               </svg>
             </button>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="next-page-btn"
               disabled=""
               tabindex="-1"
@@ -942,7 +898,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in multi user mode 1`]
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronRightIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1024,12 +980,12 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
         >
           <div>
             <div
-              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
               spellcheck="false"
               style="height: 48px; max-width: 100%; width: 100%;"
             >
               <label
-                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="true"
                 for="tableFilterBox"
                 id="tableFilterBox-label"
@@ -1037,14 +993,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 Filter pipelines
               </label>
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+                class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
               >
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="FilterListIcon"
                     focusable="false"
                     style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -1057,17 +1013,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 </div>
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                   id="tableFilterBox"
                   type="text"
                   value=""
                 />
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                  class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
                 >
                   <legend
-                    class="css-sl37lx-MuiNotchedOutlined-root"
+                    class="css-ex8a5f-MuiNotchedOutlined-root"
                   >
                     <span>
                       Filter pipelines
@@ -1084,17 +1040,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
             >
               <span
-                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 data-testid="select-all-checkbox"
               >
                 <input
-                  class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                  class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                   data-indeterminate="false"
                   type="checkbox"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="CheckBoxOutlineBlankIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1103,9 +1059,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                     d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                   />
                 </svg>
-                <span
-                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                />
               </span>
               <span
                 style="display: inline-block; min-width: 40px; width: 40px;"
@@ -1118,7 +1071,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1126,7 +1079,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 Pipeline name
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1144,7 +1097,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             >
               <span
                 aria-label="Cannot sort by this column"
-                class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1159,7 +1112,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             >
               <span
                 aria-label="Sort"
-                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
                 data-mui-internal-clone-element="true"
                 role="button"
                 tabindex="0"
@@ -1167,7 +1120,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 Uploaded on
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                   data-testid="ArrowDownwardIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1198,16 +1151,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxOutlineBlankIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1216,19 +1169,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                         d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                   <button
                     aria-label="Expand"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ArrowRightIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1237,9 +1187,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                         d="m10 17 5-5-5-5z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
                 <div
@@ -1286,16 +1233,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                   class="cell_fy8nr2z selectionToggle_f1ds3nvo"
                 >
                   <span
-                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                    class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                   >
                     <input
-                      class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                      class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                       data-indeterminate="false"
                       type="checkbox"
                     />
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="CheckBoxOutlineBlankIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1304,19 +1251,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                         d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </span>
                   <button
                     aria-label="Expand"
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                     tabindex="0"
                     type="button"
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                       data-testid="ArrowRightIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1325,9 +1269,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                         d="m10 17 5-5-5-5z"
                       />
                     </svg>
-                    <span
-                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                    />
                   </button>
                 </div>
                 <div
@@ -1369,18 +1310,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               Rows per page:
             </span>
             <div
-              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+              class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             >
               <div
-                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
               >
                 <div
-                  aria-controls="_r_f_"
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="_r_e_"
-                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                  id="_r_e_"
+                  class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                  id="_r_l_"
                   role="combobox"
                   tabindex="0"
                 >
@@ -1389,13 +1328,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 <input
                   aria-hidden="true"
                   aria-invalid="false"
-                  class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                  class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                  id="_r_n_"
                   tabindex="-1"
                   value="10"
                 />
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                   data-testid="ArrowDropDownIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
@@ -1407,7 +1347,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               </div>
             </div>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="prev-page-btn"
               disabled=""
               tabindex="-1"
@@ -1415,7 +1355,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronLeftIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1426,7 +1366,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               </svg>
             </button>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
               data-testid="next-page-btn"
               disabled=""
               tabindex="-1"
@@ -1434,7 +1374,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ChevronRightIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1458,12 +1398,12 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
       >
         <div>
           <div
-            class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root filterBox_frxzdj2 css-1xp5r68-MuiFormControl-root-MuiTextField-root"
             spellcheck="false"
             style="height: 48px; max-width: 100%; width: 100%;"
           >
             <label
-              class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+              class="MuiFormLabel-root MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root noMargin_fl8qkup MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="true"
               for="tableFilterBox"
               id="tableFilterBox-label"
@@ -1471,14 +1411,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               Filter pipelines
             </label>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-1q6at85-MuiInputBase-root-MuiOutlinedInput-root"
+              class="MuiInputBase-root MuiOutlinedInput-root noLeftPadding_f106pxd4 MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-adornedStart css-4bojcr-MuiInputBase-root-MuiOutlinedInput-root"
             >
               <div
-                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1laqsz7-MuiInputAdornment-root"
+                class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-elo8k2-MuiInputAdornment-root"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                   data-testid="FilterListIcon"
                   focusable="false"
                   style="color: rgb(128, 134, 139); padding-right: 16px;"
@@ -1491,17 +1431,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               </div>
               <input
                 aria-invalid="false"
-                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-1o9s3wi-MuiInputBase-input-MuiOutlinedInput-input"
+                class="MuiInputBase-input MuiOutlinedInput-input css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
                 id="tableFilterBox"
                 type="text"
                 value=""
               />
               <fieldset
                 aria-hidden="true"
-                class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-r01yff-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                class="MuiOutlinedInput-notchedOutline filterBorderRadius_f1ypp5hy css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
               >
                 <legend
-                  class="css-sl37lx-MuiNotchedOutlined-root"
+                  class="css-ex8a5f-MuiNotchedOutlined-root"
                 >
                   <span>
                     Filter pipelines
@@ -1518,17 +1458,17 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             class="columnName_f1kdqshe cell_fy8nr2z selectionToggle_f1ds3nvo"
           >
             <span
-              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+              class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
               data-testid="select-all-checkbox"
             >
               <input
-                class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                 data-indeterminate="false"
                 type="checkbox"
               />
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                 data-testid="CheckBoxOutlineBlankIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1537,9 +1477,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                   d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                 />
               </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
             </span>
             <span
               style="display: inline-block; min-width: 40px; width: 40px;"
@@ -1552,7 +1489,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -1560,7 +1497,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               Pipeline name
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1578,7 +1515,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
           >
             <span
               aria-label="Cannot sort by this column"
-              class="MuiButtonBase-root MuiTableSortLabel-root ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root MuiTableSortLabel-directionAsc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -1593,7 +1530,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
           >
             <span
               aria-label="Sort"
-              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active ellipsis_f15ay66x css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+              class="MuiButtonBase-root MuiTableSortLabel-root Mui-active MuiTableSortLabel-directionDesc ellipsis_f15ay66x css-12l68kz-MuiButtonBase-root-MuiTableSortLabel-root"
               data-mui-internal-clone-element="true"
               role="button"
               tabindex="0"
@@ -1601,7 +1538,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               Uploaded on
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionDesc css-3l415a-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon css-asweb8-MuiSvgIcon-root-MuiTableSortLabel-icon"
                 data-testid="ArrowDownwardIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1632,16 +1569,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 class="cell_fy8nr2z selectionToggle_f1ds3nvo"
               >
                 <span
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 >
                   <input
-                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="CheckBoxOutlineBlankIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -1650,19 +1587,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                       d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </span>
                 <button
                   aria-label="Expand"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="ArrowRightIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -1671,9 +1605,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                       d="m10 17 5-5-5-5z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
               <div
@@ -1720,16 +1651,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                 class="cell_fy8nr2z selectionToggle_f1ds3nvo"
               >
                 <span
-                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-p6iyue-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+                  class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-1ml7hhy-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
                 >
                   <input
-                    class="PrivateSwitchBase-input css-1p3z7et-MuiSwitchBase-root"
+                    class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
                     data-indeterminate="false"
                     type="checkbox"
                   />
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="CheckBoxOutlineBlankIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -1738,19 +1669,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                       d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </span>
                 <button
                   aria-label="Expand"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge expandButton_fcy5tjm css-sravn7-MuiButtonBase-root-MuiIconButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <svg
                     aria-hidden="true"
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
                     data-testid="ArrowRightIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
@@ -1759,9 +1687,6 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
                       d="m10 17 5-5-5-5z"
                     />
                   </svg>
-                  <span
-                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-                  />
                 </button>
               </div>
               <div
@@ -1803,18 +1728,16 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             Rows per page:
           </span>
           <div
-            class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+            class="MuiFormControl-root MuiTextField-root verticalAlignInitial_fclh73n rowsPerPage_fvpkhlp css-1xp5r68-MuiFormControl-root-MuiTextField-root"
           >
             <div
-              class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+              class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiSelect-root css-x0hrh7-MuiInputBase-root-MuiInput-root"
             >
               <div
-                aria-controls="_r_f_"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-labelledby="_r_e_"
-                class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                id="_r_e_"
+                class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1skkqr-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                id="_r_l_"
                 role="combobox"
                 tabindex="0"
               >
@@ -1823,13 +1746,14 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
               <input
                 aria-hidden="true"
                 aria-invalid="false"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                class="MuiSelect-nativeInput css-j0riat-MuiSelect-nativeInput"
+                id="_r_n_"
                 tabindex="-1"
                 value="10"
               />
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon css-ug7h84-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
                 data-testid="ArrowDropDownIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -1841,7 +1765,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             </div>
           </div>
           <button
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             data-testid="prev-page-btn"
             disabled=""
             tabindex="-1"
@@ -1849,7 +1773,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="ChevronLeftIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -1860,7 +1784,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
             </svg>
           </button>
           <button
-            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeLarge css-sravn7-MuiButtonBase-root-MuiIconButton-root"
             data-testid="next-page-btn"
             disabled=""
             tabindex="-1"
@@ -1868,7 +1792,7 @@ exports[`PrivateAndSharedPipelines > it renders correctly in single user mode 1`
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
               data-testid="ChevronRightIcon"
               focusable="false"
               viewBox="0 0 24 24"

--- a/frontend/src/pages/__snapshots__/Status.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/Status.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Status > statusToIcon > displays start and end dates if both are provid
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -30,7 +30,7 @@ exports[`Status > statusToIcon > does not display a end date if none was provide
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -52,7 +52,7 @@ exports[`Status > statusToIcon > does not display a start date if none was provi
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -74,7 +74,7 @@ exports[`Status > statusToIcon > does not display any dates if neither was provi
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -96,7 +96,7 @@ exports[`Status > statusToIcon > handles an undefined phase 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -118,7 +118,7 @@ exports[`Status > statusToIcon > handles an unknown phase 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -143,7 +143,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: CACHED 
     >
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
         data-testid="CheckCircleIcon"
         focusable="false"
         style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -156,7 +156,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: CACHED 
       <div>
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
           data-testid="CachedIcon"
           focusable="false"
           style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -180,7 +180,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: ERROR 1
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(213, 0, 0); height: 18px; width: 18px;"
@@ -202,7 +202,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: FAILED 
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(213, 0, 0); height: 18px; width: 18px;"
@@ -224,7 +224,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: OMITTED
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -246,7 +246,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: PENDING
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(154, 160, 166); height: 18px; width: 18px;"
@@ -309,7 +309,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: SKIPPED
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -331,7 +331,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: SUCCEED
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -433,7 +433,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: UNKNOWN
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"

--- a/frontend/src/pages/__snapshots__/StatusV2.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/StatusV2.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Status > statusToIcon > displays start and end dates if both are provid
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -30,7 +30,7 @@ exports[`Status > statusToIcon > does not display a end date if none was provide
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -52,7 +52,7 @@ exports[`Status > statusToIcon > does not display a start date if none was provi
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -74,7 +74,7 @@ exports[`Status > statusToIcon > does not display any dates if neither was provi
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -176,7 +176,7 @@ exports[`Status > statusToIcon > handles FAILED state 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(213, 0, 0); height: 18px; width: 18px;"
@@ -198,7 +198,7 @@ exports[`Status > statusToIcon > handles PENDING state 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(154, 160, 166); height: 18px; width: 18px;"
@@ -261,7 +261,7 @@ exports[`Status > statusToIcon > handles SKIPPED state 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -283,7 +283,7 @@ exports[`Status > statusToIcon > handles SUCCEEDED state 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"
@@ -305,7 +305,7 @@ exports[`Status > statusToIcon > handles an undefined state 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -327,7 +327,7 @@ exports[`Status > statusToIcon > handles an unknown state 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -429,7 +429,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: FAILED 
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(213, 0, 0); height: 18px; width: 18px;"
@@ -451,7 +451,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: PAUSED 
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(154, 160, 166); height: 18px; width: 18px;"
@@ -476,7 +476,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: PENDING
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(154, 160, 166); height: 18px; width: 18px;"
@@ -539,7 +539,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: RUNTIME
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -561,7 +561,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: SKIPPED
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(95, 99, 104); height: 18px; width: 18px;"
@@ -583,7 +583,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: SUCCEED
   >
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
       data-testid="node-status-sign"
       focusable="false"
       style="color: rgb(52, 168, 83); height: 18px; width: 18px;"

--- a/frontend/src/testUtils/muiSnapshot.test.ts
+++ b/frontend/src/testUtils/muiSnapshot.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { normalizeReactUseIdAttrs } from './muiSnapshot';
+
+function fragmentFor(id: string): DocumentFragment {
+  const template = document.createElement('template');
+  template.innerHTML = `
+    <label id="${id}-label" for="${id}">Run name</label>
+    <input id="${id}" aria-labelledby="${id}-label heading"
+      aria-describedby="${id}-helper-text" aria-controls="${id}-list" />
+    <span id="${id}-helper-text">Required</span>
+    <ul id="${id}-list"><li>Existing run</li></ul>
+    <h2 id="heading">Create a run</h2>
+    <a href="/runs/new">New run</a>
+  `;
+  return template.content;
+}
+
+describe('normalizeReactUseIdAttrs', () => {
+  it.each(['_r_abc_', ':r1:'])('preserves label and description relationships for %s', (id) => {
+    const fragment = fragmentFor(id);
+    normalizeReactUseIdAttrs(fragment);
+
+    const input = fragment.querySelector('input')!;
+    expect(input.id).toBe('react-use-id-0');
+    expect(fragment.querySelector('label')?.getAttribute('for')).toBe(input.id);
+    expect(fragment.querySelector('label')?.getAttribute('id')).toBe(`${input.id}-label`);
+    expect(input.getAttribute('aria-labelledby')).toBe(`${input.id}-label heading`);
+    expect(input.getAttribute('aria-describedby')).toBe(`${input.id}-helper-text`);
+    expect(fragment.querySelector('span')?.getAttribute('id')).toBe(`${input.id}-helper-text`);
+    expect(input.getAttribute('aria-controls')).toBe(`${input.id}-list`);
+    expect(fragment.querySelector('ul')?.getAttribute('id')).toBe(`${input.id}-list`);
+    expect(fragment.querySelector('h2')?.getAttribute('id')).toBe('heading');
+    expect(fragment.querySelector('a')?.getAttribute('href')).toBe('/runs/new');
+    expect(fragment.querySelector('label')?.textContent).toBe('Run name');
+  });
+
+  it('normalizes changing generated IDs without changing ordinary identifiers', () => {
+    const first = fragmentFor('_r_1_');
+    const second = fragmentFor('_r_xyz_');
+    normalizeReactUseIdAttrs(first);
+    normalizeReactUseIdAttrs(second);
+    expect(first.isEqualNode(second)).toBe(true);
+
+    const ordinary = fragmentFor('run-name');
+    const original = ordinary.cloneNode(true);
+    normalizeReactUseIdAttrs(ordinary);
+    expect(ordinary.isEqualNode(original)).toBe(true);
+  });
+});

--- a/frontend/src/testUtils/muiSnapshot.ts
+++ b/frontend/src/testUtils/muiSnapshot.ts
@@ -44,17 +44,17 @@ export const normalizeReactUseIdAttrs = (fragment: DocumentFragment) => {
   const idMap = new Map<string, string>();
   let nextId = 0;
 
-  const isReactUseId = (value: string): boolean =>
-    /^_r_[A-Za-z0-9]+_$/.test(value) || /^:r[a-zA-Z0-9]*:$/.test(value);
-
   const mapToken = (token: string): string => {
-    if (!isReactUseId(token)) {
+    // MUI derives label and helper text IDs by appending a suffix to React's ID.
+    const match = token.match(/^(_r_[A-Za-z0-9]+_|:r[a-zA-Z0-9]*:)(.*)$/);
+    if (!match) {
       return token;
     }
-    if (!idMap.has(token)) {
-      idMap.set(token, `react-use-id-${nextId++}`);
+    const [, baseId, suffix] = match;
+    if (!idMap.has(baseId)) {
+      idMap.set(baseId, `react-use-id-${nextId++}`);
     }
-    return idMap.get(token)!;
+    return `${idMap.get(baseId)!}${suffix}`;
   };
 
   const mapAttrValue = (value: string): string => value.split(/\s+/).map(mapToken).join(' ');


### PR DESCRIPTION
**Description of your changes:**

Draft: defer review and merge until MLMD removal is complete. Refresh the remaining UI changes and validation after that removal.

Upgrades @mui/material and @mui/icons-material together from 5.18.0 to 9.4.0, resolving the incompatible peer versions in the separate dependency updates. Migrates deprecated component props to slot props, updates theme and test class selectors, and preserves form adornments, control state and dialog selectors. Connects visualization selector labels explicitly and asserts their accessible names.

Updates reviewed MUI snapshots, normalizing generated React IDs while preserving label relationships. Generated snapshots are exempt from trailing-whitespace rewriting in pre-commit.

This is an independent MUI-only change. React Router, runtypes and Recharts are handled in #14306. Replaces #14279 and #14281. Closes #14142.

Validation:
- Production build, UI/server lint, frontend and mock-backend typechecks, formatting, and React peer checks pass.
- UI tests: 151 files / 2,091 tests verified across the hosted full run and a local rerun after correcting five BusyButton snapshots. Snapshot changes reviewed for preserved labels, values and navigation.
- Repository pre-commit hooks pass.
- Refresh the draft and run the full UI suite after MLMD removal before marking it ready for review.

**Checklist:**
- [x] Commits include DCO sign-off.
- [x] PR title follows the project convention.
- [ ] MLMD removal is complete and this draft has been refreshed against it.
