### PR TITLE
test(backend): capture query-string drop in ParseBucketConfigForArtifactURI. Part of #14046

### DIFF
--- a/backend/src/v2/objectstore/config_test.go
+++ b/backend/src/v2/objectstore/config_test.go
@@ -20,6 +20,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// ParseBucketConfigForArtifactURI is used to resolve the bucket for an
+// artifact that lives outside the pipeline root (e.g. an imported artifact
+// consumed as a downstream component's input). Unlike ParseBucketPathToConfig,
+// it does not capture the URI's prefix or query string, so a query-string
+// provider override (e.g. ?endpoint=...) on such a URI is silently dropped
+// here and ends up folded into the object key by KeyFromURI instead of being
+// available as bucket config.
+func TestParseBucketConfigForArtifactURIDropsPrefixAndQueryString(t *testing.T) {
+	uri := "s3://my-bucket/my-path/object.txt?endpoint=example.com&disableSSL=true"
+
+	config, err := ParseBucketConfigForArtifactURI(uri)
+	assert.NoError(t, err)
+	assert.Equal(t, "s3://", config.Scheme)
+	assert.Equal(t, "my-bucket", config.BucketName)
+	assert.Empty(t, config.Prefix)
+	assert.Empty(t, config.QueryString)
+
+	key, err := config.KeyFromURI(uri)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-path/object.txt?endpoint=example.com&disableSSL=true", key)
+}
+
 func TestHasStructuredS3Settings(t *testing.T) {
 	assert.False(t, HasStructuredS3Settings(map[string]string{}))
 


### PR DESCRIPTION
**Description of your changes:**

Adds a regression test documenting that `ParseBucketConfigForArtifactURI` (used to resolve the bucket for artifacts outside the pipeline root) drops a URI's prefix and query string, unlike `ParseBucketPathToConfig`. This means a query-string provider override on such a URI is silently folded into the object key by `KeyFromURI` instead of being available as bucket config. Related to the trust-contract discussion in #14046.

**Checklist:**
- [x] You have signed off your commits
- [x] The title for your pull request (PR) should follow our title convention.