### PR TITLE
fix(sdk): align memory and workspace size validation with Kubernetes

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -4444,11 +4444,16 @@ class TestPlatformConfig(unittest.TestCase):
         """Test that workspace size validation works correctly."""
         from kfp.dsl.pipeline_config import WorkspaceConfig
 
-        valid_sizes = ['10Gi', '1.5Gi', '1000Ti', '500Mi', '2Ki']
+        valid_sizes = [
+            '10Gi', '1.5Gi', '1000Ti', '500Mi', '2Ki', '100k', '500m', '1e3'
+        ]
         for size in valid_sizes:
             with self.subTest(size=size):
                 workspace = WorkspaceConfig(size=size)
                 self.assertEqual(workspace.size, size)
+
+        # Kubernetes only reads the lowercase kilobyte suffix.
+        self.assertEqual(WorkspaceConfig(size='10K').size, '10k')
 
         with self.assertRaises(ValueError) as context:
             WorkspaceConfig(size='')
@@ -4468,7 +4473,9 @@ class TestPlatformConfig(unittest.TestCase):
             WorkspaceConfig(size=None)
 
         # Test invalid size raise error
-        invalid_sizes = ['abc', '10XYZ', 'Gi', '.', '1..5Gi', '-10Gi']
+        invalid_sizes = [
+            'abc', '10XYZ', 'Gi', '.', '1..5Gi', '-10Gi', '1gi', '1GB', '1KI'
+        ]
         for size in invalid_sizes:
             with self.subTest(invalid_size=size):
                 with self.assertRaisesRegex(

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -878,46 +878,45 @@ def _cpu_to_float(cpu: str) -> float:
     return float(cpu[:-1]) / 1000 if cpu.endswith('m') else float(cpu)
 
 
+# Multipliers for every suffix Kubernetes accepts on a resource quantity,
+# longest first so that "Gi" is matched before "G". "K" is kept alongside "k"
+# because KFP accepted it before it was normalized away.
+_MEMORY_SUFFIX_MULTIPLIERS = (
+    ('Ei', constants._EI),
+    ('Pi', constants._PI),
+    ('Ti', constants._TI),
+    ('Gi', constants._GI),
+    ('Mi', constants._MI),
+    ('Ki', constants._KI),
+    ('E', constants._E),
+    ('P', constants._P),
+    ('T', constants._T),
+    ('G', constants._G),
+    ('M', constants._M),
+    ('K', constants._K),
+    ('k', constants._K),
+    ('m', 1e-3),
+    ('u', 1e-6),
+    ('n', 1e-9),
+)
+
+
 # Note that memory_to_float assumes the string has already been validated by the _validate_memory_request_limit method.
 def _memory_to_float(memory: str) -> float:
     """Converts the validated memory request/limit string to its numeric value.
 
     Args:
-        memory: Memory requests or limits. This string should be a number or
-            a number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G",
-            "Gi", "M", "Mi", "K", or "Ki".
-    Returns:
-        The numeric value (float) of the memory request/limit.
-    """
-    if memory.endswith('E'):
-        memory = float(memory[:-1]) * constants._E / constants._G
-    elif memory.endswith('Ei'):
-        memory = float(memory[:-2]) * constants._EI / constants._G
-    elif memory.endswith('P'):
-        memory = float(memory[:-1]) * constants._P / constants._G
-    elif memory.endswith('Pi'):
-        memory = float(memory[:-2]) * constants._PI / constants._G
-    elif memory.endswith('T'):
-        memory = float(memory[:-1]) * constants._T / constants._G
-    elif memory.endswith('Ti'):
-        memory = float(memory[:-2]) * constants._TI / constants._G
-    elif memory.endswith('G'):
-        memory = float(memory[:-1])
-    elif memory.endswith('Gi'):
-        memory = float(memory[:-2]) * constants._GI / constants._G
-    elif memory.endswith('M'):
-        memory = float(memory[:-1]) * constants._M / constants._G
-    elif memory.endswith('Mi'):
-        memory = float(memory[:-2]) * constants._MI / constants._G
-    elif memory.endswith('K'):
-        memory = float(memory[:-1]) * constants._K / constants._G
-    elif memory.endswith('Ki'):
-        memory = float(memory[:-2]) * constants._KI / constants._G
-    else:
-        # By default interpret as a plain integer, in the unit of Bytes.
-        memory = float(memory) / constants._G
+        memory: Memory requests or limits, as a Kubernetes quantity.
 
-    return memory
+    Returns:
+        The memory request/limit in gigabytes (float).
+    """
+    for suffix, multiplier in _MEMORY_SUFFIX_MULTIPLIERS:
+        if memory.endswith(suffix):
+            return float(memory[:-len(suffix)]) * multiplier / constants._G
+    # No suffix, so the quantity is a plain byte count. This also covers the
+    # exponent form, such as "1e3", which float() reads directly.
+    return float(memory) / constants._G
 
 
 class KubernetesManifestOptions:

--- a/sdk/python/kfp/compiler/compiler_utils_test.py
+++ b/sdk/python/kfp/compiler/compiler_utils_test.py
@@ -176,5 +176,64 @@ class TestAdditionalInputNameForPipelineChannel(parameterized.TestCase):
                 data, old_value, new_value))
 
 
+class TestMemoryToFloat(parameterized.TestCase):
+
+    # _memory_to_float reports gigabytes, which is the unit of the deprecated
+    # memoryLimit and memoryRequest fields in the pipeline spec.
+    @parameterized.parameters(
+        {
+            'memory': '1G',
+            'expected': 1.0
+        },
+        {
+            'memory': '1Gi',
+            'expected': 1.073741824
+        },
+        {
+            'memory': '1.5Gi',
+            'expected': 1.610612736
+        },
+        {
+            'memory': '2.5G',
+            'expected': 2.5
+        },
+        {
+            'memory': '512Mi',
+            'expected': 0.536870912
+        },
+        {
+            'memory': '6K',
+            'expected': 6e-06
+        },
+        {
+            'memory': '6k',
+            'expected': 6e-06
+        },
+        {
+            'memory': '500m',
+            'expected': 5e-13
+        },
+        {
+            'memory': '1u',
+            'expected': 1e-15
+        },
+        {
+            'memory': '1n',
+            'expected': 1e-18
+        },
+        {
+            'memory': '1e3',
+            'expected': 1e-06
+        },
+        {
+            'memory': '7000',
+            'expected': 7e-06
+        },
+    )
+    def test_memory_to_float(self, memory, expected):
+        self.assertAlmostEqual(
+            compiler_utils._memory_to_float(memory), expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/dsl/pipeline_config.py
+++ b/sdk/python/kfp/dsl/pipeline_config.py
@@ -13,20 +13,9 @@
 # limitations under the License.
 """Pipeline-level config options."""
 
-import re
 from typing import Any, Dict, Optional
 
-# Workspace size validation regex
-_SIZE_REGEX = re.compile(
-    r'^(?:(?:0|[1-9]\d*)(?:\.\d+)?)(?:Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$')
-
-
-def _is_valid_workspace_size(value: str) -> bool:
-    """Returns True if size is a valid Kubernetes resource quantity string."""
-    if not isinstance(value, str):
-        return False
-    size = value.strip()
-    return _SIZE_REGEX.match(size) is not None
+from kfp.dsl import utils
 
 
 class KubernetesWorkspaceConfig:
@@ -66,8 +55,8 @@ class WorkspaceConfig:
         """The size of the workspace (e.g., ``'250Gi'``). This is a required
         field.
 
-        See the `Kubernetes quantity documentation
-        <https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/>`_
+        See the
+        `Kubernetes quantity documentation <https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/>`_
         for valid quantity formats.
         """
         return self._size
@@ -76,11 +65,12 @@ class WorkspaceConfig:
     def size(self, size: str) -> None:
         if not size or not str(size).strip():
             raise ValueError('Workspace size is required and cannot be empty')
-        if not _is_valid_workspace_size(str(size)):
+        normalized = utils.normalize_resource_quantity(str(size).strip())
+        if normalized is None:
             raise ValueError(
                 f'Workspace size "{size}" is invalid. Must be a valid Kubernetes resource quantity '
                 '(e.g., "10Gi", "500Mi", "1Ti")')
-        self._size = str(size).strip()
+        self._size = normalized
 
     def get_workspace(self) -> dict:
         workspace = {'size': self.size}

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -531,30 +531,27 @@ class PipelineTask:
         return self.set_accelerator_limit(gpu)
 
     def _validate_memory_request_limit(self, memory: str) -> str:
-        """Validates memory request/limit string and converts to its numeric
-        string value.
+        """Validates a memory request/limit string.
 
         Args:
-            memory: Memory requests or limits. This string should be a number or
-               a number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G",
-               "Gi", "M", "Mi", "K", or "Ki".
+            memory: Memory requests or limits, as a Kubernetes quantity.
 
         Raises:
             ValueError if the memory request/limit string value is invalid.
 
         Returns:
-            The numeric string value of the memory request/limit.
+            The memory request/limit in the form Kubernetes accepts.
         """
         if isinstance(memory, pipeline_channel.PipelineChannel):
-            memory = str(memory)
-        else:
-            if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
-                        memory) is None:
-                raise ValueError(
-                    'Invalid memory string. Should be a number or a number '
-                    'followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G", '
-                    '"Gi", "M", "Mi", "K", "Ki".')
-        return memory
+            return str(memory)
+
+        normalized = utils.normalize_resource_quantity(memory)
+        if normalized is None:
+            raise ValueError(
+                f'Invalid memory string {memory!r}. Should be a non-negative '
+                'Kubernetes quantity, such as "512Mi", "1.5Gi", "2G" or the '
+                'plain byte count "1000".')
+        return normalized
 
     @warn_if_final()
     def set_memory_request(
@@ -564,9 +561,10 @@ class PipelineTask:
         """Sets memory request (minimum) for the task.
 
         Args:
-            memory: The minimum memory requests required. This string should be
-                a number or a number followed by one of "E", "Ei", "P", "Pi",
-                "T", "Ti", "G", "Gi", "M", "Mi", "K", or "Ki".
+            memory: The minimum memory requests required, as a Kubernetes
+                quantity such as ``'512Mi'``, ``'1.5Gi'`` or ``'2G'``. For more
+                information, see `Resource units in Kubernetes
+                <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`_.
 
         Returns:
             Self return to allow chained setting calls.
@@ -591,9 +589,10 @@ class PipelineTask:
         """Sets memory limit (maximum) for the task.
 
         Args:
-            memory: The maximum memory requests allowed. This string should be
-                a number or a number followed by one of "E", "Ei", "P", "Pi",
-                "T", "Ti", "G", "Gi", "M", "Mi", "K", or "Ki".
+            memory: The maximum memory allowed, as a Kubernetes quantity such
+                as ``'512Mi'``, ``'1.5Gi'`` or ``'2G'``. For more information,
+                see `Resource units in Kubernetes
+                <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`_.
 
         Returns:
             Self return to allow chained setting calls.

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -324,8 +324,14 @@ class PipelineTaskTest(parameterized.TestCase):
             'expected_memory': '55Mi',
         },
         {
+            # Kubernetes only reads the lowercase kilobyte suffix, so the
+            # historic "K" is rewritten instead of reaching the cluster.
             'memory': '6K',
-            'expected_memory': '6K',
+            'expected_memory': '6k',
+        },
+        {
+            'memory': '6k',
+            'expected_memory': '6k',
         },
         {
             'memory': '65Ki',
@@ -334,6 +340,26 @@ class PipelineTaskTest(parameterized.TestCase):
         {
             'memory': '7000',
             'expected_memory': '7000',
+        },
+        {
+            'memory': '1.5Gi',
+            'expected_memory': '1.5Gi',
+        },
+        {
+            'memory': '2.5G',
+            'expected_memory': '2.5G',
+        },
+        {
+            'memory': '0.5',
+            'expected_memory': '0.5',
+        },
+        {
+            'memory': '500m',
+            'expected_memory': '500m',
+        },
+        {
+            'memory': '1e3',
+            'expected_memory': '1e3',
         },
     )
     def test_set_memory_limit(self, memory: str, expected_memory: str):
