### PR TITLE
fix(sdk): Typos and TODO comment formatting

### DIFF
--- a/sdk/python/kfp/cli/diagnose_me/kubernetes_cluster.py
+++ b/sdk/python/kfp/cli/diagnose_me/kubernetes_cluster.py
@@ -114,7 +114,7 @@ def get_kubectl_configuration(
 
 
 def _get_kfp_runtime() -> Text:
-    """Captures the current version of kpf in k8 cluster.
+    """Captures the current version of kfp in k8 cluster.
 
     Returns:
       Returns the run-time version of kfp in as a string.

--- a/sdk/python/kfp/cli/diagnose_me/utility.py
+++ b/sdk/python/kfp/cli/diagnose_me/utility.py
@@ -26,7 +26,7 @@ class ExecutorResponse(object):
     pattern.
 
     TODO() This class should be extended to contain data structure to better
-    represent the underlying data instaed of dict for various response types.
+    represent the underlying data instead of dict for various response types.
     """
 
     def execute_command(self, command_list: List[Text]):
@@ -38,7 +38,7 @@ class ExecutorResponse(object):
         deviates from MVP design pattern. It should be factored out in future.
 
         Args:
-          command_list: A List of strings that represts the command and parameters
+          command_list: A List of strings that represents the command and parameters
             to be executed.
 
         Returns:

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1042,7 +1042,7 @@ class Client:
         Returns:
             ``RunPipelineResult`` object containing information about the pipeline run.
         """
-        #TODO: Check arguments against the pipeline function
+        # TODO: Check arguments against the pipeline function
         pipeline_name = pipeline_func.name
         run_name = run_name or pipeline_name + ' ' + datetime.datetime.now(
         ).strftime('%Y-%m-%d %H-%M-%S')
@@ -1110,7 +1110,7 @@ class Client:
             ``RunPipelineResult`` object containing information about the pipeline run.
         """
 
-        #TODO: Check arguments against the pipeline function
+        # TODO: Check arguments against the pipeline function
         pipeline_name = os.path.basename(pipeline_file)
 
         if (experiment_name is not None) and (experiment_id is not None):

--- a/sdk/python/kfp/dsl/v1_modelbase.py
+++ b/sdk/python/kfp/dsl/v1_modelbase.py
@@ -25,7 +25,7 @@ T = TypeVar('T')
 def verify_object_against_type(x: Any, typ: Type[T]) -> T:
     """Verifies that the object is compatible to the specified type (types from
     the typing package can be used)."""
-    #TODO: Merge with parse_object_from_struct_based_on_type which has almost the same code
+    # TODO: Merge with parse_object_from_struct_based_on_type which has almost the same code
     if typ is type(None):
         if x is None:
             return x
@@ -240,7 +240,7 @@ def convert_object_to_struct(obj, serialized_names: Mapping[str, str] = {}):
     """
     signature = inspect.signature(obj.__init__)  #Needed for default values
     result = {}
-    for python_name in signature.parameters:  #TODO: Make it possible to specify the field ordering regardless of the presence of default values
+    for python_name in signature.parameters:  # TODO: Make it possible to specify the field ordering regardless of the presence of default values
         value = getattr(obj, python_name)
         if python_name.startswith('_'):
             continue

--- a/sdk/python/kfp/dsl/v1_structures.py
+++ b/sdk/python/kfp/dsl/v1_structures.py
@@ -296,7 +296,7 @@ class ContainerSpec(ModelBase):
     """Describes the container component implementation."""
     _serialized_names = {
         'file_outputs':
-            'fileOutputs',  #TODO: rename to something like legacy_unconfigurable_output_paths
+            'fileOutputs',  # TODO: rename to something like legacy_unconfigurable_output_paths
     }
 
     def __init__(
@@ -308,7 +308,7 @@ class ContainerSpec(ModelBase):
             file_outputs:
         Optional[Mapping[
             str,
-            str]] = None,  #TODO: rename to something like legacy_unconfigurable_output_paths
+            str]] = None,  # TODO: rename to something like legacy_unconfigurable_output_paths
     ):
         super().__init__(locals())
 
@@ -733,7 +733,7 @@ class TaskSpec(ModelBase):
         annotations: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(locals())
-        #TODO: If component_ref is resolved to component spec, then check that the arguments correspond to the inputs
+        # TODO: If component_ref is resolved to component spec, then check that the arguments correspond to the inputs
 
     def _init_outputs(self):
         #Adding output references to the task


### PR DESCRIPTION
## Description of your changes

Fixes spelling mistakes and normalizes TODO comment formatting in the KFP SDK.

Changes include:

- Corrected `kpf` to `kfp`.
- Corrected `instaed` to `instead`.
- Corrected `represts` to `represents`.
- Updated `#TODO:` comments to `# TODO:` in the affected SDK files.

These are comment and docstring-only changes. No runtime logic or public API behavior was modified.

Fixes #14327

## Checklist

- [x] I have signed off my commits.
- [x] The PR title follows the repository title convention.
- [x] Changes are limited to comments and docstrings.
- [x] `git diff --check` passes.