### PR TITLE
fix(frontend): declare graph node fields for @types/dagre 0.7.54

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,7 +59,7 @@
         "@testing-library/react": "^16.3.3",
         "@testing-library/user-event": "^14.5.2",
         "@types/d3-dsv": "^3.0.7",
-        "@types/dagre": "^0.7.40",
+        "@types/dagre": "^0.7.54",
         "@types/express": "^5.0.6",
         "@types/google-protobuf": "^3.7.2",
         "@types/js-yaml": "^3.12.3",
@@ -3434,7 +3434,9 @@
       }
     },
     "node_modules/@types/dagre": {
-      "version": "0.7.40",
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,7 +121,7 @@
     "@testing-library/react": "^16.3.3",
     "@testing-library/user-event": "^14.5.2",
     "@types/d3-dsv": "^3.0.7",
-    "@types/dagre": "^0.7.40",
+    "@types/dagre": "^0.7.54",
     "@types/express": "^5.0.6",
     "@types/google-protobuf": "^3.7.2",
     "@types/js-yaml": "^3.12.3",

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -19,6 +19,7 @@ import * as React from 'react';
 import { classes, stylesheet } from 'typestyle';
 import { fontsize, color, fonts, zIndex } from '../Css';
 import { Constants } from '../lib/Constants';
+import type { SelectedNodeInfo } from '../lib/StaticGraphParser';
 import { Tooltip } from '@mui/material';
 
 interface Segment {
@@ -36,6 +37,23 @@ interface Edge {
   from: string;
   segments: Segment[];
   to: string;
+}
+
+/**
+ * The layout properties dagre computes, plus the presentation data the
+ * parsers attach to each node with `setNode`.
+ *
+ * `@types/dagre` describes `Graph.node()` as returning only dagre's own
+ * layout fields, so these extras have to be declared to be read back out.
+ * `StaticGraphParser` supplies `bgColor` and `info`; `WorkflowParser`
+ * supplies `icon`, `statusColoring`, and `isPlaceholder`.
+ */
+export interface GraphNode extends dagre.Node {
+  bgColor?: string;
+  icon?: React.ReactNode;
+  info?: SelectedNodeInfo;
+  isPlaceholder?: boolean;
+  statusColoring?: string;
 }
 
 const css = stylesheet({
@@ -202,7 +220,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
           // Note that these adjustments may cause edges to overlap with nodes since we are
           // deviating from the explicit layout provided by dagre.
           if (finalSegment) {
-            const destinationNode = graph.node(edgeInfo.w);
+            const destinationNode = graph.node(edgeInfo.w) as GraphNode;
 
             // Placeholder nodes never need adjustment because they always have only a single
             // incoming edge.
@@ -264,7 +282,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       <div className={css.root}>
         {graph
           .nodes()
-          .map((id) => Object.assign(graph.node(id), { id }))
+          .map((id) => Object.assign(graph.node(id) as GraphNode, { id }))
           .map((node, i) => (
             <div
               className={classes(

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -19,7 +19,7 @@ import * as React from 'react';
 import { classes, stylesheet } from 'typestyle';
 import { fontsize, color, fonts, zIndex } from '../Css';
 import { Constants } from '../lib/Constants';
-import type { SelectedNodeInfo } from '../lib/StaticGraphParser';
+import type { DagreGraph } from '../lib/GraphTypes';
 import { Tooltip } from '@mui/material';
 
 interface Segment {
@@ -37,23 +37,6 @@ interface Edge {
   from: string;
   segments: Segment[];
   to: string;
-}
-
-/**
- * The layout properties dagre computes, plus the presentation data the
- * parsers attach to each node with `setNode`.
- *
- * `@types/dagre` describes `Graph.node()` as returning only dagre's own
- * layout fields, so these extras have to be declared to be read back out.
- * `StaticGraphParser` supplies `bgColor` and `info`; `WorkflowParser`
- * supplies `icon`, `statusColoring`, and `isPlaceholder`.
- */
-export interface GraphNode extends dagre.Node {
-  bgColor?: string;
-  icon?: React.ReactNode;
-  info?: SelectedNodeInfo;
-  isPlaceholder?: boolean;
-  statusColoring?: string;
 }
 
 const css = stylesheet({
@@ -118,7 +101,7 @@ const css = stylesheet({
 });
 
 interface GraphProps {
-  graph: dagre.graphlib.Graph;
+  graph: DagreGraph;
   onClick?: (id: string) => void;
   selectedNodeId?: string;
 }
@@ -220,7 +203,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
           // Note that these adjustments may cause edges to overlap with nodes since we are
           // deviating from the explicit layout provided by dagre.
           if (finalSegment) {
-            const destinationNode = graph.node(edgeInfo.w) as GraphNode;
+            const destinationNode = graph.node(edgeInfo.w);
 
             // Placeholder nodes never need adjustment because they always have only a single
             // incoming edge.
@@ -282,7 +265,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       <div className={css.root}>
         {graph
           .nodes()
-          .map((id) => Object.assign(graph.node(id) as GraphNode, { id }))
+          .map((id) => Object.assign(graph.node(id), { id }))
           .map((node, i) => (
             <div
               className={classes(

--- a/frontend/src/lib/GraphTypes.ts
+++ b/frontend/src/lib/GraphTypes.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as dagre from 'dagre';
+import type * as React from 'react';
+import type { SelectedNodeInfo } from './StaticGraphParser';
+
+/**
+ * Presentation data the parsers attach to each dagre node, on top of the
+ * layout fields dagre computes itself.
+ *
+ * `StaticGraphParser` supplies `bgColor` and `info`; `WorkflowParser`
+ * supplies `icon`, `statusColoring`, and `isPlaceholder`.
+ *
+ * Producers should write their `setNode` literals with `satisfies
+ * GraphNodeInput`. dagre types the label parameter as `Label`, an index
+ * signature accepting anything, so the graph's own type parameter checks
+ * readers but cannot check writers.
+ */
+export interface GraphNodeData {
+  bgColor?: string;
+  icon?: React.ReactNode;
+  info?: SelectedNodeInfo;
+  isPlaceholder?: boolean;
+  statusColoring?: string;
+}
+
+/**
+ * What a producer passes to `setNode`: presentation data plus the layout
+ * hints dagre reads. `x` and `y` are computed by `dagre.layout`, so they are
+ * deliberately absent here.
+ */
+export type GraphNodeInput = GraphNodeData & {
+  height?: number;
+  label?: string;
+  width?: number;
+};
+
+/** A dagre graph whose nodes carry {@link GraphNodeData}. */
+export type DagreGraph = dagre.graphlib.Graph<GraphNodeData>;

--- a/frontend/src/lib/StaticGraphParser.ts
+++ b/frontend/src/lib/StaticGraphParser.ts
@@ -21,6 +21,7 @@ import { color } from '../Css';
 import { Constants } from './Constants';
 import { logger } from './Utils';
 import { parseTaskDisplayName } from './ParserUtils';
+import type { DagreGraph, GraphNodeData, GraphNodeInput } from './GraphTypes';
 import { graphlib } from 'dagre';
 
 export type nodeType = 'container' | 'resource' | 'dag' | 'unknown';
@@ -116,7 +117,7 @@ export function _populateInfoFromTemplate(
  * where A and C are DAGs, the parentFullPath when rootTemplateId is C would be: /A/C
  */
 function buildDag(
-  graph: dagre.graphlib.Graph,
+  graph: DagreGraph,
   rootTemplateId: string,
   templates: Map<string, { nodeType: nodeType; template: Template }>,
   alreadyVisited: Map<string, string>,
@@ -199,7 +200,7 @@ function buildDag(
         info,
         label: nodeLabel,
         width: Constants.NODE_WIDTH,
-      });
+      } satisfies GraphNodeInput);
 
       // DAG tasks can indicate dependencies which are graphically shown as parents with edges
       // pointing to their children (the task(s)).
@@ -211,8 +212,8 @@ function buildDag(
   }
 }
 
-export function createGraph(workflow: Workflow): dagre.graphlib.Graph {
-  const graph = new dagre.graphlib.Graph();
+export function createGraph(workflow: Workflow): DagreGraph {
+  const graph = new dagre.graphlib.Graph<GraphNodeData>();
   graph.setGraph({});
   graph.setDefaultEdgeLabel(() => ({}));
 
@@ -241,7 +242,7 @@ export function createGraph(workflow: Workflow): dagre.graphlib.Graph {
         info,
         label: 'onExit - ' + template.name,
         width: Constants.NODE_WIDTH,
-      });
+      } satisfies GraphNodeInput);
     }
 
     if (template.container) {
@@ -267,7 +268,7 @@ export function createGraph(workflow: Workflow): dagre.graphlib.Graph {
         height: Constants.NODE_HEIGHT,
         label: entryPointTemplate.name,
         width: Constants.NODE_WIDTH,
-      });
+      } satisfies GraphNodeInput);
     }
   }
 
@@ -289,7 +290,7 @@ export function createGraph(workflow: Workflow): dagre.graphlib.Graph {
  *
  * @param graph The dagre graph object
  */
-export function transitiveReduction(graph: dagre.graphlib.Graph): dagre.graphlib.Graph | undefined {
+export function transitiveReduction(graph: DagreGraph): DagreGraph | undefined {
   // safeguard against too big graphs
   if (!graph || graph.edgeCount() > 1000 || graph.nodeCount() > 1000) {
     return undefined;
@@ -316,7 +317,7 @@ export function transitiveReduction(graph: dagre.graphlib.Graph): dagre.graphlib
   return result;
 }
 
-export function compareGraphEdges(graph1: dagre.graphlib.Graph, graph2: dagre.graphlib.Graph) {
+export function compareGraphEdges(graph1: DagreGraph, graph2: DagreGraph) {
   return (
     graph1
       .edges()

--- a/frontend/src/lib/WorkflowParser.ts
+++ b/frontend/src/lib/WorkflowParser.ts
@@ -28,6 +28,7 @@ import { isS3Endpoint } from './AwsHelper';
 import * as metadataStorePb from 'src/third_party/mlmd/generated/ml_metadata/proto/metadata_store_pb';
 import { isV2Pipeline } from './v2/WorkflowUtils';
 import { ExecutionHelpers } from 'src/mlmd/MlmdUtils';
+import type { DagreGraph, GraphNodeData, GraphNodeInput } from './GraphTypes';
 
 export enum StorageService {
   GCS = 'gcs',
@@ -48,9 +49,9 @@ export default class WorkflowParser {
   public static createRuntimeGraph(
     workflow: Workflow,
     executions: metadataStorePb.Execution[] | undefined,
-  ): dagre.graphlib.Graph {
+  ): DagreGraph {
     const nodeStateMap = buildNodeToExecutionStateMap(executions);
-    const g = new dagre.graphlib.Graph();
+    const g = new dagre.graphlib.Graph<GraphNodeData>();
     g.setGraph({});
     g.setDefaultEdgeLabel(() => ({}));
 
@@ -111,7 +112,7 @@ export default class WorkflowParser {
         statusColoring: statusToBgColor(node.phase as NodePhase, node.message),
         width: Constants.NODE_WIDTH,
         ...node,
-      });
+      } satisfies GraphNodeInput);
 
       if (!hasFinished(node.phase as NodePhase) && !this.isVirtual(node)) {
         g.setNode(node.id + runningNodeSuffix, {
@@ -125,7 +126,7 @@ export default class WorkflowParser {
           }),
           isPlaceholder: true,
           width: PLACEHOLDER_NODE_DIMENSION,
-        });
+        } satisfies GraphNodeInput);
         g.setEdge(node.id, node.id + runningNodeSuffix, { color: color.weak, isPlaceholder: true });
       }
     });

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -57,10 +57,11 @@ import { ApiJob } from 'src/apis/job';
 import { V2beta1Run } from 'src/apisv2beta1/run';
 import { V2beta1RecurringRun } from 'src/apisv2beta1/recurringrun';
 import { V2beta1Experiment } from 'src/apisv2beta1/experiment';
+import type { DagreGraph } from '../lib/GraphTypes';
 
 interface PipelineDetailsState {
-  graph: dagre.graphlib.Graph | null;
-  reducedGraph: dagre.graphlib.Graph | null;
+  graph: DagreGraph | null;
+  reducedGraph: DagreGraph | null;
   graphV2: PipelineFlowElement[] | null;
   graphIsLoading: boolean;
   v1Pipeline: ApiPipeline | null;

--- a/frontend/src/pages/PipelineDetailsV1.tsx
+++ b/frontend/src/pages/PipelineDetailsV1.tsx
@@ -24,6 +24,7 @@ import { classes, stylesheet } from 'typestyle';
 import MD2Tabs from '../atoms/MD2Tabs';
 import { Description } from '../components/Description';
 import PipelineGraph from '../components/Graph';
+import type { GraphNode } from '../components/Graph';
 import ReduceGraphSwitch from '../components/ReduceGraphSwitch';
 import SidePanel from '../components/SidePanel';
 import StaticNodeDetails from '../components/StaticNodeDetails';
@@ -109,7 +110,7 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
 
   let selectedNodeInfo: StaticGraphParser.SelectedNodeInfo | null = null;
   if (graphToShow && graphToShow.node(selectedNodeId)) {
-    selectedNodeInfo = graphToShow.node(selectedNodeId).info;
+    selectedNodeInfo = (graphToShow.node(selectedNodeId) as GraphNode).info ?? null;
     if (!!selectedNodeId && !selectedNodeInfo) {
       logger.error(`Node with ID: ${selectedNodeId} was not found in the graph`);
     }

--- a/frontend/src/pages/PipelineDetailsV1.tsx
+++ b/frontend/src/pages/PipelineDetailsV1.tsx
@@ -24,7 +24,6 @@ import { classes, stylesheet } from 'typestyle';
 import MD2Tabs from '../atoms/MD2Tabs';
 import { Description } from '../components/Description';
 import PipelineGraph from '../components/Graph';
-import type { GraphNode } from '../components/Graph';
 import ReduceGraphSwitch from '../components/ReduceGraphSwitch';
 import SidePanel from '../components/SidePanel';
 import StaticNodeDetails from '../components/StaticNodeDetails';
@@ -33,6 +32,7 @@ import * as StaticGraphParser from '../lib/StaticGraphParser';
 import { formatDateString, logger, sanitizeExternalHref } from '../lib/Utils';
 
 import { Button, FormControl, InputLabel, MenuItem, Paper, Select } from '@mui/material';
+import type { DagreGraph } from '../lib/GraphTypes';
 
 const summaryCardWidth = 500;
 
@@ -82,8 +82,8 @@ export const css = stylesheet({
 });
 
 export interface PipelineDetailsV1Props {
-  graph: dagre.graphlib.Graph | null;
-  reducedGraph: dagre.graphlib.Graph | null;
+  graph: DagreGraph | null;
+  reducedGraph: DagreGraph | null;
   pipeline: ApiPipeline | null;
   templateString?: string;
   updateBanner: (bannerProps: BannerProps) => void;
@@ -110,7 +110,7 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
 
   let selectedNodeInfo: StaticGraphParser.SelectedNodeInfo | null = null;
   if (graphToShow && graphToShow.node(selectedNodeId)) {
-    selectedNodeInfo = (graphToShow.node(selectedNodeId) as GraphNode).info ?? null;
+    selectedNodeInfo = graphToShow.node(selectedNodeId).info ?? null;
     if (!!selectedNodeId && !selectedNodeInfo) {
       logger.error(`Node with ID: ${selectedNodeId} was not found in the graph`);
     }


### PR DESCRIPTION
Supersedes #14319.

Carries the same `@types/dagre` bump (`^0.7.40` -> `^0.7.54`) plus the source change it needs to compile.

## Why the bump alone fails

`@types/dagre` 0.7.54 gives `Graph.node()` a concrete return type instead of the loose one 0.7.40 had. The parsers attach presentation data to each node with `setNode` — `StaticGraphParser` supplies `bgColor` and `info`, `WorkflowParser` supplies `icon`, `statusColoring`, and `isPlaceholder` — and reading those back no longer type-checks:

```
src/components/Graph.tsx(209,34): error TS2339: Property 'isPlaceholder' does not exist on type '{ x: number; y: number; width: number; height: number; ... }'
src/components/Graph.tsx(291,39): error TS2339: Property 'bgColor' does not exist ...
src/components/Graph.tsx(305,67): error TS2339: Property 'statusColoring' does not exist ...
src/components/Graph.tsx(306,23): error TS2339: Property 'icon' does not exist ...
src/pages/PipelineDetailsV1.tsx(112,57): error TS2339: Property 'info' does not exist ...
```

Eight errors across two files, which is why `frontend-tests` fails on #14319, with `image-build` and `Frontend Integration Tests` failing downstream of it.

## The change

A `GraphNode` interface beside the existing `Edge` interface, listing what the parsers actually attach, plus reads going through it. No runtime code changes.

The fields are taken from the `setNode` call sites rather than from the error messages, so the interface documents the real contract between the parsers and the renderer instead of just silencing the compiler. `@types/dagre` 0.7.54 then checks that contract rather than rubber-stamping it.

## Worth flagging: this is not purely latent

`package.json` already declared `^0.7.40`, and `0.7.54` satisfies that range. Only the lockfile was holding the 2018 version, so any `npm install` (as opposed to `npm ci`) could resolve to 0.7.54 and break the build with no dependency change at all. This PR isn't creating that exposure, it's removing it.

## Note on the imports

Both new imports are `import type`, deliberately. `SelectedNodeInfo` is a class, so a value import pulls `StaticGraphParser` and its transitive graph — including `third_party/mlmd/argo_template` — into `Graph.tsx` at runtime. That perturbs module initialisation enough to fail two tests in `NewPipelineVersion` and `NewRunV2`, which I hit and had to track down. Type-only imports are erased and add no runtime edge. `StaticGraphParser` itself already uses this pattern for React.

`selectedNodeInfo` also now coalesces to `null` so it matches its declared `SelectedNodeInfo | null`; every use is a truthiness check, so behaviour is unchanged.

## Verification

- `tsc --noEmit`: clean (was 8 errors)
- Full frontend suite: **150 files, 2088 tests, all passing**
- Verified against a master baseline in the same worktree — same five files, 179/179 both before and after
- `eslint --max-warnings=0` and `prettier --check`: clean

## Not addressed here

`dagre` itself stays at `^0.8.5`, which is still the latest release. Only the type definitions moved.