### PR TITLE
fix(sdk): explicitly filter embedded archive extraction

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -8,6 +8,11 @@
 
 ## Bug fixes and other changes
 
+* Generated components now extract their embedded archive through an explicit safe
+  extraction policy instead of relying on the runtime's default `tarfile.extractall()`
+  behavior, which varies by Python version. Pipelines compiled with earlier versions
+  keep their previously generated extraction code and must be recompiled to pick this up.
+
 # 2.15.2
 
 ## Bug fixes and other changes

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -40,6 +40,7 @@ from kfp.dsl import structures
 from kfp.dsl import task_final_status
 from kfp.dsl.component_task_config import TaskConfigPassthrough
 from kfp.dsl.task_config import TaskConfig
+from kfp.dsl.templates.safe_extract import get_safe_extract_source
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import custom_artifact_types
 from kfp.dsl.types import type_annotations
@@ -680,6 +681,7 @@ def _generate_shared_extraction_helper(embedded_archive_b64: str,
     file_assignment = ''
     if file_basename:
         file_assignment = f"\n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR, '{file_basename}')\n"
+    safe_extract_source = get_safe_extract_source()
     return f'''__KFP_EMBEDDED_ARCHIVE_B64 = '{embedded_archive_b64}'
 
 import base64 as __kfp_b64
@@ -689,13 +691,14 @@ import sys as __kfp_sys
 import tarfile as __kfp_tarfile
 import tempfile as __kfp_tempfile
 
+{safe_extract_source}
 # Extract embedded archive at import time to ensure sys.path and globals are set
 __kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()
 __KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name
 try:
     __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))
     with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz') as __kfp_tar:
-        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)
+        __kfp_safe_extract(__kfp_tar, __KFP_EMBEDDED_ASSET_DIR)
 except Exception as __kfp_e:
     raise RuntimeError(f'Failed to extract embedded archive: {{__kfp_e}}')
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -685,5 +685,30 @@ class TestEmbeddedArtifactSymlinkResolution(unittest.TestCase):
                     pass
 
 
+class TestEmbeddedArchiveExtractionFilter(unittest.TestCase):
+    """Generated helpers must route extraction through the safe extractor."""
+
+    def _assert_uses_safe_extractor(self, source: str) -> None:
+        self.assertIn('def __kfp_safe_extract', source)
+        self.assertIn('__kfp_safe_extract(__kfp_tar, __KFP_EMBEDDED_ASSET_DIR)',
+                      source)
+        self.assertNotIn('__kfp_tar.extractall(', source)
+        compile(source, '<generated>', 'exec')
+
+    def test_component_helper_uses_safe_extractor(self):
+        self._assert_uses_safe_extractor(
+            component_factory._generate_shared_extraction_helper('QkFTRTY0'))
+
+    def test_component_helper_with_single_file_uses_safe_extractor(self):
+        self._assert_uses_safe_extractor(
+            component_factory._generate_shared_extraction_helper(
+                'QkFTRTY0', 'asset.txt'))
+
+    def test_notebook_helper_uses_safe_extractor(self):
+        from kfp.dsl.templates.notebook_executor import get_notebook_executor_source
+        self._assert_uses_safe_extractor(
+            get_notebook_executor_source('QkFTRTY0', 'nb.ipynb'))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/dsl/templates/notebook_executor.py
+++ b/sdk/python/kfp/dsl/templates/notebook_executor.py
@@ -11,6 +11,8 @@ those dependencies when this module is imported for code generation.
 import inspect
 import textwrap
 
+from kfp.dsl.templates.safe_extract import get_safe_extract_source
+
 
 def __kfp_write_parameters_cell(nb, params):
     """Inject parameters following Papermill semantics.
@@ -220,6 +222,7 @@ def get_notebook_executor_source(archive_b64_placeholder: str,
     # Combine everything into the final source with archive extraction at import
     functions_code = streaming_client_source + '\n' + '\n'.join(
         function_sources)
+    safe_extract_source = get_safe_extract_source()
     return f"""__KFP_EMBEDDED_ARCHIVE_B64 = '{archive_b64_placeholder}'
 __KFP_NOTEBOOK_REL_PATH = '{notebook_relpath_placeholder}'
 
@@ -232,6 +235,7 @@ import tarfile as __kfp_tarfile
 import tempfile as __kfp_tempfile
 from nbclient import NotebookClient
 
+{safe_extract_source}
 # Extract embedded archive at import time to ensure sys.path and globals are set
 print('[KFP] Extracting embedded notebook archive...', flush=True)
 __kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()
@@ -239,7 +243,7 @@ __KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name
 try:
     __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))
     with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz') as __kfp_tar:
-        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)
+        __kfp_safe_extract(__kfp_tar, __KFP_EMBEDDED_ASSET_DIR)
     print(f'[KFP] Notebook archive extracted to: {{__KFP_EMBEDDED_ASSET_DIR}}', flush=True)
 except Exception as __kfp_e:
     raise RuntimeError(f'Failed to extract embedded notebook archive: {{__kfp_e}}')

--- a/sdk/python/kfp/dsl/templates/safe_extract.py
+++ b/sdk/python/kfp/dsl/templates/safe_extract.py
@@ -1,0 +1,53 @@
+"""Template for embedded-archive extraction code generation.
+
+This module contains the extraction helper that gets embedded into generated
+component source. Using inspect.getsource() to convert it to source code keeps a
+single definition shared by every generator and keeps it directly testable.
+
+Note: The template function imports its dependencies locally, both to avoid
+requiring them when this module is imported for code generation and to keep the
+generated module namespace free of unprefixed names.
+"""
+
+import inspect
+import textwrap
+
+
+def __kfp_safe_extract(tar, path):
+    """Extract ``tar`` into ``path`` without letting members escape it."""
+    import os as __kfp_os
+    import tarfile as __kfp_tarfile
+
+    # tarfile gained the PEP 706 extraction filters in Python 3.12, backported to
+    # 3.9.17, 3.10.12 and 3.11.4. Where they exist, 'data' is the policy we want:
+    # it refuses absolute paths, traversal outside the destination, links
+    # pointing outside it, and special files.
+    if hasattr(__kfp_tarfile, 'data_filter'):
+        tar.extractall(path=path, filter='data')
+        return
+
+    # Older runtimes have no filters at all. Check containment here rather than
+    # falling back to an unrestricted extractall.
+    __kfp_dest = __kfp_os.path.realpath(path)
+    for __kfp_member in tar.getmembers():
+        if __kfp_member.issym() or __kfp_member.islnk():
+            raise RuntimeError(
+                'Refusing to extract link member %r from the embedded archive.'
+                % __kfp_member.name)
+        if not (__kfp_member.isfile() or __kfp_member.isdir()):
+            raise RuntimeError(
+                'Refusing to extract special member %r from the embedded archive.'
+                % __kfp_member.name)
+        __kfp_target = __kfp_os.path.realpath(
+            __kfp_os.path.join(__kfp_dest, __kfp_member.name))
+        if __kfp_target != __kfp_dest and not __kfp_target.startswith(
+                __kfp_dest + __kfp_os.sep):
+            raise RuntimeError(
+                'Refusing to extract %r outside the embedded asset directory.' %
+                __kfp_member.name)
+    tar.extractall(path=path)
+
+
+def get_safe_extract_source() -> str:
+    """Return the extraction helper's source code for embedding."""
+    return textwrap.dedent(inspect.getsource(__kfp_safe_extract))

--- a/sdk/python/kfp/dsl/templates/safe_extract_test.py
+++ b/sdk/python/kfp/dsl/templates/safe_extract_test.py
@@ -1,0 +1,173 @@
+"""Tests for the embedded-archive extraction helper."""
+
+import contextlib
+import io
+import os
+import tarfile
+import tempfile
+import unittest
+import warnings
+
+from kfp.dsl.templates import safe_extract
+
+# Resolved here rather than inside a class body, where the leading double
+# underscore would trigger private name mangling.
+_safe_extract = getattr(safe_extract, '__kfp_safe_extract')
+
+# The filtered path raises a tarfile.FilterError subclass; the compatibility
+# path raises RuntimeError. Both are refusals.
+_REFUSALS = (RuntimeError, tarfile.TarError)
+
+
+@contextlib.contextmanager
+def _without_extraction_filters():
+    """Simulate a runtime predating the PEP 706 extraction filters."""
+    missing = object()
+    saved = getattr(tarfile, 'data_filter', missing)
+    if saved is not missing:
+        del tarfile.data_filter
+    try:
+        with warnings.catch_warnings():
+            # The unfiltered extractall the compatibility path falls through to
+            # is deprecated on the interpreters this context manager pretends
+            # not to be running on.
+            warnings.simplefilter('ignore', DeprecationWarning)
+            yield
+    finally:
+        if saved is not missing:
+            tarfile.data_filter = saved
+
+
+def _archive(name: str,
+             data: bytes = b'payload',
+             typeflag: bytes = tarfile.REGTYPE,
+             linkname: str = '') -> io.BytesIO:
+    """Build an in-memory tar holding a single member."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w') as tar:
+        info = tarfile.TarInfo(name)
+        info.type = typeflag
+        if typeflag == tarfile.REGTYPE:
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        else:
+            info.linkname = linkname
+            tar.addfile(info)
+    buf.seek(0)
+    return buf
+
+
+class TestSafeExtract(unittest.TestCase):
+
+    @contextlib.contextmanager
+    def _dest(self):
+        """Yield (extraction destination, a sibling directory outside it)."""
+        with tempfile.TemporaryDirectory() as root:
+            dest = os.path.join(root, 'assets')
+            outside = os.path.join(root, 'outside')
+            os.makedirs(dest)
+            os.makedirs(outside)
+            yield dest, outside
+
+    def _extract(self, buf: io.BytesIO, dest: str) -> None:
+        with tarfile.open(fileobj=buf, mode='r') as tar:
+            _safe_extract(tar, dest)
+
+    def test_extracts_ordinary_member(self):
+        with self._dest() as (dest, _):
+            self._extract(_archive('data.txt', b'hello'), dest)
+            with open(os.path.join(dest, 'data.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'hello')
+
+    def test_extracts_nested_member(self):
+        with self._dest() as (dest, _):
+            self._extract(_archive('pkg/mod.py', b'x = 1'), dest)
+            self.assertTrue(os.path.exists(os.path.join(dest, 'pkg', 'mod.py')))
+
+    def test_rejects_parent_traversal(self):
+        with self._dest() as (dest, outside):
+            with self.assertRaises(_REFUSALS):
+                self._extract(_archive('../outside/escaped.txt'), dest)
+            self.assertFalse(
+                os.path.exists(os.path.join(outside, 'escaped.txt')))
+
+    def test_absolute_member_does_not_escape(self):
+        with self._dest() as (dest, outside):
+            absolute = os.path.join(outside, 'escaped.txt')
+            # The two paths neutralise this differently: the extraction filters
+            # strip the leading separator and keep the member inside the
+            # destination, while the compatibility path refuses it outright.
+            # What matters either way is that nothing lands at the absolute
+            # location.
+            with contextlib.suppress(*_REFUSALS):
+                self._extract(_archive(absolute), dest)
+            self.assertFalse(os.path.exists(absolute))
+
+    def test_rejects_symlink_escaping_destination(self):
+        with self._dest() as (dest, outside):
+            with self.assertRaises(_REFUSALS):
+                self._extract(
+                    _archive(
+                        'link',
+                        typeflag=tarfile.SYMTYPE,
+                        linkname=os.path.join(outside, 'target')), dest)
+            self.assertFalse(os.path.exists(os.path.join(dest, 'link')))
+
+    def test_compatibility_path_extracts_ordinary_member(self):
+        with self._dest() as (dest, _):
+            with _without_extraction_filters():
+                self._extract(_archive('data.txt', b'hello'), dest)
+            with open(os.path.join(dest, 'data.txt'), 'rb') as f:
+                self.assertEqual(f.read(), b'hello')
+
+    def test_compatibility_path_rejects_parent_traversal(self):
+        with self._dest() as (dest, outside):
+            with _without_extraction_filters():
+                with self.assertRaises(RuntimeError):
+                    self._extract(_archive('../outside/escaped.txt'), dest)
+            self.assertFalse(
+                os.path.exists(os.path.join(outside, 'escaped.txt')))
+
+    def test_compatibility_path_rejects_absolute_member(self):
+        with self._dest() as (dest, outside):
+            absolute = os.path.join(outside, 'escaped.txt')
+            with _without_extraction_filters():
+                with self.assertRaises(RuntimeError):
+                    self._extract(_archive(absolute), dest)
+            self.assertFalse(os.path.exists(absolute))
+
+    def test_compatibility_path_rejects_symlink(self):
+        with self._dest() as (dest, outside):
+            with _without_extraction_filters():
+                with self.assertRaises(RuntimeError):
+                    self._extract(
+                        _archive(
+                            'link',
+                            typeflag=tarfile.SYMTYPE,
+                            linkname=os.path.join(outside, 'target')), dest)
+            self.assertFalse(os.path.exists(os.path.join(dest, 'link')))
+
+
+class TestSafeExtractSource(unittest.TestCase):
+
+    def test_source_defines_the_helper(self):
+        namespace = {}
+        exec(safe_extract.get_safe_extract_source(), namespace)  # noqa: S102
+        self.assertIn('__kfp_safe_extract', namespace)
+
+    def test_embedded_source_enforces_containment(self):
+        namespace = {}
+        exec(safe_extract.get_safe_extract_source(), namespace)  # noqa: S102
+        embedded = namespace['__kfp_safe_extract']
+        with tempfile.TemporaryDirectory() as root:
+            dest = os.path.join(root, 'assets')
+            os.makedirs(dest)
+            with tarfile.open(
+                    fileobj=_archive('../escaped.txt'), mode='r') as tar:
+                with self.assertRaises(_REFUSALS):
+                    embedded(tar, dest)
+            self.assertFalse(os.path.exists(os.path.join(root, 'escaped.txt')))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #14294

### Problem

`component_factory._generate_shared_extraction_helper` and `templates/notebook_executor.py` both
generate runtime code that calls `__kfp_tar.extractall(path=...)` with no filter, so containment
depends entirely on the interpreter's default policy — which is exactly what the issue flags as
varying by version. Through Python 3.13 that default is still `fully_trusted` with only a
`DeprecationWarning`, so a crafted embedded archive can write outside the temporary asset directory
via a `../` traversal member, a symlink, or an absolute member name.

I confirmed this rather than assuming it: with the helper replaced by a bare `extractall`, 7 of the
11 new tests fail, including the one asserting an absolute member never lands at its absolute path.

### Change

Add `kfp/dsl/templates/safe_extract.py` with a single `__kfp_safe_extract` helper, embedded into
both generators through `inspect.getsource()` — the same mechanism `notebook_executor` already uses
for its helpers. That keeps one definition shared by both call sites, which is what the acceptance
criteria ask for, and has the useful side effect of making the helper directly unit-testable
instead of only reachable as a generated string.

The helper:

- applies `filter='data'` when the runtime has the PEP 706 filters (3.12+, backported to 3.9.17,
  3.10.12 and 3.11.4), and
- on older runtimes — the SDK still supports `>=3.9.0` — validates member types and containment
  itself and then extracts, rather than silently falling back to an unrestricted `extractall`.

Ordinary embedded-file, directory and notebook behavior is unchanged; only escaping members are
refused.

### Tests

`sdk/python/kfp/dsl/templates/safe_extract_test.py`, 11 cases covering both branches: ordinary and
nested members extract; traversal, escaping symlink and absolute members do not escape; and the same
three against the compatibility path with the extraction filters removed, so the pre-3.12 branch is
actually exercised on a modern interpreter. Plus three cases in `component_factory_test.py` pinning
that both generators emit and call the helper and that the generated source still compiles.

One behavioral note worth flagging for review: the two branches neutralize an absolute member
differently — the filters strip the leading separator and keep it inside the destination, while the
compatibility path refuses it outright. Both are safe, so the shared test asserts the property that
matters (nothing lands at the absolute path) and the branch-specific test asserts the refusal.

### Verification

`safe_extract_test.py` and `component_factory_test.py` pass (46 tests). `yapf`, `isort --profile
google` and `docformatter` are clean on the touched files. Two failures in
`notebook_component_decorator_test.py::TestNotebookParameterInjection` reproduce identically on
master with this branch stashed, so they are pre-existing and untouched here.

### Docs

`sdk/RELEASE.md` notes that pipelines compiled with earlier versions keep their previously generated
extraction code and must be recompiled to pick this up.
