### PR TITLE
fix(backend): validate node_id before building archived log key

### DIFF
--- a/backend/src/apiserver/archive/log.go
+++ b/backend/src/apiserver/archive/log.go
@@ -258,6 +258,14 @@ func (a *LogArchive) GetLogObjectKey(workflow util.ExecutionSpec, nodeID string)
 	if a.logPathPrefix == "" || a.logFileName == "" || workflow == nil {
 		return "", util.Wrapf(errors.New("invalid log archive configuration"), "configuration: %v", a)
 	}
+	// nodeID is supplied by the read-log API caller and is joined into the
+	// object store key below. A value carrying a path separator or a ".."
+	// component would resolve the key outside this run's log prefix, so reject
+	// it before use. readRunLogFromPod applies the equivalent guard on the pod
+	// read path.
+	if nodeID == ".." || strings.ContainsAny(nodeID, "/\\") {
+		return "", util.NewInvalidInputError("invalid node id %q", nodeID)
+	}
 	if archivedLogKey := workflow.ExecutionStatus().FindObjectStoreArtifactKeyOrEmpty(nodeID, archivedLogArtifactName); archivedLogKey != "" {
 		return archivedLogKey, nil
 	}

--- a/backend/src/apiserver/archive/log_test.go
+++ b/backend/src/apiserver/archive/log_test.go
@@ -143,6 +143,25 @@ func TestGetLogObjectKey_InvalidConfig(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestGetLogObjectKey_RejectsPathTraversalNodeID(t *testing.T) {
+	logArchive := initLogArchive()
+	workflow := util.NewWorkflow(&workflowapi.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "MY_NAME"},
+	})
+
+	for _, nodeID := range []string{
+		"../../other-run/node",
+		"..",
+		"node/../../etc/passwd",
+		`..\other-run`,
+		"a/b",
+	} {
+		key, err := logArchive.GetLogObjectKey(workflow, nodeID)
+		assert.NotNil(t, err, "node id %q should be rejected", nodeID)
+		assert.Empty(t, key)
+	}
+}
+
 func TestCopyLogFromArchive_FromJsonToJson(t *testing.T) {
 	logArchive := initLogArchive()
 	opts := ExtractLogOptions{LogFormat: LogFormatJSON}


### PR DESCRIPTION
**Description of your changes:**

Repro: call the read-run-log endpoint (`/apis/v1beta1/runs/{run_id}/nodes/{node_id}/log`) for a run you can access, passing a `node_id` like `../../other/node` or `..`.
Cause: `GetLogObjectKey` joins the caller-supplied `node_id` into the object-store key (`logPathPrefix/executionName/nodeID/logFileName`) with no separator or `..` check, so the key can resolve outside this run's log prefix. `readRunLogFromPod` already validates a caller-controlled `node_id` (it confirms the pod belongs to the run) before streaming; the archive fallback `readRunLogFromArchive` skipped that guard.
Fix: reject a `node_id` that contains a path separator or a `..` component in `GetLogObjectKey`, before it reaches the artifact-key lookup or the key join. Legitimate Argo node ids are a single path segment, so this leaves valid reads unchanged. Regression test added.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 