### PR TITLE
fix(frontend): avoid false artifact truncation markers

### DIFF
--- a/frontend/src/components/ArtifactPreview.test.tsx
+++ b/frontend/src/components/ArtifactPreview.test.tsx
@@ -123,6 +123,43 @@ describe('ArtifactPreview', () => {
     await waitFor(() => screen.getByText(`012 345 ...`));
   });
 
+  it('does not truncate when line count is below maxlines', async () => {
+    const data = `012\n345`;
+    vi.spyOn(Apis, 'readFile').mockResolvedValueOnce(data);
+    render(
+      <CommonTestWrapper>
+        <ArtifactPreview
+          value={'minio://bucket/key'}
+          namespace={'kubeflow'}
+          maxbytes={data.length}
+          maxlines={20}
+        />
+      </CommonTestWrapper>,
+    );
+    await waitFor(() => screen.getByText('minio://bucket/key'));
+    await waitFor(() => screen.getByText('012 345'));
+    expect(screen.queryByText(/\.\.\./)).not.toBeInTheDocument();
+  });
+
+  it('does not truncate when line count exactly equals maxlines', async () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line${i}`);
+    const data = lines.join('\n');
+    vi.spyOn(Apis, 'readFile').mockResolvedValueOnce(data);
+    render(
+      <CommonTestWrapper>
+        <ArtifactPreview
+          value={'minio://bucket/key'}
+          namespace={'kubeflow'}
+          maxbytes={data.length}
+          maxlines={20}
+        />
+      </CommonTestWrapper>,
+    );
+    await waitFor(() => screen.getByText('minio://bucket/key'));
+    await waitFor(() => screen.getByText(lines.join(' ')));
+    expect(screen.queryByText(/\.\.\./)).not.toBeInTheDocument();
+  });
+
   it('handles artifact that previews with maxbytes', async () => {
     const data = `012\n345\n678\n910`;
     vi.spyOn(Apis, 'readFile').mockResolvedValueOnce(data);

--- a/frontend/src/components/ArtifactPreview.tsx
+++ b/frontend/src/components/ArtifactPreview.tsx
@@ -137,7 +137,7 @@ async function getPreview(
     peek: maxbytes + 1,
   });
   // is preview === data and no maxlines
-  if (data.length <= maxbytes && (!maxlines || data.split('\n').length < maxlines)) {
+  if (data.length <= maxbytes && (!maxlines || data.split('\n').length <= maxlines)) {
     return data;
   }
   // remove extra byte at the end (we requested maxbytes +1)

--- a/frontend/src/components/MinioArtifactPreview.test.tsx
+++ b/frontend/src/components/MinioArtifactPreview.test.tsx
@@ -356,6 +356,47 @@ describe('MinioArtifactPreview', () => {
     expect(queryByText('minio://foo/bar')).toBeTruthy();
   });
 
+  it('shows full content without a truncation marker when line count is below maxlines', async () => {
+    const minioArtifact = {
+      key: 'bar',
+      s3Bucket: {
+        accessKeySecret: { key: 'accesskey', optional: false, name: 'minio' },
+        bucket: 'foo',
+        endpoint: 'minio.kubeflow',
+        secretKeySecret: { key: 'secretkey', optional: false, name: 'minio' },
+      },
+    };
+    const data = `012\n345`;
+    readFile.mockResolvedValue(data);
+    const { queryByText } = render(
+      <MinioArtifactPreview value={minioArtifact} maxbytes={data.length} maxlines={20} />,
+    );
+    await act(TestUtils.flushPromises);
+    expect(queryByText('012 345')).toBeTruthy();
+    expect(queryByText(/\.\.\./)).toBeFalsy();
+  });
+
+  it('shows full content without a truncation marker when line count exactly equals maxlines', async () => {
+    const minioArtifact = {
+      key: 'bar',
+      s3Bucket: {
+        accessKeySecret: { key: 'accesskey', optional: false, name: 'minio' },
+        bucket: 'foo',
+        endpoint: 'minio.kubeflow',
+        secretKeySecret: { key: 'secretkey', optional: false, name: 'minio' },
+      },
+    };
+    const lines = Array.from({ length: 20 }, (_, i) => `line${i}`);
+    const data = lines.join('\n');
+    readFile.mockResolvedValue(data);
+    const { queryByText } = render(
+      <MinioArtifactPreview value={minioArtifact} maxbytes={data.length} maxlines={20} />,
+    );
+    await act(TestUtils.flushPromises);
+    expect(queryByText(lines.join(' '))).toBeTruthy();
+    expect(queryByText(/\.\.\./)).toBeFalsy();
+  });
+
   it('handles artifact that previews with maxbytes', async () => {
     const minioArtifact = {
       key: 'bar',

--- a/frontend/src/components/MinioArtifactPreview.tsx
+++ b/frontend/src/components/MinioArtifactPreview.tsx
@@ -73,7 +73,7 @@ async function getPreview(
   // TODO how to handle binary data (can probably use magic number to id common mime types)
   let data = await Apis.readFile({ path: storagePath, namespace: namespace, peek: maxbytes + 1 });
   // is preview === data and no maxlines
-  if (data.length <= maxbytes && !maxlines) {
+  if (data.length <= maxbytes && (!maxlines || data.split('\n').length <= maxlines)) {
     return { data, hasMore: false };
   }
   // remove extra byte at the end (we requested maxbytes +1)


### PR DESCRIPTION
 **Description of your changes:**

Fixes artifact previews showing a truncation marker even when no content is actually removed.

`ArtifactPreview` treated content exactly at the `maxlines` limit as truncated. `MinioArtifactPreview` could also report `hasMore: true` when the content fit within both the byte and line limits.

This PR fixes both boundary cases and adds regression tests for the line-limit behavior.

Fixes #14278

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).