### PR TITLE
fix(backend): authorize every service account a workflow can use. Fixes #14357

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -31,6 +31,7 @@ const (
 	CacheEnabled                            string = "CacheEnabled"
 	DefaultPipelineRunnerServiceAccountFlag string = "DEFAULTPIPELINERUNNERSERVICEACCOUNT"
 	AllowedServiceAccountsFlag              string = "ALLOWEDSERVICEACCOUNTS"
+	WorkflowServiceAccountAudit             string = "WORKFLOW_SERVICE_ACCOUNT_AUDIT"
 	KubeflowUserIDHeader                    string = "KUBEFLOW_USERID_HEADER"
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
@@ -90,6 +91,11 @@ func IsPipelineVersionUpdatedByDefault() bool {
 
 func IsNamespaceRequiredForPipelines() bool {
 	return GetBoolConfigWithDefault(RequireNamespaceForPipelines, false)
+}
+
+// IsWorkflowServiceAccountAuditEnabled makes additional workflow identity checks advisory.
+func IsWorkflowServiceAccountAuditEnabled() bool {
+	return GetBoolConfigWithDefault(WorkflowServiceAccountAudit, false)
 }
 
 func GetStringConfig(configName string) string {

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -26,6 +26,18 @@ import (
 // NOTE: These tests use viper.Reset() which mutates the global viper singleton.
 // Do not add t.Parallel() to these subtests — the shared viper state would race.
 
+func TestIsWorkflowServiceAccountAuditEnabled(t *testing.T) {
+	for _, value := range []string{"", "false", "true"} {
+		t.Run("value="+value, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			t.Setenv(WorkflowServiceAccountAudit, value)
+			viper.AutomaticEnv()
+			assert.Equal(t, value == "true", IsWorkflowServiceAccountAuditEnabled())
+		})
+	}
+}
+
 func TestGetStringConfigWithDefault(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -847,7 +847,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}
 
 	allowCompilerPodSpecPatch := tmpl.GetTemplateType() == template.V2
-	if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace, "create_run"); err != nil {
 		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
 	}
 
@@ -880,7 +880,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}()
 
 	if r.pluginDispatcher.PluginsRegistered() {
-		if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+		if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace, "create_run_after_plugins"); err != nil {
 			return nil, util.Wrap(err, "Failed to create a run due to service account authorization error after plugin processing")
 		}
 	}
@@ -1312,7 +1312,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		}
 		allowCompilerPodSpecPatch = retryTemplate.GetTemplateType() == template.V2
 	}
-	if err := r.authorizeExecutionServiceAccounts(ctx, newExecSpec, allowCompilerPodSpecPatch, namespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, newExecSpec, allowCompilerPodSpecPatch, namespace, "retry_run"); err != nil {
 		return util.Wrapf(err, "Failed to retry run %s due to service account authorization error", runId)
 	}
 
@@ -1752,7 +1752,7 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to inspect the recurring run's service accounts")
 	}
-	if err := r.authorizeExecutionServiceAccounts(ctx, jobExecutionSpec, templateType == template.V2, k8sNamespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, jobExecutionSpec, templateType == template.V2, k8sNamespace, "create_recurring_run"); err != nil {
 		return nil, util.Wrap(err, "Failed to create a recurring run due to service account authorization error")
 	}
 
@@ -1820,7 +1820,7 @@ func (r *ResourceManager) ChangeJobMode(ctx context.Context, jobId string, enabl
 				return util.Wrapf(err, "Failed to enable recurring run %v because its workflow could not be inspected", jobId)
 			}
 			allowCompilerPodSpecPatch := job.WorkflowSpecManifest == "" && job.PipelineSpecManifest != ""
-			if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+			if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace, "enable_recurring_run"); err != nil {
 				return util.Wrapf(err, "Failed to enable recurring run %v due to service account authorization error", jobId)
 			}
 		}
@@ -3835,15 +3835,52 @@ func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAc
 	})
 }
 
-func (r *ResourceManager) authorizeExecutionServiceAccounts(ctx context.Context, executionSpec util.ExecutionSpec, allowCompilerPodSpecPatch bool, namespace string) error {
+func (r *ResourceManager) authorizeExecutionServiceAccounts(ctx context.Context, executionSpec util.ExecutionSpec, allowCompilerPodSpecPatch bool, namespace, operation string) error {
+	audit := common.IsWorkflowServiceAccountAuditEnabled()
+	mainServiceAccount := executionSpec.ServiceAccount()
+	if mainServiceAccount == "" {
+		mainServiceAccount = "default"
+	}
+	if audit {
+		// Audit only the expanded checks; the main-account policy still applies,
+		// including when a dynamic patch prevents identity collection.
+		if err := r.authorizeServiceAccount(ctx, mainServiceAccount, namespace); err != nil {
+			return err
+		}
+	}
 	serviceAccounts, err := executionSpec.ServiceAccounts(allowCompilerPodSpecPatch)
 	if err != nil {
+		if audit {
+			logWorkflowServiceAccountAudit(executionSpec, namespace, operation, "", "inspection_incomplete")
+			return nil
+		}
 		return err
 	}
 	for _, serviceAccount := range serviceAccounts {
+		if audit && serviceAccount == mainServiceAccount {
+			continue
+		}
 		if err := r.authorizeServiceAccount(ctx, serviceAccount, namespace); err != nil {
+			if audit {
+				finding := "authorization_error"
+				if util.IsUserErrorCodeMatch(err, codes.InvalidArgument) {
+					finding = "account_not_allowed"
+				} else if util.IsUserErrorCodeMatch(err, codes.PermissionDenied) {
+					finding = "account_denied"
+				}
+				logWorkflowServiceAccountAudit(executionSpec, namespace, operation, serviceAccount, finding)
+				continue
+			}
 			return err
 		}
 	}
 	return nil
+}
+
+func logWorkflowServiceAccountAudit(executionSpec util.ExecutionSpec, namespace, operation, serviceAccount, finding string) {
+	meta := executionSpec.ExecutionObjectMeta()
+	// Parser errors can contain patch values. Log metadata and a finding code,
+	// never the manifest, patch contents, or raw authorization error.
+	glog.Warningf("Workflow service account audit: operation=%q namespace=%q workflow=%q generate_name=%q run_id=%q service_account=%q finding=%q; continuing because %s=true",
+		operation, namespace, meta.Name, meta.GenerateName, meta.Labels[util.LabelKeyWorkflowRunId], serviceAccount, finding, common.WorkflowServiceAccountAudit)
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -846,7 +846,8 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		executionSpec.SetCannonicalLabels(swf.Name, run.CreatedAtInSec, nextIndex)
 	}
 
-	if err := r.authorizeServiceAccount(ctx, executionSpec.ServiceAccount(), k8sNamespace); err != nil {
+	allowCompilerPodSpecPatch := tmpl.GetTemplateType() == template.V2
+	if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
 		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
 	}
 
@@ -877,6 +878,12 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 			}
 		}
 	}()
+
+	if r.pluginDispatcher.PluginsRegistered() {
+		if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+			return nil, util.Wrap(err, "Failed to create a run due to service account authorization error after plugin processing")
+		}
+	}
 
 	newExecSpec, err := r.getWorkflowClient(k8sNamespace).Create(ctx, executionSpec, v1.CreateOptions{})
 	if err != nil {
@@ -1296,6 +1303,19 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		}
 	}
 
+	allowCompilerPodSpecPatch := false
+	// Recurring-run reports store both the source pipeline and compiled workflow.
+	if run.PipelineSpecManifest != "" {
+		retryTemplate, templateErr := template.New([]byte(run.PipelineSpecManifest), template.TemplateOptions{})
+		if templateErr != nil {
+			return util.NewInternalServerError(templateErr, "Failed to retry run %s due to error parsing its pipeline spec", runId)
+		}
+		allowCompilerPodSpecPatch = retryTemplate.GetTemplateType() == template.V2
+	}
+	if err := r.authorizeExecutionServiceAccounts(ctx, newExecSpec, allowCompilerPodSpecPatch, namespace); err != nil {
+		return util.Wrapf(err, "Failed to retry run %s due to service account authorization error", runId)
+	}
+
 	// Atomically claim via database-side CAS to prevent ReportWorkflowResource
 	// from overwriting with a stale terminal state. The returned claimGeneration
 	// acts as a unique fence token: UpdateRun checks it to reject stale reports,
@@ -1640,7 +1660,9 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 
 	var manifest string
 	var scheduledWorkflow *scheduledworkflow.ScheduledWorkflow
+	var renderedScheduledWorkflow *scheduledworkflow.ScheduledWorkflow
 	var tmpl template.Template
+	var templateType template.TemplateType
 
 	// If the pipeline version or pipeline spec is provided, this means the user wants to pin to a specific pipeline.
 	// Otherwise, always let the ScheduledWorkflow controller pick the latest.
@@ -1652,7 +1674,12 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		if err != nil {
 			return nil, util.NewInternalServerError(err, "Failed to create a recurring run with an invalid pipeline spec manifest")
 		}
+		templateType = tmpl.GetTemplateType()
 
+		renderedScheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+		}
 		// When plugins are enabled, the SWF controller must call the CreateRun API
 		// so that per-run plugin logic executes.
 		if r.pluginDispatcher.PluginsRegistered() {
@@ -1660,9 +1687,7 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			// so the SWF controller calls the CreateRun API for per-run plugin logic.
 			scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
 		} else {
-			// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
-			// Convert modelJob into scheduledWorkflow.
-			scheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
+			scheduledWorkflow = renderedScheduledWorkflow
 		}
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
@@ -1687,16 +1712,17 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			DefaultRunAsNonRoot:  r.options.DefaultRunAsNonRoot,
 			DefaultHostUsers:     r.options.DefaultHostUsers,
 		}
-		tmpl, err := template.New(manifest, templateOptions)
+		latestTemplate, err := template.New(manifest, templateOptions)
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to fetch a template with an invalid pipeline spec manifest")
 		}
+		templateType = latestTemplate.GetTemplateType()
 
-		validatedScheduledWorkflow, err := tmpl.ScheduledWorkflow(job)
+		renderedScheduledWorkflow, err = latestTemplate.ScheduledWorkflow(job)
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
 		}
-		if v2Tmpl, ok := tmpl.(*template.V2Spec); ok {
+		if v2Tmpl, ok := latestTemplate.(*template.V2Spec); ok {
 			if err = v2Tmpl.ValidateJobInputs(job); err != nil {
 				return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
 			}
@@ -1715,18 +1741,18 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
 			Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
 		}
-		scheduledWorkflow.Spec.ServiceAccount = validatedScheduledWorkflow.Spec.ServiceAccount
+		scheduledWorkflow.Spec.ServiceAccount = renderedScheduledWorkflow.Spec.ServiceAccount
 	}
 
-	if tmpl != nil && util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
+	if util.IsV1PipelinesBlocked(k8sNamespace) && templateType == template.V1 {
 		return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
 	}
 
-	resolvedJobServiceAccount := scheduledWorkflow.Spec.ServiceAccount
-	if resolvedJobServiceAccount == "" {
-		resolvedJobServiceAccount = job.ServiceAccount
+	jobExecutionSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, renderedScheduledWorkflow.Spec.Workflow)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to inspect the recurring run's service accounts")
 	}
-	if err := r.authorizeServiceAccount(ctx, resolvedJobServiceAccount, k8sNamespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, jobExecutionSpec, templateType == template.V2, k8sNamespace); err != nil {
 		return nil, util.Wrap(err, "Failed to create a recurring run due to service account authorization error")
 	}
 
@@ -1785,6 +1811,18 @@ func (r *ResourceManager) ChangeJobMode(ctx context.Context, jobId string, enabl
 		}
 		if scheduledWorkflow == nil || string(scheduledWorkflow.UID) != jobId {
 			return util.Wrapf(util.NewResourceNotFoundError("recurring run", job.K8SName), "Failed to enable recurring run %v. Check if its k8s resource exists", jobId)
+		}
+		// An embedded workflow is launched directly by the ScheduledWorkflow
+		// controller, so reauthorize its identities whenever a job is enabled.
+		if scheduledWorkflow.Spec.Workflow != nil && scheduledWorkflow.Spec.Workflow.Spec != nil {
+			executionSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, scheduledWorkflow.Spec.Workflow)
+			if err != nil {
+				return util.Wrapf(err, "Failed to enable recurring run %v because its workflow could not be inspected", jobId)
+			}
+			allowCompilerPodSpecPatch := job.WorkflowSpecManifest == "" && job.PipelineSpecManifest != ""
+			if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+				return util.Wrapf(err, "Failed to enable recurring run %v due to service account authorization error", jobId)
+			}
 		}
 	}
 
