### PR TITLE
fix(backend): authorize referenced pipeline access

### DIFF
--- a/backend/src/apiserver/common/utils.go
+++ b/backend/src/apiserver/common/utils.go
@@ -33,6 +33,10 @@ const (
 	// * Allows lowercase letters, numbers, and "-" in everywhere else
 	// * Sets max length to be 128 characters
 	pipelineNamePattern = "^[a-z0-9][a-z0-9-]{0,127}$"
+	// PipelineIDResourceNameKey identifies pipeline IDs returned by ParseResourceIdsFromFullName.
+	PipelineIDResourceNameKey = "PipelineId"
+	// PipelineVersionIDResourceNameKey identifies version IDs returned by ParseResourceIdsFromFullName.
+	PipelineVersionIDResourceNameKey = "PipelineVersionId"
 )
 
 // CreateArtifactPath creates artifact resource path.
@@ -52,14 +56,14 @@ func CreateArtifactPath(runID string, nodeID string, artifactName string) string
 func ParseResourceIdsFromFullName(p string) map[string]string {
 	p = strings.TrimPrefix(strings.TrimSuffix(p, "/"), "/")
 	results := map[string]string{
-		"Namespace":         "",
-		"ExperimentId":      "",
-		"PipelineId":        "",
-		"PipelineVersionId": "",
-		"RunID":             "",
-		"RecurringRunId":    "",
-		"ArtifactId":        "",
-		"ExecutionId":       "",
+		"Namespace":                      "",
+		"ExperimentId":                   "",
+		PipelineIDResourceNameKey:        "",
+		PipelineVersionIDResourceNameKey: "",
+		"RunID":                          "",
+		"RecurringRunId":                 "",
+		"ArtifactId":                     "",
+		"ExecutionId":                    "",
 	}
 	names := strings.Split(p, "/")
 	i := 0
@@ -69,9 +73,9 @@ func ParseResourceIdsFromFullName(p string) map[string]string {
 			case "namespaces", "namespace":
 				results["Namespace"] = names[i+1]
 			case "pipelines", "pipeline":
-				results["PipelineId"] = names[i+1]
+				results[PipelineIDResourceNameKey] = names[i+1]
 			case "versions", "version", "pipelineversions", "pipelineversion", "pipeline_versions", "pipeline_version":
-				results["PipelineVersionId"] = names[i+1]
+				results[PipelineVersionIDResourceNameKey] = names[i+1]
 			case "experiments", "experiment":
 				results["ExperimentId"] = names[i+1]
 			case "runs", "run":

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1603,19 +1603,19 @@ func (r *ResourceManager) fetchPipelineVersionFromPipelineSpec(pipelineSpec mode
 		return pipelineVersion, nil
 	} else if pipelineSpec.PipelineName != "" {
 		resourceNames := common.ParseResourceIdsFromFullName(pipelineSpec.PipelineName)
-		if resourceNames["PipelineVersionId"] == "" && resourceNames["PipelineId"] == "" {
+		if resourceNames[common.PipelineVersionIDResourceNameKey] == "" && resourceNames[common.PipelineIDResourceNameKey] == "" {
 			return nil, util.Wrapf(util.NewInvalidInputError("Pipeline spec source is missing"), "Failed to fetch a pipeline version and its manifest due to an empty pipeline spec source: %v", pipelineSpec.PipelineName)
 		}
-		if resourceNames["PipelineVersionId"] != "" {
-			pipelineVersion, err := r.GetPipelineVersion(resourceNames["PipelineVersionId"])
+		if resourceNames[common.PipelineVersionIDResourceNameKey] != "" {
+			pipelineVersion, err := r.GetPipelineVersion(resourceNames[common.PipelineVersionIDResourceNameKey])
 			if err != nil {
-				return nil, util.Wrapf(err, "Failed to fetch a pipeline version and its manifest from pipeline %v. Check if pipeline version %v exists", pipelineSpec.PipelineName, resourceNames["PipelineVersionId"])
+				return nil, util.Wrapf(err, "Failed to fetch a pipeline version and its manifest from pipeline %v. Check if pipeline version %v exists", pipelineSpec.PipelineName, resourceNames[common.PipelineVersionIDResourceNameKey])
 			}
 			return pipelineVersion, nil
 		} else {
-			pipelineVersion, err := r.GetLatestPipelineVersion(resourceNames["PipelineId"])
+			pipelineVersion, err := r.GetLatestPipelineVersion(resourceNames[common.PipelineIDResourceNameKey])
 			if err != nil {
-				return nil, util.Wrapf(err, "Failed to fetch a pipeline version and its manifest from pipeline %v. Check if pipeline %v exists", pipelineSpec.PipelineName, resourceNames["PipelineId"])
+				return nil, util.Wrapf(err, "Failed to fetch a pipeline version and its manifest from pipeline %v. Check if pipeline %v exists", pipelineSpec.PipelineName, resourceNames[common.PipelineIDResourceNameKey])
 			}
 			return pipelineVersion, nil
 		}

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -1340,10 +1340,10 @@ func toModelRun(r interface{}) (*model.Run, error) {
 					experimentId = resources["ExperimentId"]
 				}
 				if pipelineId == "" {
-					pipelineId = resources["PipelineId"]
+					pipelineId = resources[common.PipelineIDResourceNameKey]
 				}
 				if pipelineVersionId == "" {
-					pipelineVersionId = resources["PipelineVersionId"]
+					pipelineVersionId = resources[common.PipelineVersionIDResourceNameKey]
 				}
 				if runId == "" {
 					runId = resources["RunID"]

--- a/backend/src/apiserver/server/job_server.go
+++ b/backend/src/apiserver/server/job_server.go
@@ -117,6 +117,9 @@ func (s *BaseJobServer) createJob(ctx context.Context, job *model.Job) (*model.J
 	if err := s.canAccessJob(ctx, "", resourceAttributes); err != nil {
 		return nil, util.Wrapf(err, "Failed to create a recurring run due to authorization error. Check if you have write permission to namespace %s", job.Namespace)
 	}
+	if err := canAccessReferencedPipeline(ctx, s.resourceManager, &job.PipelineSpec, job.Namespace); err != nil {
+		return nil, util.Wrap(err, "Failed to create a recurring run due to authorization error on the referenced pipeline")
+	}
 	return s.resourceManager.CreateJob(ctx, job)
 }
 

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -29,13 +29,18 @@ import (
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -630,6 +635,96 @@ func TestCreateJob_Unauthorized(t *testing.T) {
 		err.Error(),
 		"PermissionDenied: User 'user@google.com' is not authorized with reason",
 	)
+}
+
+func TestCreateJob_PrivatePipelineVersionUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	clients, manager, experiment := initWithExperiment(t)
+	defer clients.Close()
+	privatePipeline, err := manager.CreatePipeline(&model.Pipeline{Name: "private-pipeline", Namespace: "ns2"})
+	require.NoError(t, err)
+	pipelineStore, ok := clients.PipelineStore().(*storage.PipelineStore)
+	require.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(NonDefaultFakeUUID, nil))
+	privateVersion, err := manager.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "private-version",
+		PipelineId:   privatePipeline.UUID,
+		PipelineSpec: model.LargeText(testWorkflow.ToStringForStore()),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, privatePipeline.UUID, privateVersion.UUID)
+
+	reviewClient := &recordingSubjectAccessReviewClient{
+		authorize: func(attributes authorizationv1.ResourceAttributes) bool {
+			return attributes.Resource != common.RbacResourceTypePipelines
+		},
+	}
+	clients.SubjectAccessReviewClientFake = reviewClient
+	manager = resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	server := createJobServer(manager)
+	_, err = server.createJob(ctx, &model.Job{
+		DisplayName:  "private-pipeline-job",
+		ExperimentId: experiment.UUID,
+		Namespace:    experiment.Namespace,
+		PipelineSpec: model.PipelineSpec{PipelineVersionId: privateVersion.UUID},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PermissionDenied")
+	require.Len(t, reviewClient.requests, 2)
+	assert.Equal(t, authorizationv1.ResourceAttributes{
+		Namespace: "ns2",
+		Verb:      common.RbacResourceVerbGet,
+		Group:     common.RbacPipelinesGroup,
+		Version:   common.RbacPipelinesVersion,
+		Resource:  common.RbacResourceTypePipelines,
+		Name:      privatePipeline.Name,
+	}, reviewClient.requests[1])
+}
+
+func TestCreateJob_PrivatePipelineVersionMustMatchDestinationNamespace(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	clients, manager, experiment := initWithExperiment(t)
+	defer clients.Close()
+	privatePipeline, err := manager.CreatePipeline(&model.Pipeline{Name: "private-pipeline", Namespace: "ns2"})
+	require.NoError(t, err)
+	pipelineStore, ok := clients.PipelineStore().(*storage.PipelineStore)
+	require.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(NonDefaultFakeUUID, nil))
+	privateVersion, err := manager.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "private-version",
+		PipelineId:   privatePipeline.UUID,
+		PipelineSpec: model.LargeText(testWorkflow.ToStringForStore()),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, privatePipeline.UUID, privateVersion.UUID)
+
+	// Model the scheduled-workflow controller, whose cluster-wide pipeline read
+	// permission must not let a namespaced recurring-run resource reference a
+	// different tenant's private pipeline.
+	reviewClient := &recordingSubjectAccessReviewClient{allowed: true}
+	clients.SubjectAccessReviewClientFake = reviewClient
+	manager = resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	server := createJobServer(manager)
+	_, err = server.createJob(ctx, &model.Job{
+		DisplayName:  "cross-namespace-pipeline-job",
+		ExperimentId: experiment.UUID,
+		Namespace:    experiment.Namespace,
+		PipelineSpec: model.PipelineSpec{PipelineVersionId: privateVersion.UUID},
+	})
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+	assert.Contains(t, err.Error(), "private pipeline can only be referenced")
+	require.Len(t, reviewClient.requests, 2)
+	assert.Equal(t, common.RbacResourceTypeJobs, reviewClient.requests[0].Resource)
+	assert.Equal(t, common.RbacResourceTypePipelines, reviewClient.requests[1].Resource)
 }
 
 func TestGetJob_Unauthorized(t *testing.T) {

--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -1254,33 +1254,51 @@ func (s *PipelineServerV1) GetPipelineVersionTemplate(ctx context.Context, reque
 // Adds namespace of the parent pipeline if version id is not empty,
 // API group, version, and resource type.
 func (s *BasePipelineServer) canAccessPipelineVersion(ctx context.Context, versionId string, resourceAttributes *authorizationv1.ResourceAttributes) error {
+	return authorizePipelineVersionAccess(ctx, s.resourceManager, versionId, resourceAttributes)
+}
+
+func authorizePipelineVersionAccess(ctx context.Context, resourceManager *resource.ResourceManager, versionID string, resourceAttributes *authorizationv1.ResourceAttributes) error {
 	if !common.IsMultiUserMode() {
 		// Skip authorization if not multi-user mode.
 		return nil
 	}
-	pipelineId := ""
-	if versionId != "" {
-		pipelineVersion, err := s.resourceManager.GetPipelineVersion(versionId)
+	pipelineID := ""
+	if versionID != "" {
+		pipelineVersion, err := resourceManager.GetPipelineVersion(versionID)
 		if err != nil {
-			return util.Wrapf(err, "Failed to access pipeline version %s. Check if it exists", versionId)
+			return util.Wrapf(err, "Failed to access pipeline version %s. Check if it exists", versionID)
 		}
-		pipelineId = pipelineVersion.PipelineId
+		pipelineID = pipelineVersion.PipelineId
 	}
-	return s.canAccessPipeline(ctx, pipelineId, resourceAttributes)
+	return authorizePipelineAccess(ctx, resourceManager, pipelineID, resourceAttributes)
 }
 
 // Checks if a user can access a pipeline.
 // Adds parent namespace if pipeline id is not empty,
 // API group, version, and resource type.
 func (s *BasePipelineServer) canAccessPipeline(ctx context.Context, pipelineId string, resourceAttributes *authorizationv1.ResourceAttributes) error {
+	return authorizePipelineAccess(ctx, s.resourceManager, pipelineId, resourceAttributes)
+}
+
+func authorizePipelineAccess(ctx context.Context, resourceManager *resource.ResourceManager, pipelineID string, resourceAttributes *authorizationv1.ResourceAttributes) error {
+	_, err := authorizePipelineAccessAndGet(ctx, resourceManager, pipelineID, resourceAttributes)
+	return err
+}
+
+// authorizePipelineAccessAndGet applies pipeline authorization and returns the
+// pipeline loaded to derive its authorization attributes. Callers that also
+// need pipeline ownership can reuse the row instead of reading it twice.
+func authorizePipelineAccessAndGet(ctx context.Context, resourceManager *resource.ResourceManager, pipelineID string, resourceAttributes *authorizationv1.ResourceAttributes) (*model.Pipeline, error) {
 	if !common.IsMultiUserMode() {
 		// Skip authorization if not multi-user mode.
-		return nil
+		return nil, nil
 	}
-	if pipelineId != "" {
-		pipeline, err := s.resourceManager.GetPipeline(pipelineId)
+	var pipeline *model.Pipeline
+	if pipelineID != "" {
+		var err error
+		pipeline, err = resourceManager.GetPipeline(pipelineID)
 		if err != nil {
-			return util.Wrapf(err, "Failed to access pipeline %s. Check if it exists and have a namespace assigned", pipelineId)
+			return nil, util.Wrapf(err, "Failed to access pipeline %s. Check if it exists and have a namespace assigned", pipelineID)
 		}
 		resourceAttributes.Namespace = pipeline.Namespace
 		if resourceAttributes.Name == "" {
@@ -1290,28 +1308,28 @@ func (s *BasePipelineServer) canAccessPipeline(ctx context.Context, pipelineId s
 	// Skip authorization for read-only operations on shared pipelines in multi-user mode.
 	// Write operations (create, update, delete) on shared pipelines must still be authorized
 	// against the KFP system namespace, since shared pipelines have no namespace of their own.
-	if s.resourceManager.IsEmptyNamespace(resourceAttributes.Namespace) {
+	if resourceManager.IsEmptyNamespace(resourceAttributes.Namespace) {
 		if resourceAttributes.Verb == common.RbacResourceVerbGet || resourceAttributes.Verb == common.RbacResourceVerbList {
-			return nil
+			return pipeline, nil
 		}
 		resourceAttributes.Namespace = common.GetPodNamespace()
 		resourceAttributes.Group = common.RbacPipelinesGroup
 		resourceAttributes.Version = common.RbacPipelinesVersion
 		resourceAttributes.Resource = common.RbacResourceTypePipelines
-		err := s.resourceManager.IsAuthorized(ctx, resourceAttributes)
+		err := resourceManager.IsAuthorized(ctx, resourceAttributes)
 		if err != nil {
-			return util.Wrapf(err, "Failed to access shared pipeline %s. Check if you have permission to %s shared pipelines", pipelineId, resourceAttributes.Verb)
+			return nil, util.Wrapf(err, "Failed to access shared pipeline %s. Check if you have permission to %s shared pipelines", pipelineID, resourceAttributes.Verb)
 		}
-		return nil
+		return pipeline, nil
 	}
 	resourceAttributes.Group = common.RbacPipelinesGroup
 	resourceAttributes.Version = common.RbacPipelinesVersion
 	resourceAttributes.Resource = common.RbacResourceTypePipelines
-	err := s.resourceManager.IsAuthorized(ctx, resourceAttributes)
+	err := resourceManager.IsAuthorized(ctx, resourceAttributes)
 	if err != nil {
-		return util.Wrapf(err, "Failed to access pipeline %s. Check if you have access to namespace %s", pipelineId, resourceAttributes.Namespace)
+		return nil, util.Wrapf(err, "Failed to access pipeline %s. Check if you have access to namespace %s", pipelineID, resourceAttributes.Namespace)
 	}
-	return nil
+	return pipeline, nil
 }
 
 // buildPipelineName extracts the common logic of naming the pipeline.

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -157,7 +157,43 @@ func (s *BaseRunServer) createRun(ctx context.Context, run *model.Run) (*model.R
 	if err := s.canAccessRun(ctx, "", resourceAttributes); err != nil {
 		return nil, util.Wrapf(err, "Failed to create a run due to authorization error. Check if you have write permissions to namespace %s", run.Namespace)
 	}
+	if err := validateRecurringRunNamespace(s.resourceManager, run); err != nil {
+		return nil, util.Wrap(err, "Failed to create a run for the referenced recurring run")
+	}
+	if err := canAccessReferencedPipeline(ctx, s.resourceManager, &run.PipelineSpec, run.Namespace); err != nil {
+		return nil, util.Wrap(err, "Failed to create a run due to authorization error on the referenced pipeline")
+	}
 	return s.resourceManager.CreateRun(ctx, run)
+}
+
+func validateRecurringRunNamespace(resourceManager *resource.ResourceManager, run *model.Run) error {
+	if !common.IsMultiUserMode() || run.RecurringRunId == "" {
+		return nil
+	}
+	job, err := resourceManager.GetJob(run.RecurringRunId)
+	if err != nil {
+		return util.Wrapf(err, "Failed to retrieve recurring run %s", run.RecurringRunId)
+	}
+	jobNamespace := job.Namespace
+	if resourceManager.IsEmptyNamespace(jobNamespace) {
+		jobNamespace, err = resourceManager.GetNamespaceFromExperimentId(job.ExperimentId)
+		if err != nil {
+			return util.Wrapf(err, "Failed to determine the namespace of recurring run %s", run.RecurringRunId)
+		}
+	}
+	if resourceManager.IsEmptyNamespace(jobNamespace) || jobNamespace != run.Namespace {
+		if resourceManager.IsEmptyNamespace(jobNamespace) {
+			return util.NewPermissionDeniedError(
+				fmt.Errorf("recurring run %q has no resolvable namespace", run.RecurringRunId),
+				"The recurring run has no resolvable namespace; recreate it in a namespaced experiment before triggering runs",
+			)
+		}
+		return util.NewPermissionDeniedError(
+			fmt.Errorf("recurring run namespace %q does not match destination namespace %q", jobNamespace, run.Namespace),
+			"A recurring run can only create runs in its own namespace",
+		)
+	}
+	return nil
 }
 
 // Creates a run.
@@ -678,6 +714,84 @@ func (s *BaseRunServer) canAccessRun(ctx context.Context, runId string, resource
 	err := s.resourceManager.IsAuthorized(ctx, resourceAttributes)
 	if err != nil {
 		return util.Wrapf(err, "Failed to access run %s. Check if you have access to namespace %s", runId, resourceAttributes.Namespace)
+	}
+	return nil
+}
+
+func canAccessReferencedPipeline(ctx context.Context, resourceManager *resource.ResourceManager, pipelineSpec *model.PipelineSpec, destinationNamespace string) error {
+	if !common.IsMultiUserMode() {
+		// Skip authz if not multi-user mode.
+		return nil
+	}
+	pipelineVersionID := pipelineSpec.PipelineVersionId
+	pipelineID := pipelineSpec.PipelineId
+	hasExplicitPipelineVersionID := pipelineVersionID != ""
+	// The pipeline/version may instead be encoded in the full pipeline name.
+	// Parse it even when one explicit field is present so mixed reference forms
+	// cannot hide a version from authorization.
+	if pipelineSpec.PipelineName != "" {
+		resourceNames := common.ParseResourceIdsFromFullName(pipelineSpec.PipelineName)
+		if pipelineVersionID == "" {
+			pipelineVersionID = resourceNames[common.PipelineVersionIDResourceNameKey]
+		}
+		// V1 conversion historically synthesizes PipelineName as
+		// "pipelines/<version-id>" for a version-only reference. Do not treat
+		// that compatibility name as an independent pipeline ID when the real
+		// version ID is already explicit.
+		if pipelineID == "" && !hasExplicitPipelineVersionID {
+			pipelineID = resourceNames[common.PipelineIDResourceNameKey]
+		}
+	}
+	resourceAttributes := &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet}
+	// Run creation resolves a version before a pipeline ID, so authorization must
+	// follow the same order when both are supplied.
+	if pipelineVersionID != "" {
+		pipelineVersion, err := resourceManager.GetPipelineVersion(pipelineVersionID)
+		if err != nil {
+			return util.Wrapf(err, "Failed to authorize access to the referenced pipeline version %s", pipelineVersionID)
+		}
+		// Fail closed if the version has no owning pipeline: authorizing an empty
+		// pipeline ID would leave the namespace empty and be treated as a shared,
+		// world-readable pipeline, skipping the SubjectAccessReview entirely.
+		if pipelineVersion.PipelineId == "" {
+			return util.NewInternalServerError(
+				fmt.Errorf("pipeline version %s resolves to an empty pipeline id", pipelineVersionID),
+				"Failed to authorize access to the referenced pipeline")
+		}
+		if err := authorizeReferencedPipelineAccess(ctx, resourceManager, pipelineVersion.PipelineId, destinationNamespace, resourceAttributes); err != nil {
+			return err
+		}
+		if pipelineID != "" && pipelineVersion.PipelineId != "" && pipelineID != pipelineVersion.PipelineId {
+			return util.NewInvalidInputError("Pipeline version %s does not belong to pipeline %s", pipelineVersionID, pipelineID)
+		}
+		return nil
+	}
+	if pipelineID == "" {
+		// Inline manifests do not reference a stored pipeline.
+		return nil
+	}
+	return authorizeReferencedPipelineAccess(ctx, resourceManager, pipelineID, destinationNamespace, resourceAttributes)
+}
+
+// authorizeReferencedPipelineAccess first applies the caller's normal pipeline
+// authorization, then ensures that a private pipeline cannot be used to create
+// a run in another namespace. This second check is required for trusted
+// controllers whose service account can read pipelines cluster-wide: otherwise
+// a namespaced custom resource could make the controller act as a confused
+// deputy for a pipeline owned by a different tenant. Shared pipelines remain
+// available in every namespace. MULTIUSER_SHARED_READ intentionally permits
+// cross-namespace references because that mode makes private pipeline reads
+// globally available.
+func authorizeReferencedPipelineAccess(ctx context.Context, resourceManager *resource.ResourceManager, pipelineID string, destinationNamespace string, resourceAttributes *authorizationv1.ResourceAttributes) error {
+	pipeline, err := authorizePipelineAccessAndGet(ctx, resourceManager, pipelineID, resourceAttributes)
+	if err != nil {
+		return err
+	}
+	if !common.IsMultiUserSharedReadMode() && !resourceManager.IsEmptyNamespace(pipeline.Namespace) && pipeline.Namespace != destinationNamespace {
+		return util.NewPermissionDeniedError(
+			fmt.Errorf("pipeline namespace %q does not match destination namespace %q", pipeline.Namespace, destinationNamespace),
+			"A private pipeline can only be referenced by runs in its own namespace",
+		)
 	}
 	return nil
 }

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -29,18 +29,42 @@ import (
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
+
+type recordingSubjectAccessReviewClient struct {
+	allowed   bool
+	authorize func(authorizationv1.ResourceAttributes) bool
+	requests  []authorizationv1.ResourceAttributes
+}
+
+func (c *recordingSubjectAccessReviewClient) Create(_ context.Context, review *authorizationv1.SubjectAccessReview, _ metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error) {
+	allowed := c.allowed
+	if review.Spec.ResourceAttributes != nil {
+		attributes := *review.Spec.ResourceAttributes.DeepCopy()
+		c.requests = append(c.requests, attributes)
+		if c.authorize != nil {
+			allowed = c.authorize(attributes)
+		}
+	}
+	return &authorizationv1.SubjectAccessReview{
+		Status: authorizationv1.SubjectAccessReviewStatus{Allowed: allowed, Reason: "test authorization decision"},
+	}, nil
+}
 
 func createRunServerV1(resourceManager *resource.ResourceManager) *RunServerV1 {
 	return &RunServerV1{
@@ -520,6 +544,230 @@ func TestCreateRunV1_Unauthorized(t *testing.T) {
 		err.Error(),
 		"PermissionDenied: User 'user@google.com' is not authorized with reason",
 	)
+}
+
+func TestCanAccessReferencedPipeline_Multiuser(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	// newManagerWithPipeline returns a resource manager holding a single pipeline
+	// in the given namespace plus one pipeline version, along with their IDs. When
+	// authorized is false the SubjectAccessReview client denies every request.
+	newManagerWithPipeline := func(namespace string, authorized bool) (*resource.ResourceManager, string, string) {
+		initEnvVars()
+		clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+		t.Cleanup(func() { clientManager.Close() })
+		if !authorized {
+			clientManager.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+		}
+		resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+		pipeline, err := resourceManager.CreatePipeline(&model.Pipeline{Name: "p1", Namespace: namespace})
+		assert.Nil(t, err)
+		pipelineVersion, err := resourceManager.CreatePipelineVersion(&model.PipelineVersion{
+			Name:         "p1",
+			PipelineId:   pipeline.UUID,
+			PipelineSpec: model.LargeText(testWorkflow.ToStringForStore()),
+		})
+		assert.Nil(t, err)
+		return resourceManager, pipeline.UUID, pipelineVersion.UUID
+	}
+
+	// A caller without access to another namespace's private pipeline is denied
+	// when referencing it by version ID or by pipeline ID.
+	rmPrivate, privatePipelineID, privateVersionID := newManagerWithPipeline("ns2", false)
+	assert.Error(t, canAccessReferencedPipeline(ctx, rmPrivate, &model.PipelineSpec{PipelineVersionId: privateVersionID}, "ns1"))
+	assert.Error(t, canAccessReferencedPipeline(ctx, rmPrivate, &model.PipelineSpec{PipelineId: privatePipelineID}, "ns1"))
+
+	// Shared (empty-namespace) pipelines remain readable by any authenticated
+	// user, even one the SubjectAccessReview would deny.
+	rmShared, sharedPipelineID, sharedVersionID := newManagerWithPipeline("", false)
+	assert.NoError(t, canAccessReferencedPipeline(ctx, rmShared, &model.PipelineSpec{PipelineVersionId: sharedVersionID}, "ns1"))
+	assert.NoError(t, canAccessReferencedPipeline(ctx, rmShared, &model.PipelineSpec{PipelineId: sharedPipelineID}, "ns1"))
+
+	// An inline manifest references no existing pipeline and needs no pipeline
+	// authorization at this layer.
+	assert.NoError(t, canAccessReferencedPipeline(ctx, rmShared, &model.PipelineSpec{}, "ns1"))
+
+	// Pairing an accessible pipeline ID with another namespace's private version
+	// ID must not authorize against the accessible pipeline: the referenced version
+	// is resolved first and its owning pipeline governs authorization. Build one
+	// manager holding both a shared pipeline and a private ns2 pipeline.
+	initEnvVars()
+	mixedClientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	defer mixedClientManager.Close()
+	mixedClientManager.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	mixedRM := resource.NewResourceManager(mixedClientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+	sharedPipeline, err := mixedRM.CreatePipeline(&model.Pipeline{Name: "shared", Namespace: ""})
+	assert.Nil(t, err)
+	_, err = mixedRM.CreatePipelineVersion(&model.PipelineVersion{Name: "shared", PipelineId: sharedPipeline.UUID, PipelineSpec: model.LargeText(testWorkflow.ToStringForStore())})
+	assert.Nil(t, err)
+	mixedClientManager.UpdateUUID(util.NewFakeUUIDGeneratorOrFatal(NonDefaultFakeUUID, nil))
+	mixedRM = resource.NewResourceManager(mixedClientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+	privatePipeline, err := mixedRM.CreatePipeline(&model.Pipeline{Name: "private", Namespace: "ns2"})
+	assert.Nil(t, err)
+	privateVersion, err := mixedRM.CreatePipelineVersion(&model.PipelineVersion{Name: "private", PipelineId: privatePipeline.UUID, PipelineSpec: model.LargeText(testWorkflow.ToStringForStore())})
+	assert.Nil(t, err)
+	err = canAccessReferencedPipeline(ctx, mixedRM, &model.PipelineSpec{PipelineId: sharedPipeline.UUID, PipelineVersionId: privateVersion.UUID}, "ns2")
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+	err = canAccessReferencedPipeline(ctx, mixedRM, &model.PipelineSpec{
+		PipelineId:   sharedPipeline.UUID,
+		PipelineName: "pipelineversions/" + privateVersion.UUID,
+	}, "ns2")
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+
+	reviewClient := &recordingSubjectAccessReviewClient{allowed: true}
+	mixedClientManager.SubjectAccessReviewClientFake = reviewClient
+	mixedRM = resource.NewResourceManager(mixedClientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+	err = canAccessReferencedPipeline(ctx, mixedRM, &model.PipelineSpec{PipelineId: sharedPipeline.UUID, PipelineVersionId: privateVersion.UUID}, "ns2")
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument))
+	require.Len(t, reviewClient.requests, 1)
+	assert.Equal(t, authorizationv1.ResourceAttributes{
+		Namespace: "ns2",
+		Verb:      common.RbacResourceVerbGet,
+		Group:     common.RbacPipelinesGroup,
+		Version:   common.RbacPipelinesVersion,
+		Resource:  common.RbacResourceTypePipelines,
+		Name:      privatePipeline.Name,
+	}, reviewClient.requests[0])
+
+	// A caller authorized for the owning namespace is allowed.
+	rmAuthorized, _, authorizedVersionID := newManagerWithPipeline("ns2", true)
+	assert.NoError(t, canAccessReferencedPipeline(ctx, rmAuthorized, &model.PipelineSpec{PipelineVersionId: authorizedVersionID}, "ns2"))
+	assert.Error(t, canAccessReferencedPipeline(ctx, rmAuthorized, &model.PipelineSpec{PipelineVersionId: authorizedVersionID}, "ns1"))
+	viper.Set(common.MultiUserModeSharedReadAccess, "true")
+	assert.NoError(t, canAccessReferencedPipeline(ctx, rmAuthorized, &model.PipelineSpec{PipelineVersionId: authorizedVersionID}, "ns1"))
+	viper.Set(common.MultiUserModeSharedReadAccess, "false")
+
+	// The pipeline/version can also be encoded in the full pipeline name; the same
+	// authorization must apply on that parsing path so it cannot silently fail open.
+	rmNamePrivate, _, namePrivateVersionID := newManagerWithPipeline("ns2", false)
+	assert.Error(t, canAccessReferencedPipeline(ctx, rmNamePrivate, &model.PipelineSpec{PipelineName: "pipelineversions/" + namePrivateVersionID}, "ns1"))
+	rmNameAuthorized, _, nameAuthorizedVersionID := newManagerWithPipeline("ns2", true)
+	assert.NoError(t, canAccessReferencedPipeline(ctx, rmNameAuthorized, &model.PipelineSpec{PipelineName: "pipelineversions/" + nameAuthorizedVersionID}, "ns2"))
+}
+
+func TestCreateRun_MultiuserRecurringRunNamespaceBoundToOwner(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	clients, manager, experiment := initWithExperiment(t)
+	defer clients.Close()
+	jobID := "recurring-run-in-ns2"
+	_, err := clients.JobStore().CreateJob(&model.Job{
+		UUID:         jobID,
+		DisplayName:  "recurring run",
+		K8SName:      "recurring-run",
+		Namespace:    "ns2",
+		ExperimentId: experiment.UUID,
+	})
+	require.NoError(t, err)
+
+	server := createRunServer(manager)
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, err = server.createRun(ctx, &model.Run{
+		DisplayName:    "controller-created-run",
+		ExperimentId:   experiment.UUID,
+		RecurringRunId: jobID,
+	})
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+	assert.Contains(t, err.Error(), "A recurring run can only create runs in its own namespace")
+}
+
+func TestValidateRecurringRunNamespace_MultiuserLegacyOwner(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	clients, manager, experiment := initWithExperiment(t)
+	defer clients.Close()
+	jobID := "legacy-recurring-run"
+	_, err := clients.JobStore().CreateJob(&model.Job{
+		UUID:         jobID,
+		DisplayName:  "legacy recurring run",
+		K8SName:      "legacy-recurring-run",
+		Namespace:    model.NoNamespace,
+		ExperimentId: experiment.UUID,
+	})
+	require.NoError(t, err)
+
+	err = validateRecurringRunNamespace(manager, &model.Run{
+		Namespace:      "ns1",
+		RecurringRunId: jobID,
+	})
+	require.NoError(t, err)
+}
+
+func TestValidateRecurringRunNamespace_MultiuserLegacyOwnerWithoutNamespace(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	clients, manager, _ := initWithExperiment(t)
+	defer clients.Close()
+	jobID := "legacy-recurring-run-without-owner"
+	_, err := clients.JobStore().CreateJob(&model.Job{
+		UUID:        jobID,
+		DisplayName: "legacy recurring run without owner",
+		K8SName:     "legacy-recurring-run-without-owner",
+		Namespace:   model.NoNamespace,
+	})
+	require.NoError(t, err)
+
+	err = validateRecurringRunNamespace(manager, &model.Run{
+		Namespace:      "ns1",
+		RecurringRunId: jobID,
+	})
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+	assert.Contains(t, err.Error(), "recreate it in a namespaced experiment")
+}
+
+func TestCreateRunV1_MultiuserVersionOnlyReferenceAuthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	clients, manager, _ := initWithExperiment(t)
+	defer clients.Close()
+	pipeline, err := manager.CreatePipeline(&model.Pipeline{Name: "version-only-pipeline", Namespace: "ns1"})
+	require.NoError(t, err)
+	pipelineStore, ok := clients.PipelineStore().(*storage.PipelineStore)
+	require.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(NonDefaultFakeUUID, nil))
+	pipelineVersion, err := manager.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "version-only-version",
+		PipelineId:   pipeline.UUID,
+		PipelineSpec: model.LargeText(testWorkflow.ToStringForStore()),
+	})
+	require.NoError(t, err)
+	require.Equal(t, NonDefaultFakeUUID, pipelineVersion.UUID)
+	require.NotEqual(t, pipeline.UUID, pipelineVersion.UUID)
+
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	server := createRunServerV1(manager)
+	createdRun, err := server.CreateRunV1(ctx, &apiv1beta1.CreateRunRequest{Run: &apiv1beta1.Run{
+		Name: "version-only-run",
+		ResourceReferences: []*apiv1beta1.ResourceReference{
+			{
+				Key: &apiv1beta1.ResourceKey{
+					Type: apiv1beta1.ResourceType_EXPERIMENT,
+					Id:   DefaultFakeUUID,
+				},
+				Relationship: apiv1beta1.Relationship_OWNER,
+			},
+			{
+				Key: &apiv1beta1.ResourceKey{
+					Type: apiv1beta1.ResourceType_PIPELINE_VERSION,
+					Id:   pipelineVersion.UUID,
+				},
+				Relationship: apiv1beta1.Relationship_CREATOR,
+			},
+		},
+		PipelineSpec: &apiv1beta1.PipelineSpec{
+			Parameters: []*apiv1beta1.Parameter{{Name: "param1", Value: "world"}},
+		},
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, pipelineVersion.UUID, getPipelineVersionFromResourceReferencesV1(createdRun.GetRun().GetResourceReferences()))
 }
 
 func TestCreateRunV1_Multiuser(t *testing.T) {

--- a/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
@@ -22,6 +22,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - pipelines
+  verbs:
+  - get
+- apiGroups:
   - kubeflow.org
   resources:
   - scheduledworkflows

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
@@ -37,6 +37,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - pipelines
+  verbs:
+  - get
+- apiGroups:
   - ''
   resources:
   - events


### PR DESCRIPTION
**Description of your changes:**

**Why:** Creating a run currently checks permission in its destination namespace but can load a stored pipeline owned by another tenant without checking access to that pipeline. Scheduled runs can also use an experiment that points outside the recurring run's namespace.

**What:** Run and recurring-run creation now verifies access to the referenced pipeline and keeps scheduled runs in their owner's namespace. Shared pipelines, inline manifests, and explicitly configured shared reads remain supported.

Coordinated under [GHSA-v83x-544f-ph2r](https://github.com/kubeflow/pipelines/security/advisories/GHSA-v83x-544f-ph2r). This is the regular PR requested by maintainers for the fix reviewed in [the private patch PR](https://github.com/kubeflow/pipelines-ghsa-v83x-544f-ph2r/pull/1).

Technical summary:

- Reuse pipeline-read authorization for pipeline IDs, version IDs, and full resource names before creating executions; reject orphan versions and authorize ownership before reporting reference mismatches.
- Require private pipeline references and recurring-run ownership to match the destination namespace, preserving explicit `MULTIUSER_SHARED_READ` behavior for pipeline reads.
- Resolve legacy recurring-run ownership through its experiment and provide migration guidance when the namespace cannot be recovered.
- Add `pipelines/get` to both shipped ScheduledWorkflow controller roles, with regression coverage for authorization attributes, mixed references, shared reads, and namespace mismatches.

Roll out the API server and controller RBAC manifests together. Custom restricted roles may need `get` on the `pipelines` authorization resource. Existing cross-namespace private-pipeline recurring runs must be migrated to a common namespace unless shared reads are intentionally enabled; legacy recurring runs without recoverable ownership must be recreated in a namespaced experiment.

Validation on current upstream `master` (`73c6ad62b6ddc22c117eb415696f0d98f2c99fc0`), with Go 1.27.1:

- `go test ./backend/src/apiserver/server ./backend/src/apiserver/common ./backend/src/apiserver/resource -count=1`
- `go vet ./backend/src/apiserver/server ./backend/src/apiserver/resource ./backend/src/apiserver/common`
- `go build ./backend/src/apiserver/...`
- `golangci-lint run --new-from-rev upstream/master ./backend/src/apiserver/common/... ./backend/src/apiserver/resource/... ./backend/src/apiserver/server/...`
- Remaining applicable pre-commit hooks, including Go formatting and YAML validation.
- `kubectl kustomize` for `platform-agnostic` and `platform-agnostic-multi-user` overlays.
- `git diff --check`; the rebased code patch is identical to the reviewed private revision.

Live-cluster integration tests were not run.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits).
- [x] The PR title follows the [repository convention](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
