### PR TITLE
fix(backend): authorize shared pipeline uploads

### DIFF
--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -401,13 +401,8 @@ func (s *PipelineUploadServer) canUploadVersionedPipeline(r *http.Request, pipel
 			resourceAttributes.Namespace = namespace
 		}
 	}
-	if resourceAttributes.Namespace == "" {
-		// Shared (cluster-wide) pipelines have no namespace of their own. The
-		// upload endpoints only ever perform writes (create pipeline / create
-		// version), and writes to shared pipelines must still be authorized
-		// against the KFP system namespace, mirroring canAccessPipeline in
-		// pipeline_server.go. Previously this returned nil here, skipping the
-		// SubjectAccessReview entirely for empty-namespace uploads.
+	if s.resourceManager.IsEmptyNamespace(resourceAttributes.Namespace) {
+		// Shared-pipeline writes require authorization in the KFP system namespace.
 		resourceAttributes.Namespace = common.GetPodNamespace()
 	}
 

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -402,7 +402,13 @@ func (s *PipelineUploadServer) canUploadVersionedPipeline(r *http.Request, pipel
 		}
 	}
 	if resourceAttributes.Namespace == "" {
-		return nil
+		// Shared (cluster-wide) pipelines have no namespace of their own. The
+		// upload endpoints only ever perform writes (create pipeline / create
+		// version), and writes to shared pipelines must still be authorized
+		// against the KFP system namespace, mirroring canAccessPipeline in
+		// pipeline_server.go. Previously this returned nil here, skipping the
+		// SubjectAccessReview entirely for empty-namespace uploads.
+		resourceAttributes.Namespace = common.GetPodNamespace()
 	}
 
 	resourceAttributes.Group = common.RbacPipelinesGroup

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
 const (
@@ -42,6 +44,98 @@ const (
 	fakeVersionName = "a_fake_version_name"
 	fakeDescription = "a_fake_description"
 )
+
+func TestUploadPipelineAuthorization(t *testing.T) {
+	for _, apiVersion := range []string{"v1beta1", "v2beta1"} {
+		for _, versionUpload := range []bool{false, true} {
+			for _, tc := range []struct {
+				name      string
+				namespace string
+				multiUser bool
+				allowed   bool
+			}{
+				{name: "shared allowed", multiUser: true, allowed: true},
+				{name: "shared denied", multiUser: true},
+				{name: "namespaced allowed", namespace: "tenant-ns", multiUser: true, allowed: true},
+				{name: "namespaced denied", namespace: "tenant-ns", multiUser: true},
+				{name: "single user shared"},
+				{name: "single user namespaced", namespace: "tenant-ns"},
+			} {
+				t.Run(fmt.Sprintf("%s/version=%t/%s", apiVersion, versionUpload, tc.name), func(t *testing.T) {
+					for _, key := range []string{common.MultiUserMode, common.RequireNamespaceForPipelines, common.KubeflowUserIDHeader, common.PodNamespace} {
+						previous := viper.Get(key)
+						t.Cleanup(func() { viper.Set(key, previous) })
+					}
+					viper.Set(common.PodNamespace, "kfp-system-test")
+					viper.Set(common.MultiUserMode, false)
+					viper.Set(common.KubeflowUserIDHeader, "kubeflow-userid")
+					viper.Set(common.RequireNamespaceForPipelines, false)
+					clients, server := setupClientManagerAndServer()
+					t.Cleanup(func() { clients.Close() })
+					if versionUpload {
+						_, err := server.resourceManager.CreatePipeline(&model.Pipeline{
+							Name: "existing-pipeline", Namespace: tc.namespace,
+						})
+						require.NoError(t, err)
+					}
+					review := &recordingSubjectAccessReviewClient{allowed: tc.allowed}
+					clients.SubjectAccessReviewClientFake = review
+					server = updateClientManager(clients, util.NewFakeUUIDGeneratorOrFatal(fakeVersionUUID, nil))
+					viper.Set(common.MultiUserMode, tc.multiUser)
+					buffer, writer := setupWriter("")
+					setWriterWithBuffer("uploadfile", "hello-world.yaml", v2SpecHelloWorld, writer)
+					endpoint := "/apis/" + apiVersion + "/pipelines/upload?name=test-pipeline&namespace=" + tc.namespace
+					handler := server.UploadPipeline
+					if apiVersion == "v1beta1" {
+						handler = server.UploadPipelineV1
+					}
+					if versionUpload {
+						endpoint = "/apis/" + apiVersion + "/pipelines/upload_version?name=test-version&pipelineid=" + DefaultFakeUUID
+						handler = server.UploadPipelineVersion
+						if apiVersion == "v1beta1" {
+							handler = server.UploadPipelineVersionV1
+						}
+					}
+					request := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewReader(buffer.Bytes()))
+					request.Header.Set("Content-Type", writer.FormDataContentType())
+					request.Header.Set("kubeflow-userid", common.GetKubeflowUserIDPrefix()+"tenant@example.com")
+					response := httptest.NewRecorder()
+					handler(response, request)
+					if tc.multiUser && !tc.allowed {
+						assert.Equal(t, http.StatusBadRequest, response.Code, response.Body.String())
+					} else {
+						require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+						pipelineID := fakeVersionUUID
+						if versionUpload {
+							pipelineID = DefaultFakeUUID
+						}
+						pipeline, err := clients.PipelineStore().GetPipeline(pipelineID)
+						require.NoError(t, err)
+						expectedStoredNamespace := tc.namespace
+						if !tc.multiUser && !versionUpload {
+							expectedStoredNamespace = ""
+						}
+						assert.Equal(t, expectedStoredNamespace, pipeline.Namespace)
+					}
+					if !tc.multiUser {
+						assert.Empty(t, review.requests)
+						return
+					}
+					expectedNamespace := tc.namespace
+					if expectedNamespace == "" {
+						expectedNamespace = "kfp-system-test"
+					}
+					require.Len(t, review.requests, 1)
+					assert.Equal(t, authorizationv1.ResourceAttributes{
+						Namespace: expectedNamespace, Verb: common.RbacResourceVerbCreate,
+						Group: common.RbacPipelinesGroup, Version: common.RbacPipelinesVersion,
+						Resource: common.RbacResourceTypePipelines,
+					}, review.requests[0])
+				})
+			}
+		}
+	}
+}
 
 // TODO: move other upload pipeline tests into this table driven test
 func TestUploadPipeline(t *testing.T) {

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -56,6 +56,8 @@ func TestUploadPipelineAuthorization(t *testing.T) {
 			}{
 				{name: "shared allowed", multiUser: true, allowed: true},
 				{name: "shared denied", multiUser: true},
+				{name: "sentinel shared allowed", namespace: model.NoNamespace, multiUser: true, allowed: true},
+				{name: "sentinel shared denied", namespace: model.NoNamespace, multiUser: true},
 				{name: "namespaced allowed", namespace: "tenant-ns", multiUser: true, allowed: true},
 				{name: "namespaced denied", namespace: "tenant-ns", multiUser: true},
 				{name: "single user shared"},
@@ -122,7 +124,7 @@ func TestUploadPipelineAuthorization(t *testing.T) {
 						return
 					}
 					expectedNamespace := tc.namespace
-					if expectedNamespace == "" {
+					if expectedNamespace == "" || expectedNamespace == model.NoNamespace {
 						expectedNamespace = "kfp-system-test"
 					}
 					require.Len(t, review.requests, 1)

--- a/backend/test/end2end/e2e_suite_test.go
+++ b/backend/test/end2end/e2e_suite_test.go
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 		*config.UploadPipelinesWithKubernetes,
 		*config.KubeflowMode,
 		*config.DebugMode,
-		*config.AuthToken,
+		userToken,
 		*config.Namespace,
 		clientConfig,
 		tlsCfg,

--- a/backend/test/testutil/pipeline_upload_test.go
+++ b/backend/test/testutil/pipeline_upload_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	upload_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
+	model "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_model"
+	api_server "github.com/kubeflow/pipelines/backend/src/common/client/api_server/v2"
+	"github.com/kubeflow/pipelines/backend/test/config"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingPipelineUploadClient struct {
+	api_server.PipelineUploadInterface
+	params *upload_params.UploadPipelineParams
+}
+
+func (c *recordingPipelineUploadClient) UploadFile(_ string, params *upload_params.UploadPipelineParams) (*model.V2beta1Pipeline, error) {
+	c.params = params
+	return &model.V2beta1Pipeline{PipelineID: "test-pipeline"}, nil
+}
+
+func TestUploadPipelineUsesTenantNamespace(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	for _, tc := range []struct {
+		name          string
+		multiUser     bool
+		kubeflow      bool
+		token         string
+		wantNamespace bool
+	}{
+		{name: "single user"},
+		{name: "multi user", multiUser: true, wantNamespace: true},
+		{name: "kubeflow", kubeflow: true, wantNamespace: true},
+		{name: "explicit token", token: "test-token", wantNamespace: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previousMultiUser, previousKubeflow := *config.MultiUserMode, *config.KubeflowMode
+			previousToken, previousNamespace, previousImage := *config.AuthToken, *config.UserNamespace, *config.BaseImage
+			t.Cleanup(func() {
+				*config.MultiUserMode, *config.KubeflowMode = previousMultiUser, previousKubeflow
+				*config.AuthToken, *config.UserNamespace, *config.BaseImage = previousToken, previousNamespace, previousImage
+			})
+			*config.MultiUserMode, *config.KubeflowMode = tc.multiUser, tc.kubeflow
+			*config.AuthToken, *config.UserNamespace, *config.BaseImage = tc.token, "test-tenant", ""
+			path := filepath.Join(t.TempDir(), "pipeline.yaml")
+			require.NoError(t, os.WriteFile(path, []byte("pipelineInfo:\n  name: test-pipeline\n"), 0600))
+			client := &recordingPipelineUploadClient{}
+			name := "test-pipeline"
+			_, err := UploadPipeline(client, path, &name, nil)
+			require.NoError(t, err)
+			require.NotNil(t, client.params)
+			if tc.wantNamespace {
+				require.NotNil(t, client.params.Namespace)
+				require.Equal(t, "test-tenant", *client.params.Namespace)
+			} else {
+				require.Nil(t, client.params.Namespace)
+			}
+		})
+	}
+}

--- a/backend/test/testutil/pipeline_upload_test.go
+++ b/backend/test/testutil/pipeline_upload_test.go
@@ -45,20 +45,28 @@ func TestUploadPipelineUsesTenantNamespace(t *testing.T) {
 		kubeflow      bool
 		token         string
 		wantNamespace bool
+		kubernetes    bool
 	}{
 		{name: "single user"},
 		{name: "multi user", multiUser: true, wantNamespace: true},
 		{name: "kubeflow", kubeflow: true, wantNamespace: true},
 		{name: "explicit token", token: "test-token", wantNamespace: true},
+		{name: "kubernetes single user", kubernetes: true},
+		{name: "kubernetes multi user", kubernetes: true, multiUser: true},
+		{name: "kubernetes kubeflow", kubernetes: true, kubeflow: true},
+		{name: "kubernetes explicit token", kubernetes: true, token: "test-token"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			previousMultiUser, previousKubeflow := *config.MultiUserMode, *config.KubeflowMode
+			previousKubernetes := *config.UploadPipelinesWithKubernetes
 			previousToken, previousNamespace, previousImage := *config.AuthToken, *config.UserNamespace, *config.BaseImage
 			t.Cleanup(func() {
+				*config.UploadPipelinesWithKubernetes = previousKubernetes
 				*config.MultiUserMode, *config.KubeflowMode = previousMultiUser, previousKubeflow
 				*config.AuthToken, *config.UserNamespace, *config.BaseImage = previousToken, previousNamespace, previousImage
 			})
 			*config.MultiUserMode, *config.KubeflowMode = tc.multiUser, tc.kubeflow
+			*config.UploadPipelinesWithKubernetes = tc.kubernetes
 			*config.AuthToken, *config.UserNamespace, *config.BaseImage = tc.token, "test-tenant", ""
 			path := filepath.Join(t.TempDir(), "pipeline.yaml")
 			require.NoError(t, os.WriteFile(path, []byte("pipelineInfo:\n  name: test-pipeline\n"), 0600))

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -46,6 +46,9 @@ func ListPipelines(client *api_server.PipelineClient, namespace *string) []*pipe
 // UploadPipeline - Upload a pipeline
 func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pipelineFilePath string, pipelineName *string, pipelineDisplayName *string) (*model.V2beta1Pipeline, error) {
 	uploadParams := upload_params.NewUploadPipelineParams()
+	if *test_config.MultiUserMode || *test_config.KubeflowMode || *test_config.AuthToken != "" {
+		uploadParams.SetNamespace(test_config.UserNamespace)
+	}
 	uploadParams.SetName(pipelineName)
 	if pipelineDisplayName != nil {
 		uploadParams.SetDisplayName(pipelineDisplayName)

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -46,7 +46,8 @@ func ListPipelines(client *api_server.PipelineClient, namespace *string) []*pipe
 // UploadPipeline - Upload a pipeline
 func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pipelineFilePath string, pipelineName *string, pipelineDisplayName *string) (*model.V2beta1Pipeline, error) {
 	uploadParams := upload_params.NewUploadPipelineParams()
-	if *test_config.MultiUserMode || *test_config.KubeflowMode || *test_config.AuthToken != "" {
+	// Kubernetes uploads use the namespace configured on the client, not a request parameter.
+	if !*test_config.UploadPipelinesWithKubernetes && (*test_config.MultiUserMode || *test_config.KubeflowMode || *test_config.AuthToken != "") {
 		uploadParams.SetNamespace(test_config.UserNamespace)
 	}
 	uploadParams.SetName(pipelineName)


### PR DESCRIPTION
## Summary

Require authorization for HTTP multipart uploads that create shared pipelines or add versions to shared pipelines in multi-user mode. Resolve the authorization target to the KFP system namespace and require `create` on `pipelines`, matching the existing gRPC write policy. The stored pipeline namespace and intentional latest-version scheduling remain unchanged.

## Attribution

Original fix by **Vito Carolillo (@vcrll)**, carried forward as a separate cherry-picked commit with the original author, author date, commit message, and DCO sign-off preserved. Jeff Spahr added the regression coverage in a separate signed-off commit. This is the public replacement for the private remediation associated with GHSA-rjr3-43j3-4q8g / CVE-2026-77596.

## Review follow-up

Addresses the private review's request for endpoint-level regression coverage. The table-driven tests exercise both v1beta1 and v2beta1 pipeline and pipeline-version upload handlers, covering:

- Allowed and denied shared-pipeline writes.
- Exact SubjectAccessReview attributes: configured system namespace, `create`, and the pipelines resource/group/version.
- Allowed and denied namespaced writes using the original tenant namespace.
- Single-user uploads skipping authorization.
- Stored pipeline namespaces remaining unchanged by the authorization remap.

## Verification

- `go test ./backend/src/apiserver/server -count=1` passes.
- `golangci-lint run --new-from-rev origin/master ./backend/src/apiserver/server/...` passes with zero issues; formatting and whitespace checks pass.
- Upload tests and shared-pipeline authorization regression subset pass.
- Negative control: restoring the old empty-namespace early return makes the new shared-upload tests fail, including denied requests incorrectly returning HTTP 200 without a SubjectAccessReview.

## Checklist

- [x] Commits include DCO sign-offs.
- [x] PR title follows the repository convention.