@@ -348,6 +374,27 @@ class PipelineTaskTest(parameterized.TestCase):
         task.set_memory_limit(memory)
         self.assertEqual(expected_memory,
                          task.container_spec.resources.memory_limit)
+
+    @parameterized.parameters(
+        {'memory': '1GB'},
+        {'memory': '1gi'},
+        {'memory': '1KI'},
+        {'memory': '512 Mi'},
+        {'memory': '-1Gi'},
+        {'memory': 'Gi'},
+        {'memory': '1..5Gi'},
+        {'memory': ''},
+    )
+    def test_set_memory_limit_invalid(self, memory: str):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        with self.assertRaisesRegex(ValueError, 'Invalid memory string'):
+            task.set_memory_limit(memory)
+        with self.assertRaisesRegex(ValueError, 'Invalid memory string'):
+            task.set_memory_request(memory)
 
     def test_set_accelerator_type_with_type_only(self):
         task = pipeline_task.PipelineTask(
@@ -500,7 +547,9 @@ class TestTaskInFinalState(unittest.TestCase):
 
     Many properties and methods will be blocked.
 
-    Also tests that the .output and .outputs behavior behaves as expected when the outputs are values, not placeholders, as will be the case when PipelineTask is in the state FINAL.
+    Also tests that the .output and .outputs behavior behaves as
+    expected when the outputs are values, not placeholders, as will be
+    the case when PipelineTask is in the state FINAL.
     """
 
     def test_output_property(self):

--- a/sdk/python/kfp/dsl/utils.py
+++ b/sdk/python/kfp/dsl/utils.py
@@ -18,7 +18,7 @@ import os
 import re
 import sys
 import types
-from typing import List
+from typing import List, Optional
 
 COMPONENT_NAME_PREFIX = 'comp-'
 _EXECUTOR_LABEL_PREFIX = 'exec-'
@@ -126,3 +126,34 @@ def validate_pipeline_name(name: str) -> None:
             'Please specify a pipeline name that matches the regular '
             'expression "^[a-z0-9][a-z0-9-]{0,127}$" using '
             '`dsl.pipeline(name=...)` decorator.' % name)
+
+
+# Kubernetes resource quantity grammar, without the leading sign and without
+# the suffix-only form that Kubernetes reads as zero:
+# https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
+_RESOURCE_QUANTITY_PATTERN = re.compile(
+    r'^\+?(?:[0-9]+\.[0-9]*|\.[0-9]+|[0-9]+)'
+    r'(?:Ki|Mi|Gi|Ti|Pi|Ei|[numkMGTPE]|[eE][+-]?[0-9]+)?$')
+
+
+def normalize_resource_quantity(value: str) -> Optional[str]:
+    """Normalizes a Kubernetes resource quantity such as ``'1.5Gi'``.
+
+    KFP has documented ``'K'`` as a kilobyte suffix since v1, but Kubernetes
+    only reads the lowercase ``'k'`` and rejects the rest of the quantity when
+    it sees ``'K'``. Such a value is rewritten rather than refused, so pipelines
+    written against the older docs keep compiling and start reaching the cluster
+    intact.
+
+    Args:
+        value: The quantity to normalize.
+
+    Returns:
+        The quantity Kubernetes will accept, or None when value is not a
+        non-negative quantity.
+    """
+    if not isinstance(value, str):
+        return None
+    if value.endswith('K'):
+        value = value[:-1] + 'k'
+    return value if _RESOURCE_QUANTITY_PATTERN.match(value) else None

--- a/sdk/python/kfp/dsl/utils_test.py
+++ b/sdk/python/kfp/dsl/utils_test.py
@@ -121,5 +121,83 @@ class UtilsTest(parameterized.TestCase):
                 utils.validate_pipeline_name('my_pipeline')
 
 
+class NormalizeResourceQuantityTest(parameterized.TestCase):
+
+    # Every value here was checked against
+    # k8s.io/apimachinery/pkg/api/resource.ParseQuantity, which is what the KFP
+    # driver runs before it builds the pod spec.
+    @parameterized.parameters(
+        '1',
+        '1000',
+        '0',
+        '1.5',
+        '0.5',
+        '.5',
+        '1.',
+        '+1',
+        '512Mi',
+        '1.5Gi',
+        '1.25Gi',
+        '2.5G',
+        '2.5Ti',
+        '1Ki',
+        '1Ei',
+        '1E',
+        '1P',
+        '1Pi',
+        '1T',
+        '1Ti',
+        '1M',
+        '1G',
+        '100k',
+        '500m',
+        '1n',
+        '1u',
+        '1e3',
+        '1E3',
+        '1e-3',
+        '1.5e3',
+    )
+    def test_accepts_kubernetes_quantity(self, value):
+        self.assertEqual(utils.normalize_resource_quantity(value), value)
+
+    @parameterized.parameters(
+        {
+            'value': '6K',
+            'expected': '6k'
+        },
+        {
+            'value': '1.5K',
+            'expected': '1.5k'
+        },
+    )
+    def test_rewrites_legacy_kilo_suffix(self, value, expected):
+        self.assertEqual(utils.normalize_resource_quantity(value), expected)
+
+    @parameterized.parameters(
+        '',
+        'Gi',
+        'abc',
+        '1gi',
+        '1KI',
+        '1GB',
+        '1B',
+        '1Mib',
+        '512 Mi',
+        '1..5Gi',
+        '1,5Gi',
+        '-1',
+        '-10Gi',
+        '1Ki3',
+        '1e',
+        '0x10',
+        '.',
+        None,
+        10,
+    )
+    def test_rejects_non_quantity(self, value):
+        self.assertIsNone(utils.normalize_resource_quantity(value))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes: #14332 🚀 

**Description of your changes:**

`set_memory_request` and `set_memory_limit` matched `^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$`, and `WorkspaceConfig.size` had a second regex that allowed decimals. Neither matched what `resource.ParseQuantity` accepts, so the SDK refused quantities that work and accepted `K`, which the driver cannot parse.

This adds `utils.normalize_resource_quantity` and uses it in both places.

- Quantities like `1.5Gi`, `2.5G`, `100k`, `500m` and `1e3` now compile.
- `K` is rewritten to `k` rather than refused, so pipelines written against the older docstring keep compiling and now reach the cluster with a suffix Kubernetes reads.
- Negative values and digit-less suffixes such as `Gi` stay rejected. Kubernetes reads a bare suffix as zero, which is a typo in every field KFP has.
- `_memory_to_float` gained the `k`, `m`, `u` and `n` suffixes so the deprecated `memoryLimit` and `memoryRequest` fields stay correct for the newly accepted values.

`set_cpu_request` and `set_cpu_limit` keep their own narrower rule. Kubernetes would take `512Mi` as a CPU quantity, and rejecting that is more useful than matching the grammar exactly.

One unrelated line changed in `pipeline_config.py`. The repo's `docformatter` hook rewraps the `WorkspaceConfig.size` docstring as soon as that file is touched, so the rewrite is included here to keep pre-commit green.

**Verification:**

Every accepted and rejected value in the tests was checked against `k8s.io/apimachinery/pkg/api/resource.ParseQuantity`, which is what the driver runs. Over a generated corpus of 550 strings the new validator never accepts a value the driver would reject. The only values it refuses that Kubernetes allows are negatives and digit-less suffixes, both listed above.

End to end, `set_memory_limit('1.5Gi').set_memory_request('6K')` compiles to:

```yaml
resourceMemoryLimit: 1.5Gi     # ParseQuantity -> 1536Mi
resourceMemoryRequest: 6k      # ParseQuantity -> 6k
memoryLimit: 1.610612736       # gigabytes, deprecated field
memoryRequest: 6.0e-06
```

On master the same pipeline raises `ValueError` on the first call.

**Testing:**

- `NormalizeResourceQuantityTest` in `sdk/python/kfp/dsl/utils_test.py`
- `test_set_memory_limit` and `test_set_memory_limit_invalid` in `sdk/python/kfp/dsl/pipeline_task_test.py`
- `TestMemoryToFloat` in `sdk/python/kfp/compiler/compiler_utils_test.py`
- `test_workspace_config_validation` in `sdk/python/kfp/compiler/compiler_test.py`

`pytest sdk/python/kfp/dsl sdk/python/kfp/compiler` passes. Three failures in `notebook_component_decorator_test.py` and `TestReadWriteEquality::test_deprecation_warning` are present on master too and are unrelated.

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).