### PR TITLE
perf(backend): read the DAG tree once per driver resolution pass

### DIFF
--- a/backend/src/v2/driver/container.go
+++ b/backend/src/v2/driver/container.go
@@ -152,7 +152,7 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		pvcNames := []string{}
 		if opts.KubernetesExecutorConfig != nil && opts.KubernetesExecutorConfig.GetPvcMount() != nil {
 			_, volumes, err := makeVolumeMountPatch(ctx, opts, opts.KubernetesExecutorConfig.GetPvcMount(),
-				dag, pipeline, mlmd, inputParams)
+				dag, pipeline, mlmd, inputParams, newDAGTaskCache())
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract volume mount info while generating fingerprint: %w", err)
 			}

--- a/backend/src/v2/driver/container_test.go
+++ b/backend/src/v2/driver/container_test.go
@@ -16,6 +16,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -28,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func Test_validateContainer(t *testing.T) {
@@ -126,6 +128,14 @@ type MockMetadataClient struct {
 	PutExecutionTypeFunc           func(ctx context.Context, in *pb.PutExecutionTypeRequest, opts ...grpc.CallOption) (*pb.PutExecutionTypeResponse, error)
 	GetExecutionsByTypeAndNameFunc func(ctx context.Context, in *pb.GetExecutionByTypeAndNameRequest, opts ...grpc.CallOption) (*pb.GetExecutionByTypeAndNameResponse, error)
 	GetExecutionByTypeAndNameFunc  func(ctx context.Context, in *pb.GetExecutionByTypeAndNameRequest, opts ...grpc.CallOption) (*pb.GetExecutionByTypeAndNameResponse, error)
+	GetExecutionsByContextFunc     func(ctx context.Context, in *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error)
+}
+
+func (m *MockMetadataClient) GetExecutionsByContext(ctx context.Context, in *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
+	if m.GetExecutionsByContextFunc != nil {
+		return m.GetExecutionsByContextFunc(ctx, in, opts...)
+	}
+	return &pb.GetExecutionsByContextResponse{}, nil
 }
 
 func (m *MockMetadataClient) GetArtifactsByID(ctx context.Context, in *pb.GetArtifactsByIDRequest, opts ...grpc.CallOption) (*pb.GetArtifactsByIDResponse, error) {
@@ -437,4 +447,143 @@ func TestContainer_CreateExecutionDoesNotExistGenericError(t *testing.T) {
 	require.Error(t, err)
 	require.NotNil(t, execution)
 	assert.Contains(t, err.Error(), "unavailable")
+}
+
+// mlmdTreeStub serves a parent DAG holding one producer task and subDAGCount
+// nested DAGs, each with a task of its own. It counts the reads getDAGTasks
+// makes so a test can tell how often the tree was walked.
+type mlmdTreeStub struct {
+	MockMetadataClient
+	subDAGCount            int
+	getExecutionsByContext int
+}
+
+func newMlmdTreeStub(subDAGCount int) *mlmdTreeStub {
+	stub := &mlmdTreeStub{subDAGCount: subDAGCount}
+	stub.GetParentContextsByContextFunc = func(ctx context.Context, in *pb.GetParentContextsByContextRequest, opts ...grpc.CallOption) (*pb.GetParentContextsByContextResponse, error) {
+		return &pb.GetParentContextsByContextResponse{}, nil
+	}
+	stub.GetContextByTypeAndNameFunc = func(ctx context.Context, in *pb.GetContextByTypeAndNameRequest, opts ...grpc.CallOption) (*pb.GetContextByTypeAndNameResponse, error) {
+		return &pb.GetContextByTypeAndNameResponse{Context: &pb.Context{Id: new(int64(1234))}}, nil
+	}
+	stub.GetContextsByExecutionFunc = func(ctx context.Context, in *pb.GetContextsByExecutionRequest, opts ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error) {
+		return &pb.GetContextsByExecutionResponse{Contexts: []*pb.Context{{Id: new(int64(1234))}}}, nil
+	}
+	stub.GetExecutionsByIDFunc = func(ctx context.Context, in *pb.GetExecutionsByIDRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error) {
+		id := int64(parentDAGID)
+		if len(in.GetExecutionIds()) > 0 {
+			id = in.GetExecutionIds()[0]
+		}
+		return &pb.GetExecutionsByIDResponse{Executions: []*pb.Execution{{
+			Id:   new(id),
+			Type: new("system.DAGExecution"),
+		}}}, nil
+	}
+	stub.PutExecutionFunc = func(ctx context.Context, in *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+		return &pb.PutExecutionResponse{ExecutionId: new(int64(999))}, nil
+	}
+	stub.GetExecutionsByContextFunc = stub.executionsByContext
+	return stub
+}
+
+const (
+	parentDAGID   = 55
+	firstSubDAGID = 1000
+)
+
+func (s *mlmdTreeStub) executionsByContext(ctx context.Context, in *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
+	s.getExecutionsByContext++
+	var parent int64
+	fmt.Sscanf(in.GetOptions().GetFilterQuery(), "custom_properties.parent_dag_id.int_value = %d", &parent)
+	outputs, err := structpb.NewStruct(map[string]interface{}{"out": "produced"})
+	if err != nil {
+		return nil, err
+	}
+	task := func(id int64, name, execType string, parentID int64) *pb.Execution {
+		return &pb.Execution{
+			Id:   new(id),
+			Type: new(execType),
+			CustomProperties: map[string]*pb.Value{
+				"task_name":     {Value: &pb.Value_StringValue{StringValue: name}},
+				"parent_dag_id": {Value: &pb.Value_IntValue{IntValue: parentID}},
+				"outputs":       {Value: &pb.Value_StructValue{StructValue: outputs}},
+			},
+		}
+	}
+	executions := []*pb.Execution{}
+	switch {
+	case parent == parentDAGID:
+		executions = append(executions, task(77, "producer", "system.ContainerExecution", parentDAGID))
+		for i := 0; i < s.subDAGCount; i++ {
+			subDAGID := int64(firstSubDAGID + i)
+			executions = append(executions, task(subDAGID, fmt.Sprintf("sub-%d", i), "system.DAGExecution", parentDAGID))
+		}
+	case parent >= firstSubDAGID:
+		executions = append(executions, task(parent*10, fmt.Sprintf("leaf-%d", parent), "system.ContainerExecution", parent))
+	}
+	return &pb.GetExecutionsByContextResponse{Executions: executions}, nil
+}
+
+// Each upstream input used to walk the tree itself, so the reads grew with the
+// input count even though every walk returned the same tasks.
+func TestContainer_WalksDAGTreeOnceForAllInputs(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	const subDAGCount = 10
+	// One read for the parent DAG plus one for every nested DAG.
+	wantReads := subDAGCount + 1
+
+	for _, inputCount := range []int{1, 3, 5} {
+		t.Run(fmt.Sprintf("%d inputs", inputCount), func(t *testing.T) {
+			stub := newMlmdTreeStub(subDAGCount)
+
+			taskInputs := map[string]*pipelinespec.TaskInputsSpec_InputParameterSpec{}
+			componentInputs := map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{}
+			for i := 0; i < inputCount; i++ {
+				name := fmt.Sprintf("in%d", i)
+				taskInputs[name] = &pipelinespec.TaskInputsSpec_InputParameterSpec{
+					Kind: &pipelinespec.TaskInputsSpec_InputParameterSpec_TaskOutputParameter{
+						TaskOutputParameter: &pipelinespec.TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec{
+							ProducerTask:       "producer",
+							OutputParameterKey: "out",
+						},
+					},
+				}
+				componentInputs[name] = &pipelinespec.ComponentInputsSpec_ParameterSpec{
+					ParameterType: pipelinespec.ParameterType_STRING,
+				}
+			}
+
+			execution, err := Container(context.Background(), Options{
+				IterationIndex: -1,
+				PipelineName:   "pipeline-1",
+				RunID:          "run-1",
+				TaskName:       "task-1",
+				Component: &pipelinespec.ComponentSpec{
+					Implementation:   &pipelinespec.ComponentSpec_ExecutorLabel{ExecutorLabel: "executor"},
+					InputDefinitions: &pipelinespec.ComponentInputsSpec{Parameters: componentInputs},
+				},
+				DAGExecutionID: parentDAGID,
+				Task: &pipelinespec.PipelineTaskSpec{
+					TaskInfo:       &pipelinespec.PipelineTaskInfo{Name: "task-1"},
+					Inputs:         &pipelinespec.TaskInputsSpec{Parameters: taskInputs},
+					CachingOptions: &pipelinespec.PipelineTaskSpec_CachingOptions{EnableCache: false},
+				},
+				Container: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+					Image:   "python:3.11",
+					Command: []string{"python", "main.py"},
+				},
+				PluginDispatcher: plugins.NoOpDispatcher{},
+			}, metadata.NewTestClient(stub), &mockCacheClient{})
+
+			require.NoError(t, err)
+			require.NotNil(t, execution)
+			for i := 0; i < inputCount; i++ {
+				assert.Equal(t, "produced",
+					execution.ExecutorInput.GetInputs().GetParameterValues()[fmt.Sprintf("in%d", i)].GetStringValue())
+			}
+			assert.Equal(t, wantReads, stub.getExecutionsByContext,
+				"the DAG tree should be read once for the whole task, not once per input")
+		})
+	}
 }

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -142,6 +142,9 @@ func extendPodSpecPatch(
 ) error {
 	kubernetesExecutorConfig := opts.KubernetesExecutorConfig
 
+	// Shared by every name resolved below, so a DAG is read once for the patch.
+	dagTasks := newDAGTaskCache()
+
 	setOnTaskConfig, setOnPod := getTaskConfigOptions(opts.Component)
 
 	// Always set setOnTaskConfig to an empty map if taskConfig is nil to avoid nil pointer dereference.
@@ -157,7 +160,7 @@ func extendPodSpecPatch(
 	// Get volume mount information
 	if kubernetesExecutorConfig.GetPvcMount() != nil {
 		volumeMounts, volumes, err := makeVolumeMountPatch(ctx, opts, kubernetesExecutorConfig.GetPvcMount(),
-			dag, pipeline, mlmd, inputParams)
+			dag, pipeline, mlmd, inputParams, dagTasks)
 		if err != nil {
 			return fmt.Errorf("failed to extract volume mount info: %w", err)
 		}
@@ -200,7 +203,7 @@ func extendPodSpecPatch(
 		skipNodeSelector := false
 		if kubernetesExecutorConfig.GetNodeSelector().GetNodeSelectorJson() != nil {
 			err := resolveK8sJsonParameter(ctx, opts, dag, pipeline, mlmd,
-				kubernetesExecutorConfig.GetNodeSelector().GetNodeSelectorJson(), inputParams, &nodeSelector)
+				kubernetesExecutorConfig.GetNodeSelector().GetNodeSelectorJson(), inputParams, &nodeSelector, dagTasks)
 			if err != nil {
 				if errors.Is(err, ErrResolvedParameterNull) {
 					skipNodeSelector = true
@@ -233,7 +236,7 @@ func extendPodSpecPatch(
 				k8sToleration := &k8score.Toleration{}
 				if toleration.TolerationJson != nil {
 					resolvedParam, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd,
-						toleration.GetTolerationJson(), inputParams)
+						toleration.GetTolerationJson(), inputParams, dagTasks)
 					if err != nil {
 						if errors.Is(err, ErrResolvedParameterNull) {
 							continue // Skip applying the patch for this null/optional parameter
@@ -305,7 +308,7 @@ func extendPodSpecPatch(
 		var secretName string
 		if secretAsVolume.SecretNameParameter != nil {
 			resolvedSecretName, err := resolveInputParameterStr(ctx, dag, pipeline, opts, mlmd,
-				secretAsVolume.SecretNameParameter, inputParams)
+				secretAsVolume.SecretNameParameter, inputParams, dagTasks)
 			if err != nil {
 				if errors.Is(err, ErrResolvedParameterNull) {
 					continue
@@ -367,7 +370,7 @@ func extendPodSpecPatch(
 			var secretName string
 			if secretAsEnv.SecretNameParameter != nil {
 				resolvedSecretName, err := resolveInputParameterStr(ctx, dag, pipeline, opts, mlmd,
-					secretAsEnv.SecretNameParameter, inputParams)
+					secretAsEnv.SecretNameParameter, inputParams, dagTasks)
 				if err != nil {
 					if errors.Is(err, ErrResolvedParameterNull) {
 						continue
@@ -399,7 +402,7 @@ func extendPodSpecPatch(
 		var configMapName string
 		if configMapAsVolume.ConfigMapNameParameter != nil {
 			resolvedConfigMapName, err := resolveInputParameterStr(ctx, dag, pipeline, opts, mlmd,
-				configMapAsVolume.ConfigMapNameParameter, inputParams)
+				configMapAsVolume.ConfigMapNameParameter, inputParams, dagTasks)
 			if err != nil {
 				if errors.Is(err, ErrResolvedParameterNull) {
 					continue
@@ -463,7 +466,7 @@ func extendPodSpecPatch(
 			var configMapName string
 			if configMapAsEnv.ConfigMapNameParameter != nil {
 				resolvedConfigMapName, err := resolveInputParameterStr(ctx, dag, pipeline, opts, mlmd,
-					configMapAsEnv.ConfigMapNameParameter, inputParams)
+					configMapAsEnv.ConfigMapNameParameter, inputParams, dagTasks)
 				if err != nil {
 					if errors.Is(err, ErrResolvedParameterNull) {
 						continue
@@ -495,7 +498,7 @@ func extendPodSpecPatch(
 		var secretName string
 		if imagePullSecret.SecretNameParameter != nil {
 			resolvedSecretName, err := resolveInputParameterStr(ctx, dag, pipeline, opts, mlmd,
-				imagePullSecret.SecretNameParameter, inputParams)
+				imagePullSecret.SecretNameParameter, inputParams, dagTasks)
 			if err != nil {
 				if errors.Is(err, ErrResolvedParameterNull) {
 					continue
@@ -637,7 +640,7 @@ func extendPodSpecPatch(
 			if nodeAffinityTerm.GetNodeAffinityJson() != nil {
 				var k8sNodeAffinity json.RawMessage
 				err := resolveK8sJsonParameter(ctx, opts, dag, pipeline, mlmd,
-					nodeAffinityTerm.GetNodeAffinityJson(), inputParams, &k8sNodeAffinity)
+					nodeAffinityTerm.GetNodeAffinityJson(), inputParams, &k8sNodeAffinity, dagTasks)
 				if err != nil {
 					if errors.Is(err, ErrResolvedParameterNull) {
 						continue
@@ -1238,6 +1241,7 @@ func makeVolumeMountPatch(
 	pipeline *metadata.Pipeline,
 	mlmd *metadata.Client,
 	inputParams map[string]*structpb.Value,
+	dagTasks *dagTaskCache,
 ) ([]k8score.VolumeMount, []k8score.Volume, error) {
 	if pvcMounts == nil {
 		return nil, nil, nil
@@ -1264,7 +1268,7 @@ func makeVolumeMountPatch(
 		}
 
 		resolvedPvcName, err := resolveInputParameterStr(ctx, dag, pipeline, opts, mlmd,
-			pvcNameParameter, inputParams)
+			pvcNameParameter, inputParams, dagTasks)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to resolve pvc name: %w", err)
 		}

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -110,6 +110,7 @@ func Test_makeVolumeMountPatch(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				nil,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, 1, len(volumeMounts))

--- a/backend/src/v2/driver/resolve.go
+++ b/backend/src/v2/driver/resolve.go
@@ -56,6 +56,40 @@ type resolveUpstreamOutputsConfig struct {
 	pipeline     *metadata.Pipeline
 	mlmd         *metadata.Client
 	err          func(error) error
+	dagTasks     *dagTaskCache
+}
+
+// dagTaskCache keeps the flattened task map of a DAG so one pass reads it once
+// instead of once per value. The producers it looks up have already finished,
+// so a second read would say the same thing. A nil cache reads every time.
+type dagTaskCache struct {
+	byDAGID map[int64]map[string]*metadata.Execution
+}
+
+func newDAGTaskCache() *dagTaskCache {
+	return &dagTaskCache{byDAGID: make(map[int64]map[string]*metadata.Execution)}
+}
+
+// tasks reads MLMD only on the first call for a given DAG.
+func (c *dagTaskCache) tasks(
+	ctx context.Context,
+	dag *metadata.DAG,
+	pipeline *metadata.Pipeline,
+	mlmd *metadata.Client,
+) (map[string]*metadata.Execution, error) {
+	if c == nil {
+		return getDAGTasks(ctx, dag, pipeline, mlmd, nil)
+	}
+	dagID := dag.Execution.GetID()
+	if cached, ok := c.byDAGID[dagID]; ok {
+		return cached, nil
+	}
+	tasks, err := getDAGTasks(ctx, dag, pipeline, mlmd, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.byDAGID[dagID] = tasks
+	return tasks, nil
 }
 
 // getDAGTasks is a recursive function that returns a map of all tasks across all DAGs in the context of nested DAGs.
@@ -320,6 +354,9 @@ func resolveInputs(
 			}
 		}
 	}
+	// Shared by every input below, so a DAG is read once however many use it.
+	dagTasks := newDAGTaskCache()
+
 	// Handle parameters.
 	for name, paramSpec := range task.GetInputs().GetParameters() {
 		if compParam := opts.Component.GetInputDefinitions().GetParameters()[name]; compParam != nil {
@@ -330,7 +367,7 @@ func resolveInputs(
 			}
 		}
 
-		v, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd, paramSpec, inputParams)
+		v, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd, paramSpec, inputParams, dagTasks)
 		if err != nil {
 			if !errors.Is(err, ErrResolvedParameterNull) {
 				return nil, err
@@ -358,7 +395,7 @@ func resolveInputs(
 
 	// Handle artifacts.
 	for name, artifactSpec := range task.GetInputs().GetArtifacts() {
-		v, err := resolveInputArtifact(ctx, dag, pipeline, mlmd, name, artifactSpec, inputArtifacts, task)
+		v, err := resolveInputArtifact(ctx, dag, pipeline, mlmd, name, artifactSpec, inputArtifacts, task, dagTasks)
 		if err != nil {
 			return nil, err
 		}
@@ -380,6 +417,7 @@ func resolveInputParameter(
 	mlmd *metadata.Client,
 	paramSpec *pipelinespec.TaskInputsSpec_InputParameterSpec,
 	inputParams map[string]*structpb.Value,
+	dagTasks *dagTaskCache,
 ) (*structpb.Value, error) {
 	glog.V(4).Infof("paramSpec: %v", paramSpec)
 	paramError := func(err error) error {
@@ -413,6 +451,7 @@ func resolveInputParameter(
 			pipeline:  pipeline,
 			mlmd:      mlmd,
 			err:       paramError,
+			dagTasks:  dagTasks,
 		}
 		v, err := resolveUpstreamParameters(cfg)
 		if err != nil {
@@ -456,7 +495,7 @@ func resolveInputParameter(
 			return nil, paramError(fmt.Errorf("param runtime value spec of type %T not implemented", t))
 		}
 	case *pipelinespec.TaskInputsSpec_InputParameterSpec_TaskFinalStatus_:
-		tasks, err := getDAGTasks(ctx, dag, pipeline, mlmd, nil)
+		tasks, err := dagTasks.tasks(ctx, dag, pipeline, mlmd)
 		if err != nil {
 			return nil, err
 		}
@@ -506,8 +545,9 @@ func resolveInputParameterStr(
 	mlmd *metadata.Client,
 	paramSpec *pipelinespec.TaskInputsSpec_InputParameterSpec,
 	inputParams map[string]*structpb.Value,
+	dagTasks *dagTaskCache,
 ) (*structpb.Value, error) {
-	val, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd, paramSpec, inputParams)
+	val, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd, paramSpec, inputParams, dagTasks)
 	if err != nil {
 		return nil, err
 	}
@@ -534,6 +574,7 @@ func resolveInputArtifact(
 	artifactSpec *pipelinespec.TaskInputsSpec_InputArtifactSpec,
 	inputArtifacts map[string]*pipelinespec.ArtifactList,
 	task *pipelinespec.PipelineTaskSpec,
+	dagTasks *dagTaskCache,
 ) (*pipelinespec.ArtifactList, error) {
 	glog.V(4).Infof("inputs: %#v", task.GetInputs())
 	glog.V(4).Infof("artifacts: %#v", task.GetInputs().GetArtifacts())
@@ -559,6 +600,7 @@ func resolveInputArtifact(
 			pipeline:     pipeline,
 			mlmd:         mlmd,
 			err:          artifactError,
+			dagTasks:     dagTasks,
 		}
 		artifacts, err := resolveUpstreamArtifacts(cfg)
 		if err != nil {
@@ -600,7 +642,7 @@ func resolveUpstreamParameters(cfg resolveUpstreamOutputsConfig) (*structpb.Valu
 	// results in a bunch of unhandled edge cases and test failures.
 	glog.V(4).Infof("producerTaskName: %v", producerTaskName)
 	glog.V(4).Infof("outputParameterKey: %v", outputParameterKey)
-	tasks, err := getDAGTasks(cfg.ctx, cfg.dag, cfg.pipeline, cfg.mlmd, nil)
+	tasks, err := cfg.dagTasks.tasks(cfg.ctx, cfg.dag, cfg.pipeline, cfg.mlmd)
 	if err != nil {
 		return nil, cfg.err(err)
 	}
@@ -721,7 +763,7 @@ func resolveUpstreamArtifacts(cfg resolveUpstreamOutputsConfig) (*pipelinespec.A
 	// "iteration_index", the producerTaskName will be updated appropriately
 	producerTaskName = InferIndexedTaskName(producerTaskName, cfg.dag.Execution)
 	glog.V(4).Infof("producerTaskName: %v", producerTaskName)
-	tasks, err := getDAGTasks(cfg.ctx, cfg.dag, cfg.pipeline, cfg.mlmd, nil)
+	tasks, err := cfg.dagTasks.tasks(cfg.ctx, cfg.dag, cfg.pipeline, cfg.mlmd)
 	if err != nil {
 		return nil, cfg.err(err)
 	}
@@ -846,9 +888,10 @@ func resolveK8sJsonParameter[k8sResource any](
 	pipelineInputParamSpec *pipelinespec.TaskInputsSpec_InputParameterSpec,
 	inputParams map[string]*structpb.Value,
 	res *k8sResource,
+	dagTasks *dagTaskCache,
 ) error {
 	resolvedParam, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd,
-		pipelineInputParamSpec, inputParams)
+		pipelineInputParamSpec, inputParams, dagTasks)
 	if err != nil {
 		return fmt.Errorf("failed to resolve k8s parameter: %w", err)
 	}

--- a/backend/src/v2/driver/resolve_test.go
+++ b/backend/src/v2/driver/resolve_test.go
@@ -52,6 +52,7 @@ func TestResolvePipelineJobCreateTimePlaceholder(t *testing.T) {
 		nil, // runtime config
 		paramSpec,
 		map[string]*structpb.Value{},
+		nil,
 	)
 
 	assert.NoError(t, err)
@@ -83,6 +84,7 @@ func TestResolvePipelineJobScheduleTimePlaceholder(t *testing.T) {
 		nil,
 		paramSpec,
 		map[string]*structpb.Value{},
+		nil,
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes: #14337 

**Description of your changes:**

`getDAGTasks` walks the DAG tree and returns a flattened task map. `resolveUpstreamParameters`, `resolveUpstreamArtifacts` and the `TaskFinalStatus` branch each called it with a fresh accumulator, so a task with N inputs from upstream tasks walked the same tree N times. Every walk costs one `GetExecutionsByContext` per DAG and one `GetExecutionsByID` per nested DAG, and a `ParallelFor` iteration counts as a nested DAG.

This adds `dagTaskCache`, a map from DAG execution ID to its flattened task map, and threads it through the resolution paths. `resolveInputs` creates one for the whole input pass, `extendPodSpecPatch` creates one for the whole patch, and the fingerprint call in `Container` gets its own because it can resolve several PVC names. A nil cache reads every time, so callers that do not want one, including the existing unit tests, are unaffected.

The caches are deliberately per pass rather than one per driver run. Each covers a single stretch of read-only work and none of them spans a point where the driver writes to MLMD, so a cached map is never read after the driver has changed something.

Measured against a stub MLMD service with a parent DAG holding ten nested DAGs:

| inputs from upstream tasks | before | after |
| --- | --- | --- |
| 1 | 11 | 11 |
| 3 | 33 | 11 |
| 5 | 55 | 11 |

No behaviour changes. The resolved values are identical, only the number of metadata reads drops.

**Testing:**

- `TestContainer_WalksDAGTreeOnceForAllInputs` drives `Container` with 1, 3 and 5 upstream inputs over a stubbed two level DAG and asserts both the resolved values and that the tree is read once.
- The stub builds on the existing `MockMetadataClient`, which only needed `GetExecutionsByContext` added, so there is still one mock in the package.
- The test fails on master with 33 and 55 reads where it expects 11.
- `go test ./backend/src/...` passes, including `-race` on the driver package.`golangci-lint run --new-from-rev master` reports no issues.

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).