### PR TITLE
fix(ci): isolate protobuf installation from third-party apt sources

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -74,8 +74,14 @@ jobs:
     - name: Verify pipeline and platform spec generation
       working-directory: frontend
       run: |
-        sudo apt-get update
-        sudo apt-get install --yes protobuf-compiler
+        # Protobuf only needs Ubuntu sources, not the runner's third-party repositories.
+        test -s /etc/apt/sources.list.d/ubuntu.sources
+        apt_sources=(
+          -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources
+          -o Dir::Etc::sourceparts=-
+        )
+        sudo apt-get "${apt_sources[@]}" update
+        sudo apt-get "${apt_sources[@]}" install --yes protobuf-compiler
         bash scripts/check-spec-generation.sh
 
     - name: Run Frontend Tests

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -23,6 +23,7 @@ GitHub Actions workflows are in `.github/workflows/`; reusable composite actions
 - `runtime-base-images.yml` is the single producer for the shared runtime-image artifact. It archives test-task, MySQL, and supported Argo images and builds the Modelcar fixture once into a separate archive; opted-in E2E lanes load that archive through the deploy action and fail setup if it is unavailable instead of contacting Hugging Face independently.
 - For workflow-only changes, verify referenced working directories, Docker contexts/files, scripts, and local action paths exist.
 - Frontend CI also runs `frontend/scripts/check-spec-generation.sh` after installing `protoc`: pipeline and Kubernetes platform specs are generated into temporary directories and typechecked. Changes to either source proto directory trigger this workflow.
+- The frontend protobuf installation scopes both APT commands to `/etc/apt/sources.list.d/ubuntu.sources`, excluding unrelated runner repositories such as Chrome without changing their configuration or bypassing package verification. If the runner's source layout changes, update this explicit path; the step checks that it exists before running APT. Browser integration tests continue to use their separate Selenium container.
 
 ## Common CI failures
 


### PR DESCRIPTION
## Summary

- Restrict both frontend protobuf APT commands to Ubuntu's `ubuntu.sources` file, so unrelated runner repositories cannot block spec-generation setup.
- Check that the source file exists before invoking APT. Preserve package signature/checksum verification and all subsequent generation and test steps.
- Document the source-layout dependency in the CI guide. No global repository configuration, installed browser, or Selenium-container changes.

Two frontend CI attempts encountered the Chrome repository checksum mismatch reported in https://github.com/actions/runner-images/issues/14708. The step only needs Ubuntu's `protobuf-compiler` package.

## Verification

- Ubuntu 24.04 container (arm64) with an intentionally unreachable third-party APT source: scoped update and protobuf installation succeed; `protoc --version` reports `libprotoc 3.21.12`.
- Compared `apt-get --print-uris update`: the default command includes the unreachable source; the scoped command excludes it while retaining Ubuntu sources.
- Workflow YAML parsing, extracted step `bash -n`, referenced working-directory/script checks.
- All applicable pre-commit hooks, including actionlint, passed; `git diff --check` passed.

The full frontend suite is left to this PR's hosted workflow; application code is unchanged.

## Checklist

- [x] Signed-off commit.
- [x] Conventional PR title.