@@ -3779,6 +3817,9 @@ func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAc
 	if serviceAccount == "" {
 		return nil
 	}
+	if strings.Contains(serviceAccount, "{{") {
+		return util.NewInvalidInputError("service account %q is templated; use a literal name so it can be authorized before execution", serviceAccount)
+	}
 	if err := common.ValidateServiceAccountAllowList(serviceAccount); err != nil {
 		return util.NewInvalidInputError("%s", err)
 	}
@@ -3792,4 +3833,17 @@ func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAc
 		Resource:  "serviceaccounts",
 		Name:      serviceAccount,
 	})
+}
+
+func (r *ResourceManager) authorizeExecutionServiceAccounts(ctx context.Context, executionSpec util.ExecutionSpec, allowCompilerPodSpecPatch bool, namespace string) error {
+	serviceAccounts, err := executionSpec.ServiceAccounts(allowCompilerPodSpecPatch)
+	if err != nil {
+		return err
+	}
+	for _, serviceAccount := range serviceAccounts {
+		if err := r.authorizeServiceAccount(ctx, serviceAccount, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/src/apiserver/resource/resource_manager_recurring_retry_internal_test.go
+++ b/backend/src/apiserver/resource/resource_manager_recurring_retry_internal_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	swfutil "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRetryRun_ReportedRecurringRunPodSpecPatch(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		v2             bool
+		v1PipelineSpec bool
+	}{
+		{name: "compiled v2 workflow", v2: true},
+		{name: "raw v1 workflow cannot impersonate compiler patch"},
+		{name: "v1 pipeline spec cannot impersonate compiler patch", v1PipelineSpec: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var store *FakeClientManager
+			var manager *ResourceManager
+			var job *model.Job
+			switch {
+			case test.v2:
+				store, manager, job = initWithJobV2(t)
+			case test.v1PipelineSpec:
+				var experiment *model.Experiment
+				store, manager, experiment = initWithExperiment(t)
+				var err error
+				job, err = manager.CreateJob(context.Background(), &model.Job{
+					DisplayName: "j1", Enabled: true, ExperimentId: experiment.UUID,
+					PipelineSpec: model.PipelineSpec{PipelineSpecManifest: model.LargeText(testWorkflow.ToStringForStore())},
+				})
+				require.NoError(t, err)
+			default:
+				store, manager, job = initWithJob(t)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			schedule, err := store.SwfClient().ScheduledWorkflow(job.Namespace).Get(ctx, job.K8SName, metav1.GetOptions{})
+			require.NoError(t, err)
+			executionSpec, err := swfutil.NewScheduledWorkflow(schedule).NewWorkflow(11, 11)
+			require.NoError(t, err)
+			workflow := executionSpec.(*util.Workflow)
+			workflow.Namespace = job.Namespace
+			if !test.v2 {
+				// Existing V1 workflows must not gain the compiler-only exemption on retry.
+				workflow.Spec.Templates[0].PodSpecPatch = "{{inputs.parameters.pod-spec-patch}}"
+			}
+			require.Contains(t, workflow.ToStringForStore(), "{{inputs.parameters.pod-spec-patch}}")
+			workflow.Status.Phase = v1alpha1.WorkflowFailed
+			syncWorkflowReportWithFakeCluster(t, store, workflow)
+			_, err = manager.ReportWorkflowResource(ctx, workflow)
+			require.NoError(t, err)
+
+			runID := workflow.Labels[util.LabelKeyWorkflowRunId]
+			run, err := manager.GetRun(runID)
+			require.NoError(t, err)
+			require.Equal(t, job.UUID, run.RecurringRunId)
+			require.NotEmpty(t, run.WorkflowSpecManifest)
+			require.Equal(t, model.RuntimeStateFailed, run.State)
+			if test.v2 || test.v1PipelineSpec {
+				require.NotEmpty(t, run.PipelineSpecManifest)
+			}
+
+			err = manager.RetryRun(ctx, runID)
+			if test.v2 {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, "podSpecPatch")
+			}
+			run, err = manager.GetRun(runID)
+			require.NoError(t, err)
+			liveWorkflow, err := store.ExecClient().Execution(job.Namespace).Get(ctx, workflow.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			if test.v2 {
+				assert.Equal(t, model.RuntimeStateRunning, run.State)
+				assert.Equal(t, string(v1alpha1.WorkflowRunning), string(liveWorkflow.ExecutionStatus().Condition()))
+			} else {
+				assert.Equal(t, model.RuntimeStateFailed, run.State)
+				assert.Zero(t, run.RetryGeneration)
+				assert.Equal(t, string(v1alpha1.WorkflowFailed), string(liveWorkflow.ExecutionStatus().Condition()))
+			}
+		})
+	}
+}

--- a/backend/src/apiserver/resource/resource_manager_service_account_audit_test.go
+++ b/backend/src/apiserver/resource/resource_manager_service_account_audit_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	plugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/plugins/mlflow"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func configureServiceAccountAuditTest(t *testing.T, audit bool) {
+	t.Helper()
+	viper.Set(common.WorkflowServiceAccountAudit, audit)
+	viper.Set(common.MultiUserMode, "true")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa,another-sa")
+	t.Cleanup(func() {
+		viper.Set(common.WorkflowServiceAccountAudit, nil)
+		viper.Set(common.MultiUserMode, "false")
+		viper.Set(common.AllowedServiceAccountsFlag, "")
+	})
+}
+
+// These tests must remain sequential: glog, stderr and Viper are process-global.
+func captureServiceAccountAuditLogs(t *testing.T, action func()) string {
+	t.Helper()
+	output, err := os.CreateTemp(t.TempDir(), "audit-log")
+	require.NoError(t, err)
+	defer output.Close()
+	originalStderr := os.Stderr
+	originalLogToStderr := flag.Lookup("logtostderr").Value.String()
+	require.NoError(t, flag.Set("logtostderr", "true"))
+	os.Stderr = output
+	defer func() {
+		os.Stderr = originalStderr
+		_ = flag.Set("logtostderr", originalLogToStderr)
+	}()
+	action()
+	data, err := os.ReadFile(output.Name())
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestWorkflowServiceAccountAuditChecks(t *testing.T) {
+	for _, test := range []struct {
+		name, finding string
+		modify        func(*util.Workflow, *ResourceManager)
+	}{
+		{name: "SAR denial", finding: "account_denied"},
+		{name: "allow list denial", finding: "account_not_allowed", modify: func(_ *util.Workflow, _ *ResourceManager) {
+			viper.Set(common.AllowedServiceAccountsFlag, "")
+		}},
+		{name: "SAR unavailable", finding: "authorization_error", modify: func(_ *util.Workflow, manager *ResourceManager) {
+			manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientError()
+		}},
+		{name: "dynamic patch", finding: "inspection_incomplete", modify: func(workflow *util.Workflow, _ *ResourceManager) {
+			workflow.Spec.PodSpecPatch = `{{workflow.parameters.private-patch-value}}`
+		}},
+		{name: "malformed patch", finding: "inspection_incomplete", modify: func(workflow *util.Workflow, _ *ResourceManager) {
+			workflow.Spec.PodSpecPatch = `{"containers":"private-patch-value"}`
+		}},
+		{name: "retained external reference", finding: "inspection_incomplete", modify: func(workflow *util.Workflow, _ *ResourceManager) {
+			workflow.Status.StoredWorkflowSpec = &workflowapi.WorkflowSpec{WorkflowTemplateRef: &workflowapi.WorkflowTemplateRef{Name: "external"}}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, audit := range []bool{false, true} {
+				mode := "enforce"
+				if audit {
+					mode = "audit"
+				}
+				t.Run(mode, func(t *testing.T) {
+					configureServiceAccountAuditTest(t, audit)
+					store, manager, _ := initWithExperimentAndUnauthorizedSAR(t)
+					defer store.Close()
+					workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+					workflow.Spec.ServiceAccountName = common.DefaultPipelineRunnerServiceAccount
+					workflow.Spec.Templates[0].ServiceAccountName = "nested-sa"
+					workflow.Spec.TemplateDefaults = &workflowapi.Template{ServiceAccountName: "another-sa"}
+					if test.modify != nil {
+						test.modify(workflow, manager)
+					}
+					logs := captureServiceAccountAuditLogs(t, func() {
+						err := manager.authorizeExecutionServiceAccounts(multiUserContext(), workflow, false, "ns1", "create_run")
+						if audit {
+							require.NoError(t, err)
+						} else {
+							require.Error(t, err)
+						}
+					})
+					if audit {
+						assert.Contains(t, logs, `operation="create_run" namespace="ns1" workflow="workflow-name"`)
+						assert.Contains(t, logs, `finding="`+test.finding+`"`)
+						assert.Contains(t, logs, common.WorkflowServiceAccountAudit+"=true")
+						if test.finding != "inspection_incomplete" {
+							assert.Contains(t, logs, `service_account="nested-sa"`)
+							assert.Contains(t, logs, `service_account="another-sa"`)
+						}
+					} else {
+						assert.NotContains(t, logs, "Workflow service account audit:")
+					}
+					assert.NotContains(t, logs, "private-patch-value")
+				})
+			}
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditStillEnforcesMainAccount(t *testing.T) {
+	for _, allowList := range []string{"", "main-sa"} {
+		t.Run("allowed="+allowList, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			viper.Set(common.AllowedServiceAccountsFlag, allowList)
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+			workflow.Spec.ServiceAccountName = "main-sa"
+			workflow.Spec.PodSpecPatch = `{"serviceAccountName":"{{workflow.parameters.param1}}"}`
+			_, err := manager.CreateRun(multiUserContext(), &model.Run{
+				DisplayName: "audit", ExperimentId: experiment.UUID,
+				PipelineSpec: model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"pipeline-runner"}]`,
+				},
+			})
+			require.Error(t, err)
+			assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditFreshWorkflows(t *testing.T) {
+	for _, version := range []string{"v1", "v2"} {
+		for _, externalReference := range []bool{false, true} {
+			name := version + "/valid"
+			if externalReference {
+				name = version + "/external reference"
+			}
+			t.Run(name, func(t *testing.T) {
+				configureServiceAccountAuditTest(t, true)
+				store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+				defer store.Close()
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.Status.StoredTemplates = map[string]workflowapi.Template{"untrusted": {Name: "untrusted", ServiceAccountName: "nested-sa"}}
+				if externalReference {
+					workflow.Spec.WorkflowTemplateRef = &workflowapi.WorkflowTemplateRef{Name: "external"}
+				}
+				pipelineSpec := model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"world"}]`,
+				}
+				if version == "v2" {
+					pipelineSpec = model.PipelineSpec{
+						PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+						RuntimeConfig:        model.RuntimeConfig{Parameters: `{"text":"world"}`},
+					}
+					if externalReference {
+						viper.Set(common.CompiledPipelineSpecPatch, `{"workflowTemplateRef":{"name":"external"}}`)
+						t.Cleanup(func() { viper.Set(common.CompiledPipelineSpecPatch, "") })
+					}
+				}
+				logs := captureServiceAccountAuditLogs(t, func() {
+					run, err := manager.CreateRun(multiUserContext(), &model.Run{DisplayName: "audit", ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec})
+					if externalReference {
+						require.ErrorContains(t, err, "external workflow template references")
+						assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+						return
+					}
+					require.NoError(t, err)
+					created, err := store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+					assert.Empty(t, created.(*util.Workflow).Status.StoredTemplates)
+					if version == "v2" {
+						assert.Contains(t, created.ToStringForStore(), "{{inputs.parameters.pod-spec-patch}}")
+					}
+				})
+				assert.NotContains(t, logs, "Workflow service account audit:")
+			})
+		}
+	}
+}
+
+func TestWorkflowServiceAccountAuditEnforcesImplicitMainAccount(t *testing.T) {
+	for _, allowList := range []string{"", "default"} {
+		t.Run("allowed="+allowList, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			viper.Set(common.AllowedServiceAccountsFlag, allowList)
+			store, manager, _ := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+			// Kubernetes uses default when a retained workflow or plugin omits
+			// the main account. An inspection failure must not bypass its policy.
+			workflow.Spec.ServiceAccountName = ""
+			workflow.Spec.PodSpecPatch = `{{workflow.parameters.param1}}`
+			logs := captureServiceAccountAuditLogs(t, func() {
+				err := manager.authorizeExecutionServiceAccounts(multiUserContext(), workflow, false, "ns1", "retry_run")
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "default")
+			})
+			assert.NotContains(t, logs, "Workflow service account audit:")
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditCreateRunAndJob(t *testing.T) {
+	for _, kind := range []string{"run", "dynamic run", "job", "job with plugins", "latest job"} {
+		t.Run(kind, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			pipelineSpec := model.PipelineSpec{WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa")}
+			if kind == "dynamic run" {
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.Spec.PodSpecPatch = `{"serviceAccountName":"{{workflow.parameters.param1}}"}`
+				pipelineSpec.WorkflowSpecManifest = model.LargeText(workflow.ToStringForStore())
+			}
+			if kind == "job with plugins" {
+				manager.pluginDispatcher = &countingTerminalReportDispatcher{}
+			}
+			if kind == "latest job" {
+				pipeline, err := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+				require.NoError(t, err)
+				_, err = manager.CreatePipelineVersion(createPipelineVersion(pipeline.UUID, "v1", "v1", "", string(pipelineSpec.WorkflowSpecManifest), "", "ns1"))
+				require.NoError(t, err)
+				pipelineSpec = model.PipelineSpec{PipelineId: pipeline.UUID}
+			}
+			operation := "create_recurring_run"
+			logs := captureServiceAccountAuditLogs(t, func() {
+				if kind == "run" || kind == "dynamic run" {
+					operation = "create_run"
+					pipelineSpec.Parameters = `[{"name":"param1","value":"pipeline-runner"}]`
+					_, err := manager.CreateRun(multiUserContext(), &model.Run{DisplayName: "audit", ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec})
+					require.NoError(t, err)
+					assert.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+				} else {
+					job, err := manager.CreateJob(multiUserContext(), &model.Job{DisplayName: "audit", Enabled: true, ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec})
+					require.NoError(t, err)
+					_, err = store.SwfClient().ScheduledWorkflow(job.Namespace).Get(context.Background(), job.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+				}
+			})
+			assert.Contains(t, logs, `operation="`+operation+`"`)
+		})
+	}
+}
+
+type auditTemplateMutatingDispatcher struct {
+	serviceAccountMutatingDispatcher
+}
+
+func (d *auditTemplateMutatingDispatcher) OnBeforeRunCreation(_ context.Context, run *plugins.PendingRun, executionSpec util.ExecutionSpec) error {
+	executionSpec.(*util.Workflow).Spec.Templates[0].ServiceAccountName = "nested-sa"
+	return plugins.SetPendingRunPluginOutput(run, mlflow.PluginName, d.output)
+}
+
+func TestWorkflowServiceAccountAuditPluginMutation(t *testing.T) {
+	for _, mainAccount := range []bool{false, true} {
+		name := "additional account"
+		if mainAccount {
+			name = "main account"
+		}
+		t.Run(name, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			dispatcher := &auditTemplateMutatingDispatcher{serviceAccountMutatingDispatcher{output: mlflow.SuccessfulPluginOutput("exp", "experiment", "parent", "https://mlflow.example/runs/parent")}}
+			manager.pluginDispatcher = dispatcher
+			if mainAccount {
+				manager.pluginDispatcher = &dispatcher.serviceAccountMutatingDispatcher
+			}
+			logs := captureServiceAccountAuditLogs(t, func() {
+				_, err := manager.CreateRun(multiUserContext(), &model.Run{
+					DisplayName: "audit", ExperimentId: experiment.UUID,
+					PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()), Parameters: `[{"name":"param1","value":"world"}]`},
+				})
+				if mainAccount {
+					require.Error(t, err)
+					assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+					require.Len(t, dispatcher.endedRuns, 1)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+					assert.Empty(t, dispatcher.endedRuns)
+				}
+			})
+			if !mainAccount {
+				assert.Contains(t, logs, `operation="create_run_after_plugins"`)
+			}
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditRetryAndEnable(t *testing.T) {
+	t.Run("retry", func(t *testing.T) {
+		store, manager, run := initWithOneTimeFailedRun(t)
+		defer store.Close()
+		run, err := manager.GetRun(run.UUID)
+		require.NoError(t, err)
+		workflow, err := util.NewWorkflowFromBytesJSON([]byte(run.WorkflowRuntimeManifest))
+		require.NoError(t, err)
+		require.NoError(t, workflow.Decompress())
+		workflow.Status.StoredTemplates = map[string]workflowapi.Template{"cached": {Name: "cached", ServiceAccountName: "nested-sa"}}
+		run.WorkflowRuntimeManifest = model.LargeText(workflow.ToStringForStore())
+		require.NoError(t, manager.runStore.UpdateRun(run))
+		syncWorkflowReportWithFakeCluster(t, store, workflow)
+		configureServiceAccountAuditTest(t, true)
+		manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+		logs := captureServiceAccountAuditLogs(t, func() {
+			require.NoError(t, manager.RetryRun(multiUserContext(), run.UUID))
+		})
+		assert.Contains(t, logs, `operation="retry_run"`)
+		after, err := manager.GetRun(run.UUID)
+		require.NoError(t, err)
+		assert.Equal(t, model.RuntimeStateRunning, after.State)
+	})
+	t.Run("enable", func(t *testing.T) {
+		configureServiceAccountAuditTest(t, true)
+		store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+		defer store.Close()
+		job, err := manager.CreateJob(multiUserContext(), &model.Job{
+			DisplayName: "audit", Enabled: false, ExperimentId: experiment.UUID,
+			PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa")},
+		})
+		require.NoError(t, err)
+		logs := captureServiceAccountAuditLogs(t, func() {
+			require.NoError(t, manager.ChangeJobMode(multiUserContext(), job.UUID, true))
+		})
+		assert.Contains(t, logs, `operation="enable_recurring_run"`)
+		after, err := manager.GetJob(job.UUID)
+		require.NoError(t, err)
+		assert.True(t, after.Enabled)
+	})
+}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	swfclientv1beta1 "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned/typed/scheduledworkflow/v1beta1"
 	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/spf13/viper"
@@ -54,6 +55,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -257,6 +259,12 @@ var testWorkflow = util.NewWorkflow(&v1alpha1.Workflow{
 	Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
 })
 
+func testWorkflowWithoutStatus() *util.Workflow {
+	workflow := testWorkflow.DeepCopy()
+	workflow.Status = v1alpha1.WorkflowStatus{}
+	return util.NewWorkflow(workflow)
+}
+
 type retryDuringTerminalReportDispatcher struct {
 	manager  *ResourceManager
 	runID    string
@@ -299,6 +307,48 @@ func (d *countingTerminalReportDispatcher) OnRunRetry(context.Context, *apiserve
 
 func (d *countingTerminalReportDispatcher) PluginsRegistered() bool {
 	return true
+}
+
+type serviceAccountMutatingDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
+	output    *apiv2beta1.PluginOutput
+	endedRuns []*apiserverPlugins.PersistedRun
+}
+
+func (serviceAccountMutatingDispatcher) PluginsRegistered() bool {
+	return true
+}
+
+func (d *serviceAccountMutatingDispatcher) OnBeforeRunCreation(_ context.Context, run *apiserverPlugins.PendingRun, executionSpec util.ExecutionSpec) error {
+	executionSpec.SetServiceAccount("plugin-sa")
+	return apiserverPlugins.SetPendingRunPluginOutput(run, apiservermlflow.PluginName, d.output)
+}
+
+func (d *serviceAccountMutatingDispatcher) OnRunEnd(_ context.Context, run *apiserverPlugins.PersistedRun) bool {
+	d.endedRuns = append(d.endedRuns, run)
+	return true
+}
+
+type patchCountingSwfClient struct {
+	client.SwfClientInterface
+	patchCalls int
+}
+
+func (c *patchCountingSwfClient) ScheduledWorkflow(namespace string) swfclientv1beta1.ScheduledWorkflowInterface {
+	return &patchCountingScheduledWorkflowClient{
+		ScheduledWorkflowInterface: c.SwfClientInterface.ScheduledWorkflow(namespace),
+		patchCalls:                 &c.patchCalls,
+	}
+}
+
+type patchCountingScheduledWorkflowClient struct {
+	swfclientv1beta1.ScheduledWorkflowInterface
+	patchCalls *int
+}
+
+func (c *patchCountingScheduledWorkflowClient) Patch(ctx context.Context, name string, patchType types.PatchType, data []byte, subresources ...string) (*swfapi.ScheduledWorkflow, error) {
+	*c.patchCalls++
+	return c.ScheduledWorkflowInterface.Patch(ctx, name, patchType, data, subresources...)
 }
 
 func TestReadRunLogFromArchiveStreamsObjectStoreFile(t *testing.T) {
@@ -598,6 +648,7 @@ func initWithOneTimeFailedRun(t *testing.T) (*FakeClientManager, *ResourceManage
 	runDetail, err := manager.CreateRun(ctx, apiRun)
 	assert.Nil(t, err)
 	updatedWorkflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	updatedWorkflow.SetServiceAccount(runDetail.ServiceAccount)
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	updatedWorkflow.Status.Nodes = map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
@@ -621,6 +672,7 @@ func initWithOneTimeFailedRunCompressed(t *testing.T) (*FakeClientManager, *Reso
 	runDetail, err := manager.CreateRun(ctx, apiRun)
 	assert.Nil(t, err)
 	updatedWorkflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	updatedWorkflow.SetServiceAccount(runDetail.ServiceAccount)
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	nodes := map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
@@ -647,6 +699,7 @@ func initWithOneTimeFailedRunOffloaded(t *testing.T) (*FakeClientManager, *Resou
 	runDetail, err := manager.CreateRun(ctx, apiRun)
 	assert.Nil(t, err)
 	updatedWorkflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	updatedWorkflow.SetServiceAccount(runDetail.ServiceAccount)
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	updatedWorkflow.Status.OffloadNodeStatusVersion = "offload-hash"
@@ -1645,7 +1698,7 @@ func TestGetPipelineTemplate(t *testing.T) {
 	defer store.Close()
 	actualTemplate, err := manager.GetPipelineLatestTemplate(p.UUID)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte(testWorkflow.ToStringForStore()), actualTemplate)
+	assert.Equal(t, []byte(testWorkflowWithoutStatus().ToStringForStore()), actualTemplate)
 }
 
 // Tests GetPipelineLatestTemplate (from PipelineSpecURI)
@@ -2496,7 +2549,7 @@ func TestCreateRun_ThroughPipelineID(t *testing.T) {
 	runDetail, err := manager.CreateRun(context.Background(), apiRun)
 	assert.Nil(t, err)
 
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2521,7 +2574,7 @@ func TestCreateRun_ThroughPipelineID(t *testing.T) {
 			PipelineVersionId:    version.UUID,
 			PipelineId:           p.UUID,
 			PipelineName:         "version_for_run",
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 		RunDetails: model.RunDetails{
@@ -2587,7 +2640,7 @@ func TestCreateRun_ThroughWorkflowSpecV2(t *testing.T) {
 func TestCreateRun_ThroughWorkflowSpec(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	expectedExperimentUUID := runDetail.ExperimentId
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2639,7 +2692,7 @@ func TestCreateRun_ThroughWorkflowSpecWithPatch(t *testing.T) {
 	viper.Set(common.DefaultBucketNameEnvVar, "test-default-bucket")
 	store, manager, runDetail := initWithPatchedRun(t)
 	expectedExperimentUUID := runDetail.ExperimentId
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2749,7 +2802,7 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 	runDetail, err := manager.CreateRun(context.Background(), apiRun)
 	assert.Nil(t, err)
 
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2775,7 +2828,7 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 			PipelineVersionId:    version.UUID,
 			PipelineId:           version.PipelineId,
 			PipelineName:         version.Name,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 		RunDetails: model.RunDetails{
@@ -2833,7 +2886,7 @@ func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	runDetail, err := manager.CreateRun(context.Background(), apiRun)
 	assert.Nil(t, err)
 
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2871,7 +2924,7 @@ func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 			PipelineId:           pipeline.UUID,
 			PipelineVersionId:    version.UUID,
 			PipelineName:         version.Name,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 	}
@@ -3381,6 +3434,61 @@ func TestRetryRun(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(actualRunDetail.WorkflowRuntimeManifest), "Running")
 	assert.Equal(t, actualRunDetail.RunDetails.State, model.RuntimeStateRunning)
+}
+
+func TestRetryRun_V2CompilerPodSpecPatch(t *testing.T) {
+	store, manager, run := initWithOneTimeRunV2(t)
+	defer store.Close()
+	executionSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.PipelineRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, executionSpec.Decompress())
+	workflow := executionSpec.(*util.Workflow)
+	require.Contains(t, workflow.ToStringForStore(), `{{inputs.parameters.pod-spec-patch}}`)
+	workflow.Status.Phase = v1alpha1.WorkflowFailed
+	run.WorkflowRuntimeManifest = model.LargeText(workflow.ToStringForStore())
+	run.State = model.RuntimeStateFailed
+	run.Conditions = string(model.RuntimeStateFailed.ToV1())
+	require.NoError(t, manager.runStore.UpdateRun(run))
+
+	require.NoError(t, manager.RetryRun(context.Background(), run.UUID))
+}
+
+func TestRetryRun_ServiceAccountSAR_Unauthorized_NoWorkflowMutation(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+	workflow := testWorkflow.DeepCopy()
+	workflow.Spec.ServiceAccountName = common.DefaultPipelineRunnerServiceAccount
+	workflow.Spec.Templates[0].ServiceAccountName = "nested-sa"
+	run, err := manager.CreateRun(context.Background(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+			Parameters:           `[{"name":"param1","value":"world"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.NoError(t, err)
+
+	failedWorkflow := util.NewWorkflow(workflow.DeepCopy())
+	failedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, run.UUID)
+	failedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
+	failedWorkflow.Status.Nodes = map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
+	syncWorkflowReportWithFakeCluster(t, store, failedWorkflow)
+	_, err = manager.ReportWorkflowResource(context.Background(), failedWorkflow)
+	require.NoError(t, err)
+
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	err = manager.RetryRun(multiUserContext(), run.UUID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	liveWorkflow, getErr := store.ExecClientFake.Execution("ns1").Get(context.Background(), run.K8SName, v1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.Equal(t, string(v1alpha1.WorkflowFailed), string(liveWorkflow.ExecutionStatus().Condition()))
 }
 
 func TestRetryRun_RefreshesDivergentWorkflowName(t *testing.T) {
@@ -4084,7 +4192,7 @@ func TestCreateJob_ThroughPipelineVersion(t *testing.T) {
 			PipelineId:           version.PipelineId,
 			PipelineName:         version.Name,
 			PipelineVersionId:    version.UUID,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 	}
@@ -4139,7 +4247,7 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 			PipelineName:         version.Name,
 			PipelineId:           pipeline.UUID,
 			PipelineVersionId:    version.UUID,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 	}
@@ -4268,6 +4376,40 @@ func TestEnableJob(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, expectedJob.ToV1(), job.ToV1())
+}
+
+func TestEnableJob_ReauthorizesEmbeddedWorkflowServiceAccounts(t *testing.T) {
+	viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, "false")
+		viper.Set(common.AllowedServiceAccountsFlag, "")
+	})
+
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+	job, err := manager.CreateJob(context.Background(), &model.Job{
+		DisplayName:  "j1",
+		Enabled:      false,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa"),
+		},
+	})
+	require.NoError(t, err)
+
+	patchCounter := &patchCountingSwfClient{SwfClientInterface: manager.swfClient}
+	manager.swfClient = patchCounter
+	manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	viper.Set(common.MultiUserMode, "true")
+
+	err = manager.ChangeJobMode(multiUserContext(), job.UUID, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	assert.Zero(t, patchCounter.patchCalls, "the ScheduledWorkflow must not be enabled when authorization fails")
+	storedJob, getErr := manager.GetJob(job.UUID)
+	require.NoError(t, getErr)
+	assert.False(t, storedJob.Enabled)
 }
 
 func TestEnableJob_JobNotExist(t *testing.T) {
@@ -6533,6 +6675,7 @@ func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDurin
 			UID:       types.UID(run.UUID),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 		},
+		Spec: v1alpha1.WorkflowSpec{ServiceAccountName: run.ServiceAccount},
 		Status: v1alpha1.WorkflowStatus{
 			Phase:      v1alpha1.WorkflowFailed,
 			FinishedAt: v1.NewTime(time.Unix(123, 0)),
@@ -9270,6 +9413,151 @@ func TestCreateRun_ServiceAccountSAR_Unauthorized_NoWorkflowCreated(t *testing.T
 	_, err := manager.CreateRun(multiUserContext(), apiRun)
 	require.NotNil(t, err)
 	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when SA authorization fails")
+}
+
+func workflowManifestWithTemplateServiceAccount(serviceAccount string) model.LargeText {
+	workflow := testWorkflow.DeepCopy()
+	workflow.Spec.Templates[0].ServiceAccountName = serviceAccount
+	return model.LargeText(util.NewWorkflow(workflow).ToStringForStore())
+}
+
+func TestCreateRun_ServiceAccountSAR_TemplateSA_Unauthorized_NoWorkflowCreated(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+	defer store.Close()
+
+	_, err := manager.CreateRun(multiUserContext(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa"),
+			Parameters:           `[{"name":"param1","value":"world"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when a template SA is unauthorized")
+}
+
+func TestCreateRun_ServiceAccountSAR_PluginMutationUnauthorized_CleansUpPlugins(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "plugin-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+	defer store.Close()
+	dispatcher := &serviceAccountMutatingDispatcher{
+		output: apiservermlflow.SuccessfulPluginOutput("exp-1", "experiment", "parent-run-1", "https://mlflow.example/runs/parent-run-1"),
+	}
+	manager.pluginDispatcher = dispatcher
+
+	run := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           `[{"name":"param1","value":"world"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	}
+	_, err := manager.CreateRun(multiUserContext(), run)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created after an unauthorized plugin mutation")
+	require.NotEmpty(t, run.UUID)
+	_, err = manager.GetRun(run.UUID)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound), "a rejected run should not be persisted")
+	require.Len(t, dispatcher.endedRuns, 1, "plugin resources must be cleaned up after post-hook authorization fails")
+	assert.Equal(t, run.UUID, dispatcher.endedRuns[0].RunID)
+	assert.True(t, proto.Equal(dispatcher.output, dispatcher.endedRuns[0].PluginsOutput[apiservermlflow.PluginName]), "cleanup must receive the output identifying the plugin resources")
+}
+
+func TestCreateJob_ServiceAccountSAR_TemplateSA_Unauthorized_NoScheduledWorkflowCreated(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	tests := []struct {
+		name, mode string
+	}{
+		{name: "pinned workflow", mode: "pinned"},
+		{name: "pinned workflow with plugins", mode: "plugins"},
+		{name: "latest pipeline version", mode: "latest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			if tt.mode == "plugins" {
+				manager.pluginDispatcher = &countingTerminalReportDispatcher{}
+			}
+			pipelineSpec := model.PipelineSpec{WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa")}
+			if tt.mode == "latest" {
+				pipeline, err := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+				require.NoError(t, err)
+				_, err = manager.CreatePipelineVersion(createPipelineVersion(
+					pipeline.UUID, "p1/v1", "v1", "", string(pipelineSpec.WorkflowSpecManifest), "", "ns1",
+				))
+				require.NoError(t, err)
+				pipelineSpec = model.PipelineSpec{PipelineId: pipeline.UUID}
+			}
+
+			_, err := manager.CreateJob(multiUserContext(), &model.Job{
+				DisplayName:  "j1",
+				Enabled:      true,
+				PipelineSpec: pipelineSpec,
+				ExperimentId: experiment.UUID,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Unauthorized")
+			_, getErr := store.SwfClient().ScheduledWorkflow("ns1").Get(context.Background(), "job-", v1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(getErr), "no ScheduledWorkflow CRD should be created when a template SA is unauthorized")
+		})
+	}
+}
+
+func TestCreateRun_ParameterizedPodSpecPatch_NoWorkflowCreated(t *testing.T) {
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+
+	workflow := testWorkflow.DeepCopy()
+	workflow.Spec.PodSpecPatch = `{"serviceAccountName":"{{workflow.parameters.param1}}"}`
+	_, err := manager.CreateRun(context.Background(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+			Parameters:           `[{"name":"param1","value":"pipeline-runner"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "podSpecPatch contains a template expression")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when a podSpecPatch cannot be authorized")
+}
+
+func TestCreateRun_V2ExternalTemplateReference_NoWorkflowCreated(t *testing.T) {
+	viper.Set(common.CompiledPipelineSpecPatch, `{"workflowTemplateRef":{"name":"external"}}`)
+	defer viper.Set(common.CompiledPipelineSpecPatch, "")
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+
+	_, err := manager.CreateRun(context.Background(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+			RuntimeConfig:        model.RuntimeConfig{Parameters: `{"text":"world"}`},
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external workflow template references")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
 }
 
 // --- SA embedded in workflow spec ---

--- a/backend/src/apiserver/resource/resource_manager_workflow_status_internal_test.go
+++ b/backend/src/apiserver/resource/resource_manager_workflow_status_internal_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	apiservermlflow "github.com/kubeflow/pipelines/backend/src/apiserver/plugins/mlflow"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func statusWithCachedServiceAccount(storedSpec bool) v1alpha1.WorkflowStatus {
+	tmpl := *testWorkflow.Spec.Templates[0].DeepCopy()
+	tmpl.Name = "cached-step"
+	status := v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowSucceeded}
+	if storedSpec {
+		status.StoredWorkflowSpec = &v1alpha1.WorkflowSpec{
+			ServiceAccountName: "cached-sa",
+			Templates:          []v1alpha1.Template{tmpl},
+		}
+	} else {
+		tmpl.ServiceAccountName = "cached-sa"
+		status.StoredTemplates = map[string]v1alpha1.Template{"cached-step": tmpl}
+	}
+	return status
+}
+
+func TestCreateRunAndJob_DiscardCallerWorkflowStatus(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	viper.Set(common.AllowedServiceAccountsFlag, "cached-sa")
+	t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, "") })
+
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, recurring := range []bool{false, true} {
+				kind := "run"
+				if recurring {
+					kind = "recurring run"
+				}
+				t.Run(kind, func(t *testing.T) {
+					store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+					defer store.Close()
+					workflow := testWorkflow.DeepCopy()
+					workflow.Status = statusWithCachedServiceAccount(storedSpec)
+					pipelineSpec := model.PipelineSpec{
+						WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+						Parameters:           `[{"name":"param1","value":"world"}]`,
+					}
+					var executionSpec util.ExecutionSpec
+					if recurring {
+						job, err := manager.CreateJob(multiUserContext(), &model.Job{
+							DisplayName: "j1", Enabled: true, ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec,
+						})
+						require.NoError(t, err)
+						schedule, err := store.SwfClient().ScheduledWorkflow(job.Namespace).Get(context.Background(), job.K8SName, metav1.GetOptions{})
+						require.NoError(t, err)
+						executionSpec, err = util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, schedule.Spec.Workflow)
+						require.NoError(t, err)
+					} else {
+						run, err := manager.CreateRun(multiUserContext(), &model.Run{
+							DisplayName: "run1", ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec,
+						})
+						require.NoError(t, err)
+						executionSpec, err = store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+						require.NoError(t, err)
+					}
+					assert.Equal(t, v1alpha1.WorkflowStatus{}, executionSpec.(*util.Workflow).Status)
+					assert.Equal(t, "testy", executionSpec.(*util.Workflow).Spec.Entrypoint)
+				})
+			}
+		})
+	}
+}
+
+func TestCreateRun_RejectsStatusOnlyEntrypoint(t *testing.T) {
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, manager, experiment := initWithExperiment(t)
+			defer store.Close()
+			workflow := testWorkflow.DeepCopy()
+			workflow.Spec.Entrypoint = "cached-step"
+			workflow.Status = statusWithCachedServiceAccount(storedSpec)
+			run := &model.Run{
+				DisplayName: "run1", ExperimentId: experiment.UUID,
+				PipelineSpec: model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"world"}]`,
+				},
+			}
+			_, err := manager.CreateRun(context.Background(), run)
+			require.ErrorContains(t, err, "cached-step")
+			assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+			_, err = manager.GetRun(run.UUID)
+			assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+		})
+	}
+}
+
+func TestRetryRun_AuthorizesAndPreservesCachedWorkflowTemplates(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "cached-sa")
+	t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, "") })
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, authorized := range []bool{false, true} {
+				verdict := "denied"
+				if authorized {
+					verdict = "authorized"
+				}
+				t.Run(verdict, func(t *testing.T) {
+					store, manager, run := initWithOneTimeFailedRun(t)
+					defer store.Close()
+					run, err := manager.GetRun(run.UUID)
+					require.NoError(t, err)
+					workflow, err := util.NewWorkflowFromBytesJSON([]byte(run.WorkflowRuntimeManifest))
+					require.NoError(t, err)
+					require.NoError(t, workflow.Decompress())
+					cached := statusWithCachedServiceAccount(storedSpec)
+					workflow.Status.StoredTemplates = cached.StoredTemplates
+					workflow.Status.StoredWorkflowSpec = cached.StoredWorkflowSpec
+					syncWorkflowReportWithFakeCluster(t, store, workflow)
+					run.WorkflowRuntimeManifest = model.LargeText(workflow.ToStringForStore())
+					require.NoError(t, manager.runStore.UpdateRun(run))
+					before, err := manager.GetRun(run.UUID)
+					require.NoError(t, err)
+					liveBefore, err := store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+					beforeManifest := liveBefore.ToStringForStore()
+
+					viper.Set(common.MultiUserMode, "true")
+					t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+					if authorized {
+						manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClient()
+					} else {
+						manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+						manager.k8sCoreClient = client.NewFakeKubernetesCoreClientWithBadPodClient()
+					}
+					err = manager.RetryRun(multiUserContext(), run.UUID)
+					if authorized {
+						require.NoError(t, err)
+					} else {
+						require.ErrorContains(t, err, "Unauthorized")
+					}
+					after, err := manager.GetRun(run.UUID)
+					require.NoError(t, err)
+					liveAfter, err := store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+					if !authorized {
+						assert.Equal(t, before, after, "authorization must precede the retry claim")
+						assert.Equal(t, beforeManifest, liveAfter.ToStringForStore())
+						return
+					}
+					assert.Equal(t, model.RuntimeStateRunning, after.State)
+					assert.Equal(t, v1alpha1.WorkflowRunning, liveAfter.(*util.Workflow).Status.Phase)
+					assert.Equal(t, cached.StoredTemplates, liveAfter.(*util.Workflow).Status.StoredTemplates)
+					assert.Equal(t, cached.StoredWorkflowSpec, liveAfter.(*util.Workflow).Status.StoredWorkflowSpec)
+				})
+			}
+		})
+	}
+}
+
+type cachedTemplateMutatingDispatcher struct {
+	serviceAccountMutatingDispatcher
+	storedSpec bool
+}
+
+func (d *cachedTemplateMutatingDispatcher) OnBeforeRunCreation(_ context.Context, run *apiserverPlugins.PendingRun, executionSpec util.ExecutionSpec) error {
+	executionSpec.(*util.Workflow).Status = statusWithCachedServiceAccount(d.storedSpec)
+	return apiserverPlugins.SetPendingRunPluginOutput(run, apiservermlflow.PluginName, d.output)
+}
+
+func TestCreateRun_PluginCachedTemplateUnauthorizedCleansUp(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	viper.Set(common.AllowedServiceAccountsFlag, "cached-sa")
+	t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, "") })
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			dispatcher := &cachedTemplateMutatingDispatcher{
+				serviceAccountMutatingDispatcher: serviceAccountMutatingDispatcher{
+					output: apiservermlflow.SuccessfulPluginOutput("exp-1", "experiment", "parent-run-1", "https://mlflow.example/runs/parent-run-1"),
+				},
+				storedSpec: storedSpec,
+			}
+			manager.pluginDispatcher = dispatcher
+			run := &model.Run{
+				DisplayName: "run1", ExperimentId: experiment.UUID,
+				PipelineSpec: model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"world"}]`,
+				},
+			}
+			_, err := manager.CreateRun(multiUserContext(), run)
+			require.ErrorContains(t, err, "Unauthorized")
+			assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+			_, err = manager.GetRun(run.UUID)
+			assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+			require.Len(t, dispatcher.endedRuns, 1)
+			assert.Equal(t, run.UUID, dispatcher.endedRuns[0].RunID)
+			assert.True(t, proto.Equal(dispatcher.output, dispatcher.endedRuns[0].PluginsOutput[apiservermlflow.PluginName]))
+		})
+	}
+}

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
@@ -314,6 +315,8 @@ func TestCreateJob_pipelineVersion(t *testing.T) {
 	job, err := server.CreateJob(nil, &apiv1beta1.CreateJobRequest{Job: apiJob})
 	assert.Nil(t, err)
 
+	expectedWorkflow := testWorkflow.DeepCopy()
+	expectedWorkflow.Status = v1alpha1.WorkflowStatus{}
 	expectedJob := &apiv1beta1.Job{
 		Id:             "123e4567-e89b-12d3-a456-426655440000",
 		Name:           "job1",
@@ -330,7 +333,7 @@ func TestCreateJob_pipelineVersion(t *testing.T) {
 		PipelineSpec: &apiv1beta1.PipelineSpec{
 			PipelineId:       "123e4567-e89b-12d3-a456-426655440000",
 			PipelineName:     "p1",
-			WorkflowManifest: testWorkflow.ToStringForStore(),
+			WorkflowManifest: util.NewWorkflow(expectedWorkflow).ToStringForStore(),
 		},
 	}
 	matched := 0

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -268,7 +268,9 @@ func TestCreateRunV1_Manifest_and_pipeline_version(t *testing.T) {
 	assert.Equal(t, DefaultFakeUUID, runDetail.Run.PipelineSpec.PipelineId)
 	assert.Equal(t, apiv1beta1.ResourceType_EXPERIMENT, runDetail.Run.ResourceReferences[0].Key.Type)
 	assert.Equal(t, exp.UUID, runDetail.Run.ResourceReferences[0].Key.Id)
-	assert.Equal(t, testWorkflow.ToStringForStore(), runDetail.Run.PipelineSpec.WorkflowManifest)
+	expectedWorkflow := testWorkflow.DeepCopy()
+	expectedWorkflow.Status = v1alpha1.WorkflowStatus{}
+	assert.Equal(t, util.NewWorkflow(expectedWorkflow).ToStringForStore(), runDetail.Run.PipelineSpec.WorkflowManifest)
 }
 
 func TestCreateRunV1_V1Params(t *testing.T) {
@@ -287,6 +289,7 @@ func TestCreateRunV1_V1Params(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.Status = v1alpha1.WorkflowStatus{}
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{
@@ -794,6 +797,7 @@ func TestCreateRunV1_Multiuser(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.Status = v1alpha1.WorkflowStatus{}
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{

--- a/backend/src/apiserver/template/argo_status_test.go
+++ b/backend/src/apiserver/template/argo_status_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template_test
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestArgoFreshWorkflowsDiscardSubmittedStatus(t *testing.T) {
+	wf := &workflowapi.Workflow{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Workflow"},
+		ObjectMeta: metav1.ObjectMeta{Name: "fresh"},
+		Spec: workflowapi.WorkflowSpec{Entrypoint: "main", Templates: []workflowapi.Template{{
+			Name: "main", Container: &corev1.Container{Image: "alpine"},
+		}}},
+		Status: workflowapi.WorkflowStatus{
+			Phase:              workflowapi.WorkflowRunning,
+			StoredTemplates:    map[string]workflowapi.Template{"stored": {Name: "stored", ServiceAccountName: "unauthorized"}},
+			StoredWorkflowSpec: &workflowapi.WorkflowSpec{ServiceAccountName: "unauthorized"},
+		},
+	}
+	original := wf.DeepCopy()
+	data, err := yaml.Marshal(wf)
+	require.NoError(t, err)
+	validated, err := template.ValidateWorkflow(data)
+	require.NoError(t, err)
+	assert.Empty(t, validated.Status)
+
+	// The direct constructor bypasses manifest validation; both execution paths
+	// must still discard status without changing the reusable source template.
+	tmpl, err := template.NewArgoTemplateFromWorkflow(wf)
+	require.NoError(t, err)
+	run, err := tmpl.RunWorkflow(&model.Run{}, template.RunWorkflowOptions{RunID: "fresh-run"})
+	require.NoError(t, err)
+	assert.Empty(t, run.(*util.Workflow).Status)
+	job, err := tmpl.ScheduledWorkflow(&model.Job{UUID: "fresh-job"})
+	require.NoError(t, err)
+	require.IsType(t, "", job.Spec.Workflow.Spec)
+	scheduled, err := util.NewWorkflowFromScheduleWorkflowSpecBytesJSON([]byte(job.Spec.Workflow.Spec.(string)))
+	require.NoError(t, err)
+	assert.Empty(t, scheduled.Status)
+	assert.Equal(t, original, wf)
+}

--- a/backend/src/apiserver/template/argo_template.go
+++ b/backend/src/apiserver/template/argo_template.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
-	"github.com/argoproj/argo-workflows/v4/workflow/validate"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -28,6 +27,7 @@ import (
 
 func (t *Argo) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (util.ExecutionSpec, error) {
 	workflow := util.NewWorkflow(t.wf.Workflow.DeepCopy())
+	workflow.Status = workflowapi.WorkflowStatus{}
 
 	// Overwrite namespace from the run object
 	if modelRun.Namespace != "" {
@@ -101,6 +101,7 @@ var _ Template = &Argo{}
 
 func (t *Argo) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
 	workflow := util.NewWorkflow(t.wf.Workflow.DeepCopy())
+	workflow.Status = workflowapi.WorkflowStatus{}
 	// Overwrite namespace from the job object
 	if modelJob.Namespace != "" {
 		workflow.SetExecutionNamespace(modelJob.Namespace)
@@ -217,15 +218,15 @@ func ValidateWorkflow(template []byte) (*util.Workflow, error) {
 	if wf.Kind != argoK8sResource {
 		return nil, util.NewInvalidInputError("Unexpected resource type. Expected: %v. Received: %v", argoK8sResource, wf.Kind)
 	}
-	err = validate.Workflow(util.ArgoContext(), nil, nil, &wf, nil, validate.Opts{
-		Lint:                       true,
-		IgnoreEntrypoint:           true,
-		WorkflowTemplateValidation: false, // not used by kubeflow
-	})
+	// Status belongs to Argo, not the submitted pipeline. In particular, its
+	// cached templates must not participate in fresh workflow validation.
+	wf.Status = workflowapi.WorkflowStatus{}
+	workflow := util.NewWorkflow(&wf)
+	err = workflow.Validate(true, true)
 	if err != nil {
 		return nil, err
 	}
-	return util.NewWorkflow(&wf), nil
+	return workflow, nil
 }
 
 func AddRuntimeMetadata(wf *workflowapi.Workflow) {

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -68,6 +68,31 @@ func TestValidateWorkflow_ParametersTooLong(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, err.(*commonutil.UserError).ExternalStatusCode())
 }
 
+func TestValidateWorkflow_RejectsExternalTemplateReference(t *testing.T) {
+	wf := v1alpha1.Workflow{
+		TypeMeta: metav1.TypeMeta{APIVersion: argoVersion, Kind: argoK8sResource},
+		Spec: v1alpha1.WorkflowSpec{
+			WorkflowTemplateRef: &v1alpha1.WorkflowTemplateRef{Name: "external-template"},
+		},
+	}
+	templateBytes, err := yaml.Marshal(wf)
+	require.NoError(t, err)
+
+	_, err = ValidateWorkflow(templateBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external workflow template references cannot be authorized")
+}
+
+func TestValidateWorkflow_AllowsParameterizedPodSpecPatch(t *testing.T) {
+	wf := unmarshalWf(awfTemplate)
+	wf.Spec.Templates[0].PodSpecPatch = `serviceAccountName: "{{inputs.parameters.dup}}"`
+	templateBytes, err := yaml.Marshal(wf)
+	require.NoError(t, err)
+
+	_, err = ValidateWorkflow(templateBytes)
+	require.NoError(t, err)
+}
+
 func TestParseSpecFormat(t *testing.T) {
 	tt := []struct {
 		template     string

--- a/backend/src/common/util/execution_spec.go
+++ b/backend/src/common/util/execution_spec.go
@@ -97,6 +97,9 @@ type ExecutionSpec interface {
 	// Get ServiceAccountName
 	ServiceAccount() string
 
+	// ServiceAccounts returns every service account the execution can use.
+	ServiceAccounts(allowCompilerPodSpecPatch bool) ([]string, error)
+
 	// Get ExecutionStatus which can be used to
 	// access status related information
 	ExecutionStatus() ExecutionStatus

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -45,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/yaml"
 )
@@ -170,6 +172,282 @@ func (w *Workflow) SetServiceAccount(serviceAccount string) {
 
 func (w *Workflow) ServiceAccount() string {
 	return w.Spec.ServiceAccountName
+}
+
+func (w *Workflow) walkTemplates(visit func(*workflowapi.Template) error) error {
+	hasReference := func(ref *workflowapi.TemplateRef, hooks workflowapi.LifecycleHooks) bool {
+		if ref != nil {
+			return true
+		}
+		for _, hook := range hooks {
+			if hook.TemplateRef != nil {
+				return true
+			}
+		}
+		return false
+	}
+	referenceError := func() error {
+		return NewInvalidInputError("external workflow template references cannot be authorized; inline the referenced template")
+	}
+
+	var walk func(*workflowapi.Template) error
+	walk = func(tmpl *workflowapi.Template) error {
+		if tmpl == nil {
+			return nil
+		}
+		if visit != nil {
+			if err := visit(tmpl); err != nil {
+				return err
+			}
+		}
+		for i := range tmpl.Steps {
+			for j := range tmpl.Steps[i].Steps {
+				step := &tmpl.Steps[i].Steps[j]
+				if hasReference(step.TemplateRef, step.Hooks) {
+					return referenceError()
+				}
+				if err := walk(step.Inline); err != nil {
+					return err
+				}
+			}
+		}
+		if tmpl.DAG != nil {
+			for i := range tmpl.DAG.Tasks {
+				task := &tmpl.DAG.Tasks[i]
+				if hasReference(task.TemplateRef, task.Hooks) {
+					return referenceError()
+				}
+				if err := walk(task.Inline); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	for _, spec := range []*workflowapi.WorkflowSpec{&w.Spec, w.Status.StoredWorkflowSpec} {
+		if spec == nil {
+			continue
+		}
+		if spec.WorkflowTemplateRef != nil || hasReference(nil, spec.Hooks) {
+			return referenceError()
+		}
+		if err := walk(spec.TemplateDefaults); err != nil {
+			return err
+		}
+		for i := range spec.Templates {
+			if err := walk(&spec.Templates[i]); err != nil {
+				return err
+			}
+		}
+	}
+	for _, tmpl := range w.Status.StoredTemplates {
+		if err := walk(&tmpl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateNoExternalTemplateReferences rejects template references because KFP
+// does not resolve them while validating or authorizing a workflow.
+func (w *Workflow) validateNoExternalTemplateReferences() error {
+	return w.walkTemplates(nil)
+}
+
+// ServiceAccounts returns every service account that pods created by the
+// workflow can use.
+func (w *Workflow) ServiceAccounts(allowCompilerPodSpecPatch bool) ([]string, error) {
+	workflowAccount := w.Spec.ServiceAccountName
+	if workflowAccount == "" {
+		workflowAccount = "default"
+	}
+	accounts := make([]string, 0, len(w.Spec.Templates)+1)
+	seen := make(map[string]struct{}, len(w.Spec.Templates)+1)
+	add := func(account string) {
+		if account == workflowServiceAccountTemplate {
+			account = workflowAccount
+		}
+		if account == "" {
+			return
+		}
+		if _, ok := seen[account]; ok {
+			return
+		}
+		seen[account] = struct{}{}
+		accounts = append(accounts, account)
+	}
+	addPatch := func(patch string) error {
+		patchAccounts, err := serviceAccountsInPodSpecPatch(patch, allowCompilerPodSpecPatch)
+		if err != nil {
+			return err
+		}
+		for _, account := range patchAccounts {
+			add(account)
+		}
+		return nil
+	}
+	add(workflowAccount)
+	if w.Spec.Executor != nil {
+		add(w.Spec.Executor.ServiceAccountName)
+	}
+	for _, plugin := range w.Spec.ExecutorPlugins {
+		if plugin.Spec.Sidecar.AutomountServiceAccountToken {
+			add(plugin.Name + "-executor-plugin")
+		}
+	}
+	if err := addPatch(w.Spec.PodSpecPatch); err != nil {
+		return nil, err
+	}
+
+	var artifactGCPatchAccounts []string
+	artifactGCPatchInspected := false
+
+	visitArtifacts := func(artifacts []workflowapi.Artifact) error {
+		for i := range artifacts {
+			artifact := &artifacts[i]
+			strategy := w.GetArtifactGCStrategy(artifact)
+			if strategy == workflowapi.ArtifactGCNever || strategy == workflowapi.ArtifactGCStrategyUndefined {
+				continue
+			}
+			account := ""
+			if w.Spec.ArtifactGC != nil {
+				account = w.Spec.ArtifactGC.ServiceAccountName
+			}
+			if artifact.ArtifactGC != nil && artifact.ArtifactGC.ServiceAccountName != "" {
+				account = artifact.ArtifactGC.ServiceAccountName
+			}
+			if account != "" {
+				add(account)
+				continue
+			}
+			if !artifactGCPatchInspected {
+				artifactGCPatchInspected = true
+				if w.Spec.ArtifactGC != nil {
+					var err error
+					artifactGCPatchAccounts, err = serviceAccountsInPodSpecPatch(w.Spec.ArtifactGC.PodSpecPatch, allowCompilerPodSpecPatch)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			if len(artifactGCPatchAccounts) == 0 {
+				add("default")
+			}
+			for _, patchAccount := range artifactGCPatchAccounts {
+				add(patchAccount)
+			}
+		}
+		return nil
+	}
+
+	visitTemplate := func(tmpl *workflowapi.Template) error {
+		add(tmpl.ServiceAccountName)
+		if tmpl.Executor != nil {
+			add(tmpl.Executor.ServiceAccountName)
+		}
+		if err := addPatch(tmpl.PodSpecPatch); err != nil {
+			return err
+		}
+		return visitArtifacts(tmpl.Outputs.Artifacts)
+	}
+
+	if err := w.walkTemplates(visitTemplate); err != nil {
+		return nil, err
+	}
+	// Argo also schedules artifact-GC pods from retained node outputs on retry.
+	for _, node := range w.Status.Nodes {
+		if node.Type == workflowapi.NodeTypePod && node.Outputs != nil {
+			if err := visitArtifacts(node.Outputs.Artifacts); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if storedSpec := w.Status.StoredWorkflowSpec; storedSpec != nil {
+		// Retried workflows retain Argo's cached spec. Inspect its own defaults
+		// as well as the submitted spec, including helpers for cached templates.
+		storedWorkflow := NewWorkflow(&workflowapi.Workflow{
+			Spec: *storedSpec,
+			Status: workflowapi.WorkflowStatus{
+				StoredTemplates: w.Status.StoredTemplates,
+				Nodes:           w.Status.Nodes,
+			},
+		})
+		storedAccounts, err := storedWorkflow.ServiceAccounts(allowCompilerPodSpecPatch)
+		if err != nil {
+			return nil, err
+		}
+		for _, account := range storedAccounts {
+			add(account)
+		}
+	}
+	return accounts, nil
+}
+
+const (
+	workflowServiceAccountTemplate        = "{{workflow.serviceAccountName}}"
+	podSpecPatchServiceAccountSentinel    = "<unchanged>" // Invalid as a Kubernetes service account name.
+	compilerGeneratedPodSpecPatchTemplate = "{{inputs.parameters.pod-spec-patch}}"
+)
+
+func serviceAccountsInPodSpecPatch(patch string, allowCompilerPatch bool) ([]string, error) {
+	if patch == "" {
+		return nil, nil
+	}
+	if strings.Contains(patch, "{{") {
+		if allowCompilerPatch && strings.TrimSpace(patch) == compilerGeneratedPodSpecPatchTemplate {
+			return nil, nil
+		}
+		return nil, NewInvalidInputError("podSpecPatch contains a template expression, so its service account cannot be authorized before execution; use a literal podSpecPatch")
+	}
+
+	// Argo preserves JSON input before validating it with encoding/json.
+	patchJSON := []byte(patch)
+	if !strings.HasPrefix(strings.TrimSpace(patch), "{") {
+		var err error
+		patchJSON, err = yaml.YAMLToJSON(patchJSON)
+		if err != nil {
+			return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+		}
+	}
+	// Case variants can be hidden by an inherited canonical field and exposed
+	// when a later template patch removes it, before Argo's case-folding decode.
+	var fields map[string]stdjson.RawMessage
+	if err := stdjson.Unmarshal(patchJSON, &fields); err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+	for field := range fields {
+		for _, canonical := range []string{"serviceAccountName", "serviceAccount"} {
+			if field != canonical && strings.EqualFold(field, canonical) {
+				return nil, NewInvalidInputError("podSpecPatch field %q has a noncanonical service account spelling; use %q", field, canonical)
+			}
+		}
+	}
+	if err := stdjson.Unmarshal(patchJSON, &corev1.PodSpec{}); err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+	baseJSON := []byte(`{"serviceAccountName":"` + podSpecPatchServiceAccountSentinel + `"}`)
+	patchedJSON, err := strategicpatch.StrategicMergePatch(baseJSON, patchJSON, corev1.PodSpec{})
+	if err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+	var patched corev1.PodSpec
+	if err := stdjson.Unmarshal(patchedJSON, &patched); err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+
+	var accounts []string
+	canonicalTouched := patched.ServiceAccountName != podSpecPatchServiceAccountSentinel
+	if canonicalTouched && patched.ServiceAccountName != "" {
+		accounts = append(accounts, patched.ServiceAccountName)
+	}
+	if patched.DeprecatedServiceAccount != "" {
+		accounts = append(accounts, patched.DeprecatedServiceAccount)
+	}
+	if canonicalTouched && patched.ServiceAccountName == "" && patched.DeprecatedServiceAccount == "" {
+		accounts = append(accounts, "default")
+	}
+	return accounts, nil
 }
 
 func (w *Workflow) SpecParameters() SpecParameters {
@@ -814,6 +1092,11 @@ func (w *Workflow) IsV2Compatible() bool {
 }
 
 func (w *Workflow) Validate(lint, ignoreEntrypoint bool) error {
+	// Argo validation receives no external-template getters, so reject
+	// references instead of allowing validation to dereference a nil getter.
+	if err := w.validateNoExternalTemplateReferences(); err != nil {
+		return err
+	}
 	err := validate.Workflow(ArgoContext(), nil, nil, w.Workflow, nil, validate.Opts{
 		Lint:                       lint,
 		IgnoreEntrypoint:           ignoreEntrypoint,

--- a/backend/src/common/util/workflow_pod_spec_patch_internal_test.go
+++ b/backend/src/common/util/workflow_pod_spec_patch_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceAccountsInPodSpecPatchRejectsNoncanonicalFields(t *testing.T) {
+	tests := []struct {
+		name, patch string
+	}{
+		{name: "lowercase JSON", patch: `{"serviceaccountname":"privileged-sa"}`},
+		{name: "mixed case YAML", patch: `serviceAccountname: privileged-sa`},
+		{name: "uppercase with replacement", patch: "$patch: replace\nServiceAccountName: privileged-sa"},
+		{name: "conflicting spellings", patch: `{"serviceAccountName":"allowed-sa","serviceaccountname":"privileged-sa"}`},
+		{name: "Unicode case folding", patch: `{"ſerviceAccountName":"privileged-sa"}`},
+		{name: "deprecated alias", patch: `{"ServiceAccount":"privileged-sa"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := serviceAccountsInPodSpecPatch(tt.patch, false)
+			require.ErrorContains(t, err, "canonical")
+		})
+	}
+}
+
+func TestWorkflow_ServiceAccountsRejectsAccountHiddenUntilTemplatePatch(t *testing.T) {
+	workflowPatch := `{"ServiceAccountName":"privileged-sa"}`
+	templatePatch := `serviceAccountName: null`
+	// Argo merges both patches before decoding: deleting the canonical field
+	// exposes ServiceAccountName, which its decoder accepts as privileged-sa.
+	w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+		ServiceAccountName: "allowed-sa",
+		PodSpecPatch:       workflowPatch,
+		Templates:          []workflowapi.Template{{PodSpecPatch: templatePatch}},
+	}})
+	_, err := w.ServiceAccounts(false)
+	require.ErrorContains(t, err, "canonical")
+}
+
+func TestServiceAccountsInPodSpecPatchPreservesArgoJSONValidation(t *testing.T) {
+	// Argo validates the original JSON before merging, including overwritten fields.
+	patch := `{"serviceAccountName":[],"serviceAccountName":"allowed-sa"}`
+	_, err := serviceAccountsInPodSpecPatch(patch, false)
+	require.ErrorContains(t, err, "valid Kubernetes PodSpec patch")
+}

--- a/backend/src/common/util/workflow_stored_status_test.go
+++ b/backend/src/common/util/workflow_stored_status_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWorkflowServiceAccountsIncludesStoredExecutionState(t *testing.T) {
+	w := util.NewWorkflow(&workflowapi.Workflow{
+		Spec: workflowapi.WorkflowSpec{ServiceAccountName: "submitted-sa"},
+		Status: workflowapi.WorkflowStatus{
+			StoredWorkflowSpec: &workflowapi.WorkflowSpec{
+				ServiceAccountName: "stored-workflow-sa",
+				Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "stored-executor-sa"},
+				PodSpecPatch:       `serviceAccountName: stored-patch-sa`,
+				ExecutorPlugins: []workflowapi.ExecutorPlugin{{
+					ObjectMeta: metav1.ObjectMeta{Name: "stored"},
+					Spec:       workflowapi.ExecutorPluginSpec{Sidecar: workflowapi.ExecutorPluginSidecar{AutomountServiceAccountToken: true}},
+				}},
+				TemplateDefaults: &workflowapi.Template{
+					ServiceAccountName: "{{workflow.serviceAccountName}}",
+					Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "stored-default-executor-sa"},
+				},
+				Templates: []workflowapi.Template{{Name: "stored", ServiceAccountName: "stored-template-sa"}},
+				ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+					ArtifactGC: workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion, ServiceAccountName: "stored-gc-sa"},
+				},
+			},
+			StoredTemplates: map[string]workflowapi.Template{
+				"local/mapped": {
+					Name: "mapped", ServiceAccountName: "mapped-sa",
+					Steps: []workflowapi.ParallelSteps{{Steps: []workflowapi.WorkflowStep{{
+						Name: "inline", Inline: &workflowapi.Template{ServiceAccountName: "inline-sa"},
+					}}}},
+					Outputs: workflowapi.Outputs{Artifacts: workflowapi.Artifacts{{Name: "cached-output"}}},
+				},
+			},
+			Nodes: workflowapi.Nodes{
+				"succeeded": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeSucceeded, Outputs: &workflowapi.Outputs{
+					Artifacts: workflowapi.Artifacts{
+						{Name: "inherited-gc"},
+						{Name: "override-gc", ArtifactGC: &workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowDeletion, ServiceAccountName: "node-gc-sa"}},
+						{Name: "inactive", ArtifactGC: &workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCNever, ServiceAccountName: "inactive-sa"}},
+					},
+				}},
+			},
+		},
+	})
+	original := w.DeepCopy()
+	accounts, err := w.ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"submitted-sa", "stored-workflow-sa", "stored-executor-sa", "stored-patch-sa", "stored-executor-plugin",
+		"stored-default-executor-sa", "stored-template-sa", "mapped-sa", "inline-sa", "stored-gc-sa", "node-gc-sa",
+	}, accounts)
+	assert.Equal(t, original, w.Workflow, "authorization must not discard retry state")
+}
+
+func TestWorkflowServiceAccountsRejectsUnsafeStoredTemplates(t *testing.T) {
+	for _, location := range []string{"stored templates", "stored workflow templates", "stored defaults"} {
+		t.Run(location, func(t *testing.T) {
+			for _, kind := range []string{"external reference", "dynamic patch"} {
+				t.Run(kind, func(t *testing.T) {
+					tmpl := workflowapi.Template{Name: "stored"}
+					wantError := "external workflow template references"
+					if kind == "external reference" {
+						tmpl.DAG = &workflowapi.DAGTemplate{Tasks: []workflowapi.DAGTask{{TemplateRef: &workflowapi.TemplateRef{Name: "external", Template: "task"}}}}
+					} else {
+						tmpl.PodSpecPatch = `serviceAccountName: "{{workflow.parameters.account}}"`
+						wantError = "podSpecPatch contains a template expression"
+					}
+					w := util.NewWorkflow(&workflowapi.Workflow{})
+					switch location {
+					case "stored templates":
+						w.Status.StoredTemplates = map[string]workflowapi.Template{"stored": tmpl}
+					case "stored workflow templates":
+						w.Status.StoredWorkflowSpec = &workflowapi.WorkflowSpec{Templates: []workflowapi.Template{tmpl}}
+					case "stored defaults":
+						w.Status.StoredWorkflowSpec = &workflowapi.WorkflowSpec{TemplateDefaults: &tmpl}
+					}
+					_, err := w.ServiceAccounts(false)
+					require.ErrorContains(t, err, wantError)
+				})
+			}
+		})
+	}
+}
+
+func TestWorkflowServiceAccountsChecksStoredNodeArtifactGCDefaults(t *testing.T) {
+	w := util.NewWorkflow(&workflowapi.Workflow{Status: workflowapi.WorkflowStatus{
+		StoredWorkflowSpec: &workflowapi.WorkflowSpec{ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+			ArtifactGC:   workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion},
+			PodSpecPatch: `serviceAccountName: cached-gc-sa`,
+		}},
+		Nodes: workflowapi.Nodes{"retained": {Type: workflowapi.NodeTypePod, Outputs: &workflowapi.Outputs{
+			Artifacts: workflowapi.Artifacts{{Name: "output"}},
+		}}},
+	}})
+	accounts, err := w.ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"default", "cached-gc-sa"}, accounts)
+	w.Status.StoredWorkflowSpec.ArtifactGC.PodSpecPatch = `{{workflow.parameters.gc-patch}}`
+	_, err = w.ServiceAccounts(false)
+	require.ErrorContains(t, err, "podSpecPatch contains a template expression")
+}

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2987,3 +2987,220 @@ func TestReadNodeMetricsOrNil_MaxResponseBytesPropagation(t *testing.T) {
 	assert.Contains(t, err.Error(), "sentinel stop here")
 	assert.Equal(t, 1, callCount, "mock must be invoked exactly once")
 }
+
+func TestWorkflow_ServiceAccountsCollectsPodIdentities(t *testing.T) {
+	dagInline := &workflowapi.Template{ServiceAccountName: "dag-inline-sa"}
+	stepInline := &workflowapi.Template{
+		ServiceAccountName: "step-inline-sa",
+		DAG: &workflowapi.DAGTemplate{Tasks: []workflowapi.DAGTask{{
+			Name:   "nested-task",
+			Inline: dagInline,
+		}}},
+	}
+	rootTemplate := workflowapi.Template{
+		Name:               "root",
+		ServiceAccountName: "{{workflow.serviceAccountName}}", // Resolves to, and de-duplicates, the workflow account.
+		Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "template-executor-sa"},
+		PodSpecPatch:       `serviceAccountName: template-patch-sa`,
+		Steps: []workflowapi.ParallelSteps{{Steps: []workflowapi.WorkflowStep{{
+			Name:   "nested-step",
+			Inline: stepInline,
+		}}}},
+	}
+	w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+		ServiceAccountName: "workflow-sa",
+		Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "workflow-executor-sa"},
+		PodSpecPatch:       `serviceAccountName: workflow-patch-sa`,
+		ExecutorPlugins: []workflowapi.ExecutorPlugin{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "token"},
+				Spec:       workflowapi.ExecutorPluginSpec{Sidecar: workflowapi.ExecutorPluginSidecar{AutomountServiceAccountToken: true}},
+			},
+			{ObjectMeta: metav1.ObjectMeta{Name: "no-token"}},
+		},
+		TemplateDefaults: &workflowapi.Template{
+			ServiceAccountName: "defaults-sa",
+			Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "defaults-executor-sa"},
+			PodSpecPatch:       `serviceAccountName: defaults-patch-sa`,
+		},
+		Templates: []workflowapi.Template{rootTemplate},
+	}})
+
+	accounts, err := w.ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"workflow-sa",
+		"workflow-executor-sa",
+		"token-executor-plugin",
+		"workflow-patch-sa",
+		"defaults-sa",
+		"defaults-executor-sa",
+		"defaults-patch-sa",
+		"template-executor-sa",
+		"template-patch-sa",
+		"step-inline-sa",
+		"dag-inline-sa",
+	}, accounts)
+
+	accounts, err = NewWorkflow(&workflowapi.Workflow{}).ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"default"}, accounts)
+
+	accounts, err = NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+		ServiceAccountName: "workflow-sa",
+		Templates: []workflowapi.Template{{
+			ServiceAccountName: "static-v2-sa",
+			PodSpecPatch:       compilerGeneratedPodSpecPatchTemplate,
+		}},
+	}}).ServiceAccounts(true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"workflow-sa", "static-v2-sa"}, accounts)
+}
+
+func TestWorkflow_ServiceAccountsCollectsArtifactGCIdentities(t *testing.T) {
+	artifact := func(strategy workflowapi.ArtifactGCStrategy, account string) workflowapi.Artifact {
+		return workflowapi.Artifact{
+			Name: account,
+			ArtifactGC: &workflowapi.ArtifactGC{
+				Strategy:           strategy,
+				ServiceAccountName: account,
+			},
+		}
+	}
+
+	tests := []struct {
+		name, account, patch string
+		outputs              workflowapi.Artifacts
+		want                 []string
+	}{
+		{
+			name:    "workflow and artifact accounts; inactive output ignored",
+			account: "workflow-gc-sa",
+			outputs: workflowapi.Artifacts{
+				artifact(workflowapi.ArtifactGCOnWorkflowCompletion, ""),
+				artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "artifact-gc-sa"),
+				artifact(workflowapi.ArtifactGCNever, "never-gc-sa"),
+			},
+			want: []string{"workflow-sa", "workflow-gc-sa", "artifact-gc-sa"},
+		},
+		{
+			name: "workflow-level pod patch", patch: `serviceAccountName: patched-gc-sa`,
+			outputs: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "")},
+			want:    []string{"workflow-sa", "patched-gc-sa"},
+		},
+		{
+			name:    "Kubernetes default account",
+			outputs: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "")},
+			want:    []string{"workflow-sa", "default"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+				ServiceAccountName: "workflow-sa",
+				ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+					ArtifactGC:   workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion, ServiceAccountName: tt.account},
+					PodSpecPatch: tt.patch,
+				},
+				Templates: []workflowapi.Template{{
+					Inputs:  workflowapi.Inputs{Artifacts: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "input-gc-sa")}},
+					Outputs: workflowapi.Outputs{Artifacts: tt.outputs},
+				}},
+			}})
+
+			accounts, err := w.ServiceAccounts(false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, accounts)
+		})
+	}
+
+	t.Run("parameterized workflow-level patch is rejected", func(t *testing.T) {
+		w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+			ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+				ArtifactGC:   workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion},
+				PodSpecPatch: `{{workflow.parameters.gc-patch}}`,
+			},
+			Templates: []workflowapi.Template{{
+				Outputs: workflowapi.Outputs{Artifacts: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "")}},
+			}},
+		}})
+		_, err := w.ServiceAccounts(false)
+		require.ErrorContains(t, err, "template expression")
+	})
+}
+
+func TestServiceAccountsInPodSpecPatch(t *testing.T) {
+	tests := []struct {
+		name, patch, wantErr string
+		allowCompiler        bool
+		want                 []string
+	}{
+		{name: "empty"},
+		{name: "canonical JSON field", patch: `{"serviceAccountName":"canonical-sa"}`, want: []string{"canonical-sa"}},
+		{name: "deprecated YAML alias", patch: `serviceAccount: alias-sa`, want: []string{"alias-sa"}},
+		{name: "null clears inherited account", patch: `serviceAccountName: null`, want: []string{"default"}},
+		{name: "root null is a no-op", patch: `null`},
+		{name: "root replacement clears inherited account", patch: "$patch: replace\ncontainers: []", want: []string{"default"}},
+		{name: "unrelated patch", patch: `containers: []`},
+		{name: "compiler patch", patch: compilerGeneratedPodSpecPatchTemplate, allowCompiler: true},
+		{name: "templated account", patch: `serviceAccountName: "{{workflow.parameters.account}}"`, wantErr: "template expression"},
+		{name: "templated unrelated field", patch: `nodeName: "{{inputs.parameters.node}}"`, allowCompiler: true, wantErr: "template expression"},
+		{name: "compiler patch in V1", patch: compilerGeneratedPodSpecPatchTemplate, wantErr: "template expression"},
+		{name: "malformed YAML", patch: `serviceAccountName: [`, wantErr: "valid Kubernetes PodSpec patch"},
+		{name: "wrong field type", patch: "serviceAccountName:\n- invalid", wantErr: "valid Kubernetes PodSpec patch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accounts, err := serviceAccountsInPodSpecPatch(tt.patch, tt.allowCompiler)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, accounts)
+		})
+	}
+}
+
+func TestWorkflow_ServiceAccountsRejectsExternalTemplateReferences(t *testing.T) {
+	templateRef := func() *workflowapi.TemplateRef {
+		return &workflowapi.TemplateRef{Name: "external", Template: "entrypoint"}
+	}
+	hookWithRef := func() workflowapi.LifecycleHooks {
+		return workflowapi.LifecycleHooks{workflowapi.ExitLifecycleEvent: {TemplateRef: templateRef()}}
+	}
+	stepSpec := func(step workflowapi.WorkflowStep) workflowapi.WorkflowSpec {
+		return workflowapi.WorkflowSpec{Templates: []workflowapi.Template{{
+			Steps: []workflowapi.ParallelSteps{{Steps: []workflowapi.WorkflowStep{step}}},
+		}}}
+	}
+	dagSpec := func(task workflowapi.DAGTask) workflowapi.WorkflowSpec {
+		return workflowapi.WorkflowSpec{Templates: []workflowapi.Template{{
+			DAG: &workflowapi.DAGTemplate{Tasks: []workflowapi.DAGTask{task}},
+		}}}
+	}
+	tests := []struct {
+		name string
+		spec workflowapi.WorkflowSpec
+	}{
+		{name: "workflow template reference", spec: workflowapi.WorkflowSpec{WorkflowTemplateRef: &workflowapi.WorkflowTemplateRef{Name: "external"}}},
+		{name: "workflow hook reference", spec: workflowapi.WorkflowSpec{Hooks: hookWithRef()}},
+		{name: "step reference", spec: stepSpec(workflowapi.WorkflowStep{TemplateRef: templateRef()})},
+		{name: "step hook reference", spec: stepSpec(workflowapi.WorkflowStep{Hooks: hookWithRef()})},
+		{name: "DAG task reference", spec: dagSpec(workflowapi.DAGTask{TemplateRef: templateRef()})},
+		{name: "DAG task hook reference", spec: dagSpec(workflowapi.DAGTask{Hooks: hookWithRef()})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.spec.ServiceAccountName = "workflow-sa"
+
+			accounts, err := NewWorkflow(&workflowapi.Workflow{Spec: tt.spec}).ServiceAccounts(false)
+			require.Error(t, err)
+			assert.Nil(t, accounts)
+			assert.Contains(t, err.Error(), "external workflow template references")
+		})
+	}
+}

--- a/docs/operator-guides/server-config.md
+++ b/docs/operator-guides/server-config.md
@@ -7,6 +7,79 @@ customizations are available for more advanced usage.
 When deploying Kubeflow Pipelines servers, you can pass various environment variables
 to customize the behavior of servers.
 
+## API Server workflow service-account checks
+
+By default, the API server enforces the service-account policy for all identities
+it finds in a workflow before creating a run or recurring run, retrying a run, or
+re-enabling an embedded recurring workflow. It also checks again after plugins
+modify a new run. Non-default accounts must be listed in `ALLOWEDSERVICEACCOUNTS`;
+in multi-user mode, the caller must additionally have `use` permission on those
+`serviceaccounts`. The configured default pipeline runner retains its existing
+exemption.
+
+### Audit mode for rollout
+
+`WORKFLOW_SERVICE_ACCOUNT_AUDIT` defaults to `false`. Set it to `"true"` on the
+`ml-pipeline` API server deployment to observe the **additional** identity checks
+without blocking on their findings:
+
+```yaml
+env:
+  - name: WORKFLOW_SERVICE_ACCOUNT_AUDIT
+    value: "true"
+```
+
+Audit mode still enforces the workflow's main service account, including Kubernetes'
+`default` account if the main field is empty. Failures involving
+other accounts, including accounts introduced by plugins or retained retry state,
+produce `Workflow service account audit:` warning logs and execution continues.
+These accounts can therefore run without passing the expanded policy while audit
+mode is enabled. Use this option temporarily to assess compatibility, then unset
+it or set it to `"false"` to enforce the checks. It applies to both V1 and V2.
+
+Warnings include the operation, namespace, workflow name or generated-name prefix,
+run ID when available, account name when known, and one of these findings:
+
+| Finding | Meaning |
+| --- | --- |
+| `account_not_allowed` | The additional account is not allowed or its name is not literal. |
+| `account_denied` | Kubernetes denied the caller permission to use the additional account. |
+| `authorization_error` | Authorization of the additional account could not be completed. |
+| `inspection_incomplete` | The workflow's identities could not be fully collected, for example because a patch is dynamic or uses noncanonical account fields. |
+
+An inspection failure stops collection, so `inspection_incomplete` is **not** a
+complete account inventory and later violations may not be reported. Review that
+workflow's templates, pod patches and retained execution state before enabling
+enforcement. Audit warnings do not include manifests, patch contents or raw error
+payloads. Logs may repeat across lifecycle operations and the post-plugin check.
+
+Audit mode does not bypass ordinary workflow validation: fresh submissions still
+reject external template references and discard caller-supplied workflow status.
+On retained workflows checked during retry or re-enable, an external reference
+instead produces an `inspection_incomplete` warning in audit mode. Existing enabled
+embedded schedules are not automatically inspected; re-enabling them triggers the
+check. Running workloads are not retroactively reauthorized.
+
+### V1 and V2 compatibility
+
+**V1 / raw Argo workflows:** this is the main compatibility change. Enforcement
+requires literal service-account names and canonical `serviceAccountName` or
+`serviceAccount` fields in pod patches. Dynamic `podSpecPatch` expressions are
+rejected even when they only affect resources. Every declared template is checked,
+including unused templates and overridden settings. External templates must be
+inlined. Submitted workflow status is ignored, so entrypoints must be defined in
+the submitted spec. Audit mode can help identify additional-account and patch
+inspection failures, but the validation and status rules still apply.
+
+**V2 / compiler-generated workflows:** the compiler's exact
+`{{inputs.parameters.pod-spec-patch}}` placeholder remains supported because the
+KFP driver constructs the runtime patch without selecting a service account.
+Literal accounts elsewhere in the workflow are still checked. V2 creation,
+plugin processing, retries and recurring runs use the same enforcement or audit
+mode as V1. V2 recurring runs remain retryable when their persisted records contain
+both the source pipeline spec and the compiled workflow manifest. Audit mode is
+not normally needed solely for the compiler-generated patch.
+
 ## Frontend Server
 
 When deploying frontend server called `ml-pipeline-ui`, you can pass various environment


### PR DESCRIPTION
**Description of your changes:**

A workflow's main service account is not necessarily the identity used by every task or helper pod. Checking only that account lets additional identities escape KFP's authorization policy. This PR extends the checks to those identities and provides an optional audit mode for rollout.

Fixes #14357 when expanded enforcement is enabled (the default).

### Default behavior

Collect and deduplicate accounts from workflow/template settings, template defaults, executors, token-enabled executor plugins, Artifact GC, inline templates, static pod patches, and retained execution state. Apply the existing allowlist policy and, in multi-user mode, the caller's Kubernetes `use` permission to each account. The configured default pipeline runner retains its existing exemption.

Check new runs before and after plugin processing, recurring runs across pinned/latest-version paths, retries before mutation, and embedded recurring workflows when re-enabled. Preserve plugin cleanup and its output if the post-plugin check rejects a run.

### Impact on V1 versus V2

Here, V1 means raw Argo workflow input and V2 means KFP pipeline specs compiled by the backend; this distinction is about pipeline format, not the API endpoint version.

| Area | V1 / raw Argo workflows | V2 / compiler-generated workflows |
| --- | --- | --- |
| Additional identities | Main compatibility impact: accounts in templates, defaults, patches and helper pods must now pass the policy. Every declared template is inspected, including unused templates and overridden settings. | Additional literal accounts, including accounts introduced by operator patches or plugins, must also pass the policy. V2 is not exempt from account authorization. |
| Dynamic `podSpecPatch` | Rejected under enforcement, even when the expression changes only resources. Use static patches with literal account names and canonical `serviceAccountName` / `serviceAccount` keys. | The exact compiler placeholder `{{inputs.parameters.pod-spec-patch}}` remains supported because the KFP driver constructs that patch without selecting service accounts. This is a specific compiler exception, not permission for arbitrary dynamic V2 patches. |
| External templates and submitted status | Fresh submissions reject external template references and discard supplied workflow status. Inline the templates and define entrypoints in the submitted spec. | Normal compilation does not depend on these inputs. The same fresh-workflow rules apply if operator customization introduces them. |
| Retry, recurring runs and plugins | Retained templates/defaults and artifact-cleanup identities are rechecked; plugin-added identities are checked before creating a workflow. | These lifecycle checks are shared. V2 recurring-run retry provenance is recognized even when the database record contains both the source pipeline spec and the compiled workflow manifest. |

The main compatibility risk is in V1/raw workflows, but V2 still shares authorization and lifecycle behavior. More distinct accounts also mean more authorization requests in multi-user mode.

### Temporary workflow-identity audit mode

`KFP_SECURITY_WORKFLOW_IDENTITY_MODE=enforce|audit` controls additional workflow identities. Unset/empty means `enforce`; invalid values fail startup, reload, and request validation. The unreleased boolean setting is replaced directly with no alias.

Audit evaluates and records additional-account allowlist and `serviceaccounts/use` denials, plus incomplete local inspection (for example dynamic/malformed patches). Authentication failures, authorization transport errors, and every SAR evaluation error remain blocking, including a response with both `allowed=true` and an evaluation error. An audited allowlist denial still proceeds to the SAR so it cannot hide an authorization-service failure.

The main workflow account remains enforced by this standalone PR, including Kubernetes' `default` account when the field is empty. Fresh-submission validation still rejects external references and discards supplied status. Audit does not turn malformed execution records into valid workflows. Findings report `account_not_allowed`, `account_denied`, or `inspection_incomplete`; incomplete collection is not a complete account inventory.

Startup exposure warnings and structured `security_audit control=workflow_identity mode=audit` findings identify safe operation/resource context without logging manifests, patches, inputs, credentials, or raw authorization errors. Apply the same setting to all API replicas, persist it in deployment configuration, exercise affected workflows, and return to `enforce`. Removal is planned for 3.0 under #14367. Audit restores exposure within this control's scope.

**Integration:** #14363 includes this branch and tests the combined scheduling behavior. Its separate `KFP_SECURITY_SERVICE_ACCOUNT_MODE` governs main-account policy; neither control overrides the other's enforcement. Main-account literal-name validation remains blocking even with both controls in audit. Merge this PR first, then the scheduling integration. Release-2.18 backports are tracked in #14409 and acceptance in #14421.

Operator guidance: [Server configuration](docs/operator-guides/server-config.md#api-server-workflow-service-account-checks).

### Validation

- Workflow mode, startup/reload validation, audit policy/inspection and fail-closed authorization regressions passed.
- Full resource suite passed: `go test -p 1 ./backend/src/apiserver/resource -count=1`.
- Scoped golangci-lint: zero issues. Applicable formatting checks passed.
- Combined API/resource/server/template/util/controller suites, four-way mode matrix, retained/recovered replay tests, and Sphinx build are validated in #14363.
- No live-cluster end-to-end validation was run.

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits).
- [x] The PR title follows the [repository convention](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
