### PR TITLE
fix(backend): isolate legacy execution cache by namespace

### DIFF
--- a/backend/src/cache/README.md
+++ b/backend/src/cache/README.md
@@ -1,3 +1,35 @@
+## Namespace isolation and upgrades
+
+This service caches legacy V1/raw-Argo steps. Standard V2 component pods bypass
+this webhook cache; their cache implementation is separate.
+
+Cache reuse is restricted to the pod's Kubernetes namespace. Admission derives
+the key from the API server's request namespace and the selected Argo template
+fields. On completion, the watcher recomputes the key from the observed pod's
+namespace and template instead of trusting its mutable cache-key annotation.
+Database reads and writes are also namespace-scoped. This does not establish an
+integrity boundary between users who can modify workloads in the same namespace.
+
+Upgrading adds a `Namespace` column and a namespace/key index automatically at
+cache-server startup. Existing rows retain an empty namespace and are not reused;
+their ownership cannot be safely inferred. Do not backfill them or restore a
+global-lookup fallback. Normal expiry still applies to these rows.
+
+Stop all old cache-server replicas before bringing up the fixed version, and
+coordinate the webhook outage with workload submission. A mixed-version rollout
+does not provide the new isolation guarantee. Allow startup migration to complete
+before resuming submissions. Expect a cold cache, extra step executions, and
+additional resource use; pre-upgrade pods with old-format keys do not seed the new
+cache. Do not roll back to the vulnerable implementation to recover cache hits.
+
+The migration/storage regression runs with SQLite in the normal cache test suite.
+To also exercise MySQL and PostgreSQL, set `KFP_CACHE_TEST_MYSQL_DSN` and
+`KFP_CACHE_TEST_POSTGRES_DSN` to empty disposable test databases and run:
+
+```sh
+go test ./backend/src/cache/storage -run TestCacheNamespaceMigrationAndStorage -count=1
+```
+
 ## Build src image
 To build the Docker image of cache server, run the following Docker command from the pipelines directory:
 

--- a/backend/src/cache/README.md
+++ b/backend/src/cache/README.md
@@ -3,17 +3,18 @@
 This service caches legacy V1/raw-Argo steps. Standard V2 component pods bypass
 this webhook cache; their cache implementation is separate.
 
-Cache reuse is restricted to the pod's Kubernetes namespace. Admission derives
-the key from the API server's request namespace and the selected Argo template
-fields. On completion, the watcher recomputes the key from the observed pod's
-namespace and template instead of trusting its mutable cache-key annotation.
-Database reads and writes are also namespace-scoped. This does not establish an
-integrity boundary between users who can modify workloads in the same namespace.
+By default, cache reuse is restricted to the pod's Kubernetes namespace. Database
+namespace filtering enforces isolation; including the namespace in the cache key
+provides an additional safeguard. Admission derives the key from the API server's
+request namespace and the selected Argo template fields. On completion, the
+watcher recomputes the key from the observed pod's namespace and template instead
+of trusting its mutable cache-key annotation. This does not establish an integrity
+boundary between users who can modify workloads in the same namespace.
 
 Upgrading adds a `Namespace` column and a namespace/key index automatically at
-cache-server startup. Existing rows retain an empty namespace and are not reused;
-their ownership cannot be safely inferred. Do not backfill them or restore a
-global-lookup fallback. Normal expiry still applies to these rows.
+cache-server startup. Existing rows retain an empty namespace and are not reused
+by default because their ownership cannot be safely inferred. Do not backfill
+them. Normal expiry still applies to these rows.
 
 Stop all old cache-server replicas before bringing up the fixed version, and
 coordinate the webhook outage with workload submission. A mixed-version rollout
@@ -21,6 +22,34 @@ does not provide the new isolation guarantee. Allow startup migration to complet
 before resuming submissions. Expect a cold cache, extra step executions, and
 additional resource use; pre-upgrade pods with old-format keys do not seed the new
 cache. Do not roll back to the vulnerable implementation to recover cache hits.
+
+### Optional legacy-cache fallback
+
+Administrators can set `ALLOW_LEGACY_CACHE_FALLBACK=true` for a bounded upgrade
+period. The default is `false` when unset. After a namespaced cache miss, this
+option permits a lookup using the original template-only hash, restricted to
+legacy rows with `Namespace = ''`. Normal namespace validation, namespace-scoped
+reads and writes, cache expiry, and disabled-cache behavior remain enforced.
+
+Enabling this option accepts possible reuse of another tenant's historical
+outputs, including poisoned outputs, because legacy row ownership is unknown.
+The full namespace isolation guarantee applies only with the fallback disabled.
+Stopping old replicas before upgrading is still required.
+
+For a deployment in the `kubeflow` namespace (adjust `NAMESPACE` as needed):
+
+```sh
+NAMESPACE=kubeflow
+kubectl set env deployment/cache-server -n "$NAMESPACE" ALLOW_LEGACY_CACHE_FALLBACK=true
+```
+
+Legacy hits do not populate the new namespaced cache, and no automatic promotion
+or backfill occurs. Turning off the option can therefore still cause cold-cache
+executions. Disable it after the planned upgrade period:
+
+```sh
+kubectl set env deployment/cache-server -n "$NAMESPACE" ALLOW_LEGACY_CACHE_FALLBACK=false
+```
 
 The migration/storage regression runs with SQLite in the normal cache test suite.
 To also exercise MySQL and PostgreSQL, set `KFP_CACHE_TEST_MYSQL_DSN` and

--- a/backend/src/cache/model/execution_cache.go
+++ b/backend/src/cache/model/execution_cache.go
@@ -16,12 +16,14 @@ package model
 
 type ExecutionCache struct {
 	ID                int64  `gorm:"column:ID; not null; primaryKey; AUTO_INCREMENT; index:composite_id_idx"`
-	ExecutionCacheKey string `gorm:"column:ExecutionCacheKey; not null; index:idx_cache_key;"`
+	ExecutionCacheKey string `gorm:"column:ExecutionCacheKey; not null; index:idx_cache_key; index:idx_cache_namespace_key,priority:2;"`
 	ExecutionTemplate string `gorm:"column:ExecutionTemplate; not null;"`
 	ExecutionOutput   string `gorm:"column:ExecutionOutput; not null;"`
 	MaxCacheStaleness int64  `gorm:"column:MaxCacheStaleness; not null;"`
 	StartedAtInSec    int64  `gorm:"column:StartedAtInSec; not null; index:composite_id_idx;"`
 	EndedAtInSec      int64  `gorm:"column:EndedAtInSec; not null;"`
+	// Empty namespace marks legacy rows whose tenant ownership cannot be established.
+	Namespace string `gorm:"column:Namespace; size:63; not null; default:''; index:idx_cache_namespace_key,priority:1;"`
 }
 
 // GetValueOfPrimaryKey returns the value of ExecutionCacheKey.

--- a/backend/src/cache/server/legacy_fallback_test.go
+++ b/backend/src/cache/server/legacy_fallback_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/cache/model"
+	"github.com/kubeflow/pipelines/backend/src/cache/storage"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/require"
+)
+
+func legacyCacheManager(t *testing.T) *FakeClientManager {
+	t.Helper()
+	m, err := NewFakeClientManager(util.NewFakeTime(time.Unix(100, 0)))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, m.Close()) })
+	return m
+}
+
+func legacyCacheRow(t *testing.T) *model.ExecutionCache {
+	t.Helper()
+	template, ok := getArgoTemplate(fakePod)
+	require.True(t, ok)
+	key, err := generateLegacyCacheKeyFromTemplate(template)
+	require.NoError(t, err)
+	// Pin the pre-upgrade hash so the fallback cannot silently use the new format.
+	require.Equal(t, "07f2c42567af4f141a52887e0a113c9aefdfdfd5e6b06b9908f7fdb0b43739af", key)
+	output, err := json.Marshal(map[string]string{ArgoWorkflowOutputs: cachePod("tenant").Annotations[ArgoWorkflowOutputs]})
+	require.NoError(t, err)
+	return &model.ExecutionCache{
+		ExecutionCacheKey: key,
+		ExecutionTemplate: template,
+		ExecutionOutput:   string(output),
+		MaxCacheStaleness: -1,
+		StartedAtInSec:    1,
+		EndedAtInSec:      2,
+	}
+}
+
+func TestLegacyCacheFallbackAdmission(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		setting      string
+		namespace    string
+		podTTL       string
+		defaultTTL   string
+		maximumTTL   string
+		rowExpired   bool
+		wantHit      bool
+		wantRowCount int64
+	}{
+		{name: "unset by default", wantRowCount: 1},
+		{name: "explicitly disabled", setting: "false", wantRowCount: 1},
+		{name: "legacy hit", setting: "true", wantHit: true, wantRowCount: 1},
+		{name: "another namespace excluded", setting: "true", namespace: "other", wantRowCount: 1},
+		{name: "pod caching disabled", setting: "true", podTTL: "P0D", wantRowCount: 1},
+		{name: "default caching disabled", setting: "true", defaultTTL: "P0D", wantRowCount: 1},
+		{name: "pod TTL expired", setting: "true", podTTL: "PT1S", wantRowCount: 1},
+		{name: "default TTL expired", setting: "true", defaultTTL: "PT1S", wantRowCount: 1},
+		{name: "row TTL expired", setting: "true", rowExpired: true, wantRowCount: 1},
+		{name: "maximum TTL expired", setting: "true", maximumTTL: "PT1S"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ALLOW_LEGACY_CACHE_FALLBACK", tc.setting)
+			if tc.setting == "" {
+				require.NoError(t, os.Unsetenv("ALLOW_LEGACY_CACHE_FALLBACK"))
+			}
+			t.Setenv("DEFAULT_CACHE_STALENESS", tc.defaultTTL)
+			t.Setenv("MAXIMUM_CACHE_STALENESS", tc.maximumTTL)
+			// The fallback setting must be independent of this existing boolean option.
+			t.Setenv("CACHE_NODE_RESTRICTIONS", "true")
+			m := legacyCacheManager(t)
+			row := legacyCacheRow(t)
+			row.Namespace = tc.namespace
+			if tc.rowExpired {
+				row.MaxCacheStaleness = 1
+			}
+			require.NoError(t, m.DB().Create(row).Error)
+			p := cachePod("tenant")
+			if tc.podTTL != "" {
+				p.Annotations[MaxCacheStalenessKey] = tc.podTTL
+			}
+			require.Equal(t, tc.wantHit, admitCachePod(t, p, m))
+			if tc.wantHit {
+				require.Equal(t, getValueFromSerializedMap(row.ExecutionOutput, ArgoWorkflowOutputs), p.Annotations[ArgoWorkflowOutputs])
+				// A legacy hit is not promoted or given a fresh age by the watcher.
+				require.NoError(t, cacheCompletedPod(context.Background(), p, m))
+				var retained model.ExecutionCache
+				require.NoError(t, m.DB().First(&retained, row.ID).Error)
+				require.Equal(t, *row, retained)
+			}
+			var rows int64
+			require.NoError(t, m.DB().Model(&model.ExecutionCache{}).Count(&rows).Error)
+			require.Equal(t, tc.wantRowCount, rows)
+		})
+	}
+}
+
+func TestLegacyCacheFallbackPreservesScopedWritesAndHitPrecedence(t *testing.T) {
+	m := legacyCacheManager(t)
+	legacy := legacyCacheRow(t)
+	require.NoError(t, m.DB().Create(legacy).Error)
+	t.Setenv("ALLOW_LEGACY_CACHE_FALLBACK", "false")
+	p := cachePod("tenant")
+	require.False(t, admitCachePod(t, p, m))
+
+	t.Setenv("ALLOW_LEGACY_CACHE_FALLBACK", "true")
+	t.Setenv("CACHE_NODE_RESTRICTIONS", "false")
+	p.Annotations[ArgoWorkflowOutputs] = `{"parameters":[{"name":"result","value":"scoped-output"}]}`
+	require.NoError(t, cacheCompletedPod(context.Background(), p, m))
+	next := cachePod("tenant")
+	require.True(t, admitCachePod(t, next, m))
+	require.Equal(t, p.Annotations[ArgoWorkflowOutputs], next.Annotations[ArgoWorkflowOutputs])
+	var rows []model.ExecutionCache
+	require.NoError(t, m.DB().Order("ID").Find(&rows).Error)
+	require.Len(t, rows, 2)
+	require.Equal(t, *legacy, rows[0])
+	require.Equal(t, "tenant", rows[1].Namespace)
+	require.NotEqual(t, legacy.ExecutionCacheKey, rows[1].ExecutionCacheKey)
+}
+
+func TestLegacyCacheFallbackInvalidConfiguration(t *testing.T) {
+	t.Setenv("ALLOW_LEGACY_CACHE_FALLBACK", "invalid")
+	m := legacyCacheManager(t)
+	require.NoError(t, m.DB().Create(legacyCacheRow(t)).Error)
+	p := cachePod("tenant")
+	req := GetFakeRequestFromPod(p)
+	req.Namespace = p.Namespace
+	patches, err := MutatePodIfCached(req, m)
+	require.ErrorContains(t, err, "ALLOW_LEGACY_CACHE_FALLBACK")
+	require.Empty(t, patches)
+}
+
+type scopedLookupErrorStore struct {
+	storage.ExecutionCacheStoreInterface
+	lookupErr   error
+	legacyReads int
+}
+
+func (s *scopedLookupErrorStore) GetExecutionCache(string, string, int64, int64) (*model.ExecutionCache, error) {
+	return nil, s.lookupErr
+}
+
+func (s *scopedLookupErrorStore) GetLegacyExecutionCache(key string, staleness, maximumStaleness int64) (*model.ExecutionCache, error) {
+	s.legacyReads++
+	return s.ExecutionCacheStoreInterface.GetLegacyExecutionCache(key, staleness, maximumStaleness)
+}
+
+func TestLegacyCacheFallbackOnlyAfterCacheMiss(t *testing.T) {
+	t.Setenv("ALLOW_LEGACY_CACHE_FALLBACK", "true")
+	for _, tc := range []struct {
+		name    string
+		err     error
+		wantHit bool
+	}{
+		{"database read error", errors.New("database read failed"), false},
+		{"database cleanup error", errors.New("database cleanup failed"), false},
+		{"wrapped cache miss", fmt.Errorf("lookup: %w", storage.ErrExecutionCacheNotFound), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := legacyCacheManager(t)
+			require.NoError(t, m.DB().Create(legacyCacheRow(t)).Error)
+			s := &scopedLookupErrorStore{ExecutionCacheStoreInterface: m.CacheStore(), lookupErr: tc.err}
+			m.cacheStore = s
+			require.Equal(t, tc.wantHit, admitCachePod(t, cachePod("tenant"), m))
+			if tc.wantHit {
+				require.Equal(t, 1, s.legacyReads)
+			} else {
+				require.Zero(t, s.legacyReads)
+			}
+		})
+	}
+}

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -156,6 +157,22 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 
 	var cachedExecution *model.ExecutionCache
 	cachedExecution, err = clientMgr.CacheStore().GetExecutionCache(req.Namespace, executionHashKey, cacheStalenessInSeconds, maximumCacheStalenessInSeconds)
+	if errors.Is(err, storage.ErrExecutionCacheNotFound) {
+		allowLegacyFallback, configErr := getEnvBool("ALLOW_LEGACY_CACHE_FALLBACK")
+		if configErr != nil {
+			return nil, fmt.Errorf("invalid ALLOW_LEGACY_CACHE_FALLBACK: set it to true or false: %w", configErr)
+		}
+		if allowLegacyFallback {
+			legacyKey, keyErr := generateLegacyCacheKeyFromTemplate(template)
+			if keyErr != nil {
+				return nil, keyErr
+			}
+			cachedExecution, err = clientMgr.CacheStore().GetLegacyExecutionCache(legacyKey, cacheStalenessInSeconds, maximumCacheStalenessInSeconds)
+			if cachedExecution != nil {
+				log.Printf("Using legacy cache entry %d for pod %s/%s: original namespace is unknown; ALLOW_LEGACY_CACHE_FALLBACK is enabled", cachedExecution.ID, req.Namespace, pod.Name)
+			}
+		}
+	}
 	if err != nil {
 		log.Println(err.Error())
 	}
@@ -271,14 +288,38 @@ func generateCacheKeyFromTemplate(template string, namespace string) (string, er
 	if namespace == "" {
 		return "", fmt.Errorf("cache key requires a pod namespace")
 	}
+	cacheKeyMap, err := filterTemplateForCacheKey(template)
+	if err != nil {
+		return "", err
+	}
+
+	// Database namespace predicates enforce ownership. Including the trusted
+	// namespace in the hash also keeps tenant identities distinct if a future
+	// lookup accidentally omits its namespace predicate.
+	return hashCacheKey(map[string]interface{}{
+		"namespace": namespace,
+		"template":  cacheKeyMap,
+	})
+}
+
+// generateLegacyCacheKeyFromTemplate reproduces the pre-namespace key for legacy-only reads.
+func generateLegacyCacheKeyFromTemplate(template string) (string, error) {
+	cacheKeyMap, err := filterTemplateForCacheKey(template)
+	if err != nil {
+		return "", err
+	}
+	return hashCacheKey(cacheKeyMap)
+}
+
+func filterTemplateForCacheKey(template string) (map[string]interface{}, error) {
 	var templateMap map[string]interface{}
 	b := []byte(template)
 	err := json.Unmarshal(b, &templateMap)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if templateMap == nil {
-		return "", fmt.Errorf("cache template must be a JSON object, not null")
+		return nil, fmt.Errorf("cache template must be a JSON object, not null")
 	}
 
 	// Selectively copying parts of the template that should affect the cache
@@ -296,21 +337,12 @@ func generateCacheKeyFromTemplate(template string, namespace string) (string, er
 		"initContainers": nil,
 		"sidecars":       nil,
 	}
-	cacheKeyMap, err := intersectStructureWithSkeleton(templateMap, templateSkeleton)
-	if err != nil {
-		return "", err
-	}
+	return intersectStructureWithSkeleton(templateMap, templateSkeleton)
+}
 
-	// Bind the cache entry to the pod's namespace (the KFP tenant boundary) so an
-	// entry written by one tenant is never served to another. Without the
-	// namespace the key is a pure function of container content, which any tenant
-	// can replicate, allowing cross-tenant cache hits in multi-user mode.
-	keyedStructure := map[string]interface{}{
-		"namespace": namespace,
-		"template":  cacheKeyMap,
-	}
-
-	b, err = json.Marshal(keyedStructure)
+func hashCacheKey(keyedStructure map[string]interface{}) (string, error) {
+	// encoding/json.Marshal documents sorted map keys, including nested maps.
+	b, err := json.Marshal(keyedStructure)
 	if err != nil {
 		return "", err
 	}
@@ -376,7 +408,7 @@ func isV2Pod(pod *corev1.Pod) bool {
 }
 
 func getEnvBool(key string) (bool, error) {
-	v, ok := os.LookupEnv("CACHE_NODE_RESTRICTIONS")
+	v, ok := os.LookupEnv(key)
 	if !ok {
 		return false, nil
 	}

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -110,7 +110,8 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 	}
 
 	// Generate the executionHashKey based on pod.metadata.annotations.workflows.argoproj.io/template
-	executionHashKey, err := generateCacheKeyFromTemplate(template)
+	// and the pod's namespace, so cache entries are scoped to a single tenant.
+	executionHashKey, err := generateCacheKeyFromTemplate(template, req.Namespace)
 	log.Println(executionHashKey)
 	if err != nil {
 		log.Printf("Unable to generate cache key for pod %s : %s", pod.ObjectMeta.Name, err.Error())
@@ -249,7 +250,7 @@ func intersectStructureWithSkeleton(src map[string]interface{}, skeleton map[str
 	return result
 }
 
-func generateCacheKeyFromTemplate(template string) (string, error) {
+func generateCacheKeyFromTemplate(template string, namespace string) (string, error) {
 	var templateMap map[string]interface{}
 	b := []byte(template)
 	err := json.Unmarshal(b, &templateMap)
@@ -274,7 +275,16 @@ func generateCacheKeyFromTemplate(template string) (string, error) {
 	}
 	cacheKeyMap := intersectStructureWithSkeleton(templateMap, templateSkeleton)
 
-	b, err = json.Marshal(cacheKeyMap)
+	// Bind the cache entry to the pod's namespace (the KFP tenant boundary) so an
+	// entry written by one tenant is never served to another. Without the
+	// namespace the key is a pure function of container content, which any tenant
+	// can replicate, allowing cross-tenant cache hits in multi-user mode.
+	keyedStructure := map[string]interface{}{
+		"namespace": namespace,
+		"template":  cacheKeyMap,
+	}
+
+	b, err = json.Marshal(keyedStructure)
 	if err != nil {
 		return "", err
 	}

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -241,18 +241,30 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 
 // intersectStructureWithSkeleton recursively intersects two maps
 // nil values in the skeleton map mean that the whole value (which can also be a map) should be kept.
-func intersectStructureWithSkeleton(src map[string]interface{}, skeleton map[string]interface{}) map[string]interface{} {
+func intersectStructureWithSkeleton(src map[string]interface{}, skeleton map[string]interface{}) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	for key, skeletonValue := range skeleton {
 		if value, ok := src[key]; ok {
 			if skeletonValue == nil {
 				result[key] = value
 			} else {
-				result[key] = intersectStructureWithSkeleton(value.(map[string]interface{}), skeletonValue.(map[string]interface{}))
+				object, ok := value.(map[string]interface{})
+				if !ok || object == nil {
+					return nil, fmt.Errorf("template field %q must be a JSON object", key)
+				}
+				nestedSkeleton, ok := skeletonValue.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf("cache skeleton field %q must be an object or nil", key)
+				}
+				nested, err := intersectStructureWithSkeleton(object, nestedSkeleton)
+				if err != nil {
+					return nil, fmt.Errorf("template field %q: %w", key, err)
+				}
+				result[key] = nested
 			}
 		}
 	}
-	return result
+	return result, nil
 }
 
 func generateCacheKeyFromTemplate(template string, namespace string) (string, error) {
@@ -264,6 +276,9 @@ func generateCacheKeyFromTemplate(template string, namespace string) (string, er
 	err := json.Unmarshal(b, &templateMap)
 	if err != nil {
 		return "", err
+	}
+	if templateMap == nil {
+		return "", fmt.Errorf("cache template must be a JSON object, not null")
 	}
 
 	// Selectively copying parts of the template that should affect the cache
@@ -281,7 +296,10 @@ func generateCacheKeyFromTemplate(template string, namespace string) (string, er
 		"initContainers": nil,
 		"sidecars":       nil,
 	}
-	cacheKeyMap := intersectStructureWithSkeleton(templateMap, templateSkeleton)
+	cacheKeyMap, err := intersectStructureWithSkeleton(templateMap, templateSkeleton)
+	if err != nil {
+		return "", err
+	}
 
 	// Bind the cache entry to the pod's namespace (the KFP tenant boundary) so an
 	// entry written by one tenant is never served to another. Without the

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -99,6 +99,11 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 		log.Printf("This pod %s is created by KFP v2 pipelines.", pod.ObjectMeta.Name)
 		return nil, nil
 	}
+	// Namespace comes from the API server's admission context, not caller metadata.
+	if req.Namespace == "" || (pod.Namespace != "" && pod.Namespace != req.Namespace) {
+		log.Printf("Skipping cache lookup for pod %s: missing or inconsistent namespace", pod.Name)
+		return nil, nil
+	}
 
 	var patches []patchOperation
 	annotations := pod.ObjectMeta.Annotations
@@ -150,7 +155,7 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 	log.Printf("cacheStalenessInSeconds: %d", cacheStalenessInSeconds)
 
 	var cachedExecution *model.ExecutionCache
-	cachedExecution, err = clientMgr.CacheStore().GetExecutionCache(executionHashKey, cacheStalenessInSeconds, maximumCacheStalenessInSeconds)
+	cachedExecution, err = clientMgr.CacheStore().GetExecutionCache(req.Namespace, executionHashKey, cacheStalenessInSeconds, maximumCacheStalenessInSeconds)
 	if err != nil {
 		log.Println(err.Error())
 	}
@@ -251,6 +256,9 @@ func intersectStructureWithSkeleton(src map[string]interface{}, skeleton map[str
 }
 
 func generateCacheKeyFromTemplate(template string, namespace string) (string, error) {
+	if namespace == "" {
+		return "", fmt.Errorf("cache key requires a pod namespace")
+	}
 	var templateMap map[string]interface{}
 	b := []byte(template)
 	err := json.Unmarshal(b, &templateMap)

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -169,6 +169,7 @@ func TestMutatePodIfCached(t *testing.T) {
 
 func TestMutatePodIfCachedWithCacheEntryExist(t *testing.T) {
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"}}`,
@@ -188,6 +189,7 @@ func TestMutatePodIfCachedWithCacheEntryExist(t *testing.T) {
 
 func TestDefaultImage(t *testing.T) {
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"}}`,
@@ -207,6 +209,7 @@ func TestSetImage(t *testing.T) {
 	defer os.Unsetenv("CACHE_IMAGE")
 
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"}}`,
@@ -224,6 +227,7 @@ func TestCacheNodeRestriction(t *testing.T) {
 	os.Setenv("CACHE_NODE_RESTRICTIONS", "false")
 
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"},"nodeSelector":{"disktype":"ssd"}}`,
@@ -239,6 +243,7 @@ func TestCacheNodeRestriction(t *testing.T) {
 
 func TestMutatePodIfCachedWithTeamplateCleanup(t *testing.T) {
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "71ad0d3873235ed88b5a3a2934b82cc180987e3a5a4107f8cb42bffe2de6cf64",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `Cache key was calculated from this: {"container":{"command":["echo", "Hello"],"image":"python:3.11"},"outputs":"anything"}`,

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -169,7 +169,7 @@ func TestMutatePodIfCached(t *testing.T) {
 
 func TestMutatePodIfCachedWithCacheEntryExist(t *testing.T) {
 	executionCache := &model.ExecutionCache{
-		ExecutionCacheKey: "07f2c42567af4f141a52887e0a113c9aefdfdfd5e6b06b9908f7fdb0b43739af",
+		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"}}`,
 		MaxCacheStaleness: -1,
@@ -188,7 +188,7 @@ func TestMutatePodIfCachedWithCacheEntryExist(t *testing.T) {
 
 func TestDefaultImage(t *testing.T) {
 	executionCache := &model.ExecutionCache{
-		ExecutionCacheKey: "07f2c42567af4f141a52887e0a113c9aefdfdfd5e6b06b9908f7fdb0b43739af",
+		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"}}`,
 		MaxCacheStaleness: -1,
@@ -207,7 +207,7 @@ func TestSetImage(t *testing.T) {
 	defer os.Unsetenv("CACHE_IMAGE")
 
 	executionCache := &model.ExecutionCache{
-		ExecutionCacheKey: "f5fe913be7a4516ebfe1b5de29bcb35edd12ecc776b2f33f10ca19709ea3b2f0",
+		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"}}`,
 		MaxCacheStaleness: -1,
@@ -224,7 +224,7 @@ func TestCacheNodeRestriction(t *testing.T) {
 	os.Setenv("CACHE_NODE_RESTRICTIONS", "false")
 
 	executionCache := &model.ExecutionCache{
-		ExecutionCacheKey: "f5fe913be7a4516ebfe1b5de29bcb35edd12ecc776b2f33f10ca19709ea3b2f0",
+		ExecutionCacheKey: "5ea9e9f07d01e21f5bbda698d3bb7d29db34b6f7462e796e8832718d336b410f",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `{"container":{"command":["echo", "Hello"],"image":"python:3.11"},"nodeSelector":{"disktype":"ssd"}}`,
 		MaxCacheStaleness: -1,
@@ -239,7 +239,7 @@ func TestCacheNodeRestriction(t *testing.T) {
 
 func TestMutatePodIfCachedWithTeamplateCleanup(t *testing.T) {
 	executionCache := &model.ExecutionCache{
-		ExecutionCacheKey: "4b868c5d0b64e4d93e529eadaa04f0451eb5ae5c652dd79c08bdc47a6a1fe67a",
+		ExecutionCacheKey: "71ad0d3873235ed88b5a3a2934b82cc180987e3a5a4107f8cb42bffe2de6cf64",
 		ExecutionOutput:   "testOutput",
 		ExecutionTemplate: `Cache key was calculated from this: {"container":{"command":["echo", "Hello"],"image":"python:3.11"},"outputs":"anything"}`,
 		MaxCacheStaleness: -1,

--- a/backend/src/cache/server/namespace_isolation_test.go
+++ b/backend/src/cache/server/namespace_isolation_test.go
@@ -162,6 +162,9 @@ func TestCacheRejectsWrongShapedTemplates(t *testing.T) {
 			key, err := generateCacheKeyFromTemplate(template, p.Namespace)
 			require.Error(t, err)
 			require.Empty(t, key)
+			legacyKey, err := generateLegacyCacheKeyFromTemplate(template)
+			require.Error(t, err)
+			require.Empty(t, legacyKey)
 			req := GetFakeRequestFromPod(p)
 			req.Namespace = p.Namespace
 			patches, err := MutatePodIfCached(req, m)

--- a/backend/src/cache/server/namespace_isolation_test.go
+++ b/backend/src/cache/server/namespace_isolation_test.go
@@ -148,3 +148,29 @@ func TestCacheAdmissionSkipsUnknownNamespaceAndMalformedTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestCacheRejectsWrongShapedTemplates(t *testing.T) {
+	for _, template := range []string{
+		`null`, `[]`, `"template"`,
+		`{"container":null}`, `{"container":[]}`, `{"container":"image"}`,
+		`{"container":42}`, `{"container":true}`,
+	} {
+		t.Run(template, func(t *testing.T) {
+			m := namespaceCacheManager(t)
+			p := cachePod("tenant")
+			p.Spec.Containers[0].Env[0].Value = template
+			key, err := generateCacheKeyFromTemplate(template, p.Namespace)
+			require.Error(t, err)
+			require.Empty(t, key)
+			req := GetFakeRequestFromPod(p)
+			req.Namespace = p.Namespace
+			patches, err := MutatePodIfCached(req, m)
+			require.NoError(t, err)
+			require.Empty(t, patches)
+			require.Error(t, cacheCompletedPod(context.Background(), p, m))
+			var rows int64
+			require.NoError(t, m.DB().Model(&model.ExecutionCache{}).Count(&rows).Error)
+			require.Zero(t, rows)
+		})
+	}
+}

--- a/backend/src/cache/server/namespace_isolation_test.go
+++ b/backend/src/cache/server/namespace_isolation_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/cache/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func namespaceCacheManager(t *testing.T) *FakeClientManager {
+	t.Helper()
+	m := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	t.Cleanup(func() { require.NoError(t, m.Close()) })
+	return m
+}
+
+func cachePod(namespace string) *corev1.Pod {
+	p := fakePod.DeepCopy()
+	p.Namespace = namespace
+	p.Name = "cache-step"
+	p.Labels[CacheIDLabelKey] = ""
+	p.Status.Phase = corev1.PodSucceeded
+	p.Annotations[ArgoWorkflowOutputs] = `{"parameters":[{"name":"result","value":"tenant-output"}]}`
+	return p
+}
+
+// admitCachePod uses the production admission handler and applies the metadata patches.
+func admitCachePod(t *testing.T, p *corev1.Pod, m *FakeClientManager) bool {
+	t.Helper()
+	req := GetFakeRequestFromPod(p)
+	req.Namespace = p.Namespace
+	patches, err := MutatePodIfCached(req, m)
+	require.NoError(t, err)
+	hit := false
+	for _, patch := range patches {
+		switch patch.Path {
+		case AnnotationPath:
+			p.Annotations = patch.Value.(map[string]string)
+		case LabelPath:
+			p.Labels = patch.Value.(map[string]string)
+		}
+		if patch.Op == OperationTypeReplace {
+			hit = true
+		}
+	}
+	return hit
+}
+
+func TestCacheNamespaceIsolationThroughWatcherAndAdmission(t *testing.T) {
+	m := namespaceCacheManager(t)
+	attacker := cachePod("attacker")
+	victim := cachePod("victim")
+	require.False(t, admitCachePod(t, attacker, m))
+	require.False(t, admitCachePod(t, victim, m))
+	attackerKey, victimKey := attacker.Annotations[ExecutionKey], victim.Annotations[ExecutionKey]
+	require.NotEmpty(t, attackerKey)
+	require.NotEqual(t, attackerKey, victimKey)
+
+	// A tenant changes its mutable key to the victim's deterministic hash.
+	attacker.Annotations[ExecutionKey] = victimKey
+	require.ErrorContains(t, cacheCompletedPod(context.Background(), attacker, m), "does not match")
+	var rows int64
+	require.NoError(t, m.DB().Model(&model.ExecutionCache{}).Count(&rows).Error)
+	require.Zero(t, rows)
+	require.False(t, admitCachePod(t, cachePod("victim"), m))
+
+	// Normal completion may populate only the attacker's namespace.
+	attacker.Annotations[ExecutionKey] = attackerKey
+	require.NoError(t, cacheCompletedPod(context.Background(), attacker, m))
+	require.NotEmpty(t, attacker.Labels[CacheIDLabelKey])
+	require.True(t, admitCachePod(t, cachePod("attacker"), m))
+	require.False(t, admitCachePod(t, cachePod("victim"), m))
+
+	// Victim completion becomes reusable within the victim namespace.
+	victim.Annotations[ArgoWorkflowOutputs] = `{"parameters":[{"name":"result","value":"victim-output"}]}`
+	require.NoError(t, cacheCompletedPod(context.Background(), victim, m))
+	nextVictim := cachePod("victim")
+	require.True(t, admitCachePod(t, nextVictim, m))
+	require.Equal(t, victim.Annotations[ArgoWorkflowOutputs], nextVictim.Annotations[ArgoWorkflowOutputs])
+}
+
+func TestCacheWatcherSkipsInvalidIdentityAndExcludedPods(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mutate    func(*corev1.Pod)
+		wantError bool
+	}{
+		{"missing namespace", func(p *corev1.Pod) { p.Namespace = "" }, true},
+		{"missing key", func(p *corev1.Pod) { delete(p.Annotations, ExecutionKey) }, true},
+		{"malformed template", func(p *corev1.Pod) { p.Spec.Containers[0].Env[0].Value = "{" }, true},
+		{"missing template", func(p *corev1.Pod) { p.Spec.Containers[0].Env = nil }, false},
+		{"no containers", func(p *corev1.Pod) { p.Spec.Containers = nil }, false},
+		{"cache disabled", func(p *corev1.Pod) { delete(p.Labels, KFPCacheEnabledLabelKey) }, false},
+		{"v2 pod", func(p *corev1.Pod) { p.Annotations[V2ComponentAnnotationKey] = V2ComponentAnnotationValue }, false},
+		{"tfx pod", func(p *corev1.Pod) { p.Labels[SdkTypeLabel] = TfxSdkTypeLabel }, false},
+		{"unfinished pod", func(p *corev1.Pod) { p.Status.Phase = corev1.PodRunning }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := namespaceCacheManager(t)
+			p := cachePod("tenant")
+			require.False(t, admitCachePod(t, p, m))
+			tc.mutate(p)
+			err := cacheCompletedPod(context.Background(), p, m)
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			var rows int64
+			require.NoError(t, m.DB().Model(&model.ExecutionCache{}).Count(&rows).Error)
+			require.Zero(t, rows)
+		})
+	}
+}
+
+func TestCacheAdmissionSkipsUnknownNamespaceAndMalformedTemplate(t *testing.T) {
+	for _, tc := range []struct{ name, requestNamespace, podNamespace, template string }{
+		{"missing admission namespace", "", "tenant", "{}"},
+		{"namespace mismatch", "victim", "attacker", "{}"},
+		{"malformed template", "tenant", "tenant", "{"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := namespaceCacheManager(t)
+			p := cachePod(tc.podNamespace)
+			p.Spec.Containers[0].Env[0].Value = tc.template
+			req := GetFakeRequestFromPod(p)
+			req.Namespace = tc.requestNamespace
+			patches, err := MutatePodIfCached(req, m)
+			require.NoError(t, err)
+			require.Empty(t, patches)
+		})
+	}
+}

--- a/backend/src/cache/server/watcher.go
+++ b/backend/src/cache/server/watcher.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"strconv"
 	"time"
 
@@ -41,71 +40,84 @@ func WatchPods(ctx context.Context, namespaceToWatch string, clientManager Clien
 		}
 
 		for event := range watcher.ResultChan() {
-			pod := reflect.ValueOf(event.Object).Interface().(*corev1.Pod)
 			if event.Type == watch.Error {
+				continue
+			}
+			pod, ok := event.Object.(*corev1.Pod)
+			if !ok {
 				continue
 			}
 			log.Printf("%s", (*pod).GetName())
 
-			if !isPodCompletedAndSucceeded(pod) {
-				log.Printf("Pod %s is not completed or not in successful status.", pod.ObjectMeta.Name)
-				continue
-			}
-
-			if isCacheWriten(pod.ObjectMeta.Labels) {
-				continue
-			}
-
-			executionKey, exists := pod.ObjectMeta.Annotations[ExecutionKey]
-			if !exists {
-				continue
-			}
-
-			executionOutput, exists := pod.ObjectMeta.Annotations[ArgoWorkflowOutputs]
-
-			executionOutputMap := make(map[string]interface{})
-			executionOutputMap[ArgoWorkflowOutputs] = executionOutput
-			executionOutputMap[MetadataExecutionIDKey] = pod.ObjectMeta.Labels[MetadataExecutionIDKey]
-			executionOutputJSON, _ := json.Marshal(executionOutputMap)
-
-			executionstaleness, exists := pod.ObjectMeta.Annotations[MaxCacheStalenessKey]
-			var cacheStalenessInSeconds int64 = -1
-			if exists {
-				cacheStalenessInSeconds = stalenessToSeconds(executionstaleness)
-			}
-
-			var maximumCacheStalenessInSeconds int64 = -1
-			maximumCacheStaleness, exists := os.LookupEnv("MAXIMUM_CACHE_STALENESS")
-			if exists {
-				log.Printf("maximumCacheStaleness: %s", maximumCacheStaleness)
-				maximumCacheStalenessInSeconds = stalenessToSeconds(maximumCacheStaleness)
-				log.Printf("maximumCacheStalenessInSeconds: %d", maximumCacheStalenessInSeconds)
-			}
-			if maximumCacheStalenessInSeconds >= 0 && cacheStalenessInSeconds > maximumCacheStalenessInSeconds {
-				cacheStalenessInSeconds = maximumCacheStalenessInSeconds
-			}
-			log.Printf("Creating cachedb entry with cacheStalenessInSeconds: %d", cacheStalenessInSeconds)
-
-			executionTemplate, _ := getArgoTemplate(pod)
-
-			executionToPersist := model.ExecutionCache{
-				ExecutionCacheKey: executionKey,
-				ExecutionTemplate: executionTemplate,
-				ExecutionOutput:   string(executionOutputJSON),
-				MaxCacheStaleness: cacheStalenessInSeconds,
-			}
-
-			cacheEntryCreated, err := clientManager.CacheStore().CreateExecutionCache(&executionToPersist)
-			if err != nil {
-				log.Println("Unable to create cache entry.")
-				continue
-			}
-			err = patchCacheID(ctx, k8sCore, pod, namespaceToWatch, cacheEntryCreated.ID)
-			if err != nil {
+			if err := cacheCompletedPod(ctx, pod, clientManager); err != nil {
 				log.Printf("%s", err.Error())
 			}
 		}
 	}
+}
+
+// cacheCompletedPod validates a watched pod's cache identity before publishing its outputs.
+func cacheCompletedPod(ctx context.Context, pod *corev1.Pod, clientManager ClientManagerInterface) error {
+	if !isKFPCacheEnabled(pod) || isTFXPod(pod) || isV2Pod(pod) || !isPodCompletedAndSucceeded(pod) {
+		log.Printf("Pod %s is not eligible for a cache write.", pod.Name)
+		return nil
+	}
+
+	if isCacheWriten(pod.Labels) {
+		return nil
+	}
+
+	executionTemplate, exists := getArgoTemplate(pod)
+	if !exists {
+		return nil
+	}
+	executionKey, err := generateCacheKeyFromTemplate(executionTemplate, pod.Namespace)
+	if err != nil {
+		return fmt.Errorf("cannot determine cache identity for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	// The cache-key annotation is mutable and must not select another tenant's row.
+	if pod.Annotations[ExecutionKey] != executionKey {
+		return fmt.Errorf("skipping cache write for pod %s/%s: execution cache key does not match namespace and template", pod.Namespace, pod.Name)
+	}
+
+	executionOutput := pod.Annotations[ArgoWorkflowOutputs]
+
+	executionOutputMap := make(map[string]interface{})
+	executionOutputMap[ArgoWorkflowOutputs] = executionOutput
+	executionOutputMap[MetadataExecutionIDKey] = pod.Labels[MetadataExecutionIDKey]
+	executionOutputJSON, _ := json.Marshal(executionOutputMap)
+
+	executionstaleness, exists := pod.Annotations[MaxCacheStalenessKey]
+	var cacheStalenessInSeconds int64 = -1
+	if exists {
+		cacheStalenessInSeconds = stalenessToSeconds(executionstaleness)
+	}
+
+	var maximumCacheStalenessInSeconds int64 = -1
+	maximumCacheStaleness, exists := os.LookupEnv("MAXIMUM_CACHE_STALENESS")
+	if exists {
+		log.Printf("maximumCacheStaleness: %s", maximumCacheStaleness)
+		maximumCacheStalenessInSeconds = stalenessToSeconds(maximumCacheStaleness)
+		log.Printf("maximumCacheStalenessInSeconds: %d", maximumCacheStalenessInSeconds)
+	}
+	if maximumCacheStalenessInSeconds >= 0 && cacheStalenessInSeconds > maximumCacheStalenessInSeconds {
+		cacheStalenessInSeconds = maximumCacheStalenessInSeconds
+	}
+	log.Printf("Creating cachedb entry with cacheStalenessInSeconds: %d", cacheStalenessInSeconds)
+
+	executionToPersist := model.ExecutionCache{
+		Namespace:         pod.Namespace,
+		ExecutionCacheKey: executionKey,
+		ExecutionTemplate: executionTemplate,
+		ExecutionOutput:   string(executionOutputJSON),
+		MaxCacheStaleness: cacheStalenessInSeconds,
+	}
+
+	cacheEntryCreated, err := clientManager.CacheStore().CreateExecutionCache(&executionToPersist)
+	if err != nil {
+		return fmt.Errorf("unable to create cache entry: %w", err)
+	}
+	return patchCacheID(ctx, clientManager.KubernetesCoreClient(), pod, cacheEntryCreated.ID)
 }
 
 func isPodCompletedAndSucceeded(pod *corev1.Pod) bool {
@@ -117,7 +129,7 @@ func isCacheWriten(labels map[string]string) bool {
 	return cacheID != ""
 }
 
-func patchCacheID(ctx context.Context, k8sCore client.KubernetesCoreInterface, podToPatch *corev1.Pod, namespaceToWatch string, id int64) error {
+func patchCacheID(ctx context.Context, k8sCore client.KubernetesCoreInterface, podToPatch *corev1.Pod, id int64) error {
 	labels := podToPatch.ObjectMeta.Labels
 	labels[CacheIDLabelKey] = strconv.FormatInt(id, 10)
 	log.Println(id)
@@ -131,7 +143,7 @@ func patchCacheID(ctx context.Context, k8sCore client.KubernetesCoreInterface, p
 	if err != nil {
 		return fmt.Errorf("Unable to patch cache_id to pod: %s", podToPatch.ObjectMeta.Name)
 	}
-	_, err = k8sCore.PodClient(namespaceToWatch).Patch(ctx, podToPatch.ObjectMeta.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	_, err = k8sCore.PodClient(podToPatch.Namespace).Patch(ctx, podToPatch.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}
@@ -150,6 +162,9 @@ func stalenessToSeconds(staleness string) int64 {
 
 // Get Argo workflow template from container env.
 func getArgoTemplate(pod *corev1.Pod) (string, bool) {
+	if len(pod.Spec.Containers) == 0 {
+		return "", false
+	}
 	for _, env := range pod.Spec.Containers[0].Env {
 		if ArgoWorkflowTemplateEnvKey == env.Name {
 			return env.Value, true

--- a/backend/src/cache/storage/execution_cache_store.go
+++ b/backend/src/cache/storage/execution_cache_store.go
@@ -26,7 +26,7 @@ import (
 )
 
 type ExecutionCacheStoreInterface interface {
-	GetExecutionCache(executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error)
+	GetExecutionCache(namespace, executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error)
 	CreateExecutionCache(*model.ExecutionCache) (*model.ExecutionCache, error)
 }
 
@@ -36,7 +36,10 @@ type ExecutionCacheStore struct {
 	dialect dialect.DBDialect
 }
 
-func (s *ExecutionCacheStore) GetExecutionCache(executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error) {
+func (s *ExecutionCacheStore) GetExecutionCache(namespace, executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("cache lookup requires a pod namespace")
+	}
 	rowsAffected, err := s.cleanDatabase(maximumCacheStaleness)
 	log.Printf("Number of deleted rows: %d", rowsAffected)
 	if err != nil {
@@ -46,7 +49,7 @@ func (s *ExecutionCacheStore) GetExecutionCache(executionCacheKey string, cacheS
 		return nil, fmt.Errorf("CacheStaleness=0, Cache is disabled.")
 	}
 	var executionCaches []model.ExecutionCache
-	result := s.db.Where(map[string]interface{}{"ExecutionCacheKey": executionCacheKey}).Find(&executionCaches)
+	result := s.db.Where(map[string]interface{}{"Namespace": namespace, "ExecutionCacheKey": executionCacheKey}).Find(&executionCaches)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get execution cache: %q, err: %v", executionCacheKey, result.Error)
 	}
@@ -144,10 +147,13 @@ func getLatestCacheEntry(executionCaches []*model.ExecutionCache) (*model.Execut
 }
 
 func (s *ExecutionCacheStore) CreateExecutionCache(executionCache *model.ExecutionCache) (*model.ExecutionCache, error) {
+	if executionCache.Namespace == "" {
+		return nil, fmt.Errorf("cache write requires a pod namespace")
+	}
 	log.Printf("checking for existing row with cache key: %s before insertion", executionCache.ExecutionCacheKey)
 
 	var existingCaches []model.ExecutionCache
-	result := s.db.Where(map[string]interface{}{"ExecutionCacheKey": executionCache.ExecutionCacheKey}).Find(&existingCaches)
+	result := s.db.Where(map[string]interface{}{"Namespace": executionCache.Namespace, "ExecutionCacheKey": executionCache.ExecutionCacheKey}).Find(&existingCaches)
 	if result.Error != nil {
 		log.Printf("Failed to get execution cache with key: %s, err: %v", executionCache.ExecutionCacheKey, result.Error)
 		return nil, result.Error

--- a/backend/src/cache/storage/execution_cache_store.go
+++ b/backend/src/cache/storage/execution_cache_store.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 
@@ -25,8 +26,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// ErrExecutionCacheNotFound indicates that no cache entry satisfies the lookup and staleness requirements.
+var ErrExecutionCacheNotFound = errors.New("execution cache not found")
+
 type ExecutionCacheStoreInterface interface {
 	GetExecutionCache(namespace, executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error)
+	GetLegacyExecutionCache(executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error)
 	CreateExecutionCache(*model.ExecutionCache) (*model.ExecutionCache, error)
 }
 
@@ -40,6 +45,16 @@ func (s *ExecutionCacheStore) GetExecutionCache(namespace, executionCacheKey str
 	if namespace == "" {
 		return nil, fmt.Errorf("cache lookup requires a pod namespace")
 	}
+	return s.getExecutionCache(namespace, executionCacheKey, cacheStaleness, maximumCacheStaleness)
+}
+
+// GetLegacyExecutionCache reads only historical entries with unknown namespace ownership.
+// Callers must explicitly opt in to cross-namespace reuse before using this lookup.
+func (s *ExecutionCacheStore) GetLegacyExecutionCache(executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error) {
+	return s.getExecutionCache("", executionCacheKey, cacheStaleness, maximumCacheStaleness)
+}
+
+func (s *ExecutionCacheStore) getExecutionCache(namespace, executionCacheKey string, cacheStaleness int64, maximumCacheStaleness int64) (*model.ExecutionCache, error) {
 	rowsAffected, err := s.cleanDatabase(maximumCacheStaleness)
 	log.Printf("Number of deleted rows: %d", rowsAffected)
 	if err != nil {
@@ -49,6 +64,7 @@ func (s *ExecutionCacheStore) GetExecutionCache(namespace, executionCacheKey str
 		return nil, fmt.Errorf("CacheStaleness=0, Cache is disabled.")
 	}
 	var executionCaches []model.ExecutionCache
+	// A map retains the empty namespace predicate for explicit legacy lookups.
 	result := s.db.Where(map[string]interface{}{"Namespace": namespace, "ExecutionCacheKey": executionCacheKey}).Find(&executionCaches)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get execution cache: %q, err: %v", executionCacheKey, result.Error)
@@ -67,7 +83,7 @@ func (s *ExecutionCacheStore) GetExecutionCache(namespace, executionCacheKey str
 	}
 
 	if len(validCaches) == 0 {
-		return nil, fmt.Errorf("Execution cache not found with cache key: %q", executionCacheKey)
+		return nil, fmt.Errorf("%w with cache key: %q", ErrExecutionCacheNotFound, executionCacheKey)
 	}
 	latestCache, err := getLatestCacheEntry(validCaches)
 	if err != nil {

--- a/backend/src/cache/storage/execution_cache_store_test.go
+++ b/backend/src/cache/storage/execution_cache_store_test.go
@@ -34,6 +34,7 @@ func closeDB(t *testing.T, db *gorm.DB) {
 
 func createExecutionCache(cacheKey string, cacheOutput string) *model.ExecutionCache {
 	return &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: cacheKey,
 		ExecutionTemplate: "testTemplate",
 		ExecutionOutput:   cacheOutput,
@@ -48,6 +49,7 @@ func TestCreateExecutionCache(t *testing.T) {
 	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect)
 	executionCacheExpected := model.ExecutionCache{
+		Namespace:         "default",
 		ID:                1,
 		ExecutionCacheKey: "test",
 		ExecutionTemplate: "testTemplate",
@@ -57,6 +59,7 @@ func TestCreateExecutionCache(t *testing.T) {
 		EndedAtInSec:      1,
 	}
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "test",
 		ExecutionTemplate: "testTemplate",
 		ExecutionOutput:   "testOutput",
@@ -69,6 +72,7 @@ func TestCreateExecutionCache(t *testing.T) {
 
 func TestCreateExecutionCacheWithDuplicateRecord(t *testing.T) {
 	executionCache := &model.ExecutionCache{
+		Namespace:         "default",
 		ID:                1,
 		ExecutionCacheKey: "test",
 		ExecutionTemplate: "testTemplate",
@@ -93,6 +97,7 @@ func TestGetExecutionCache(t *testing.T) {
 
 	executionCacheStore.CreateExecutionCache(createExecutionCache("testKey", "testOutput"))
 	executionCacheExpected := model.ExecutionCache{
+		Namespace:         "default",
 		ID:                1,
 		ExecutionCacheKey: "testKey",
 		ExecutionTemplate: "testTemplate",
@@ -103,7 +108,7 @@ func TestGetExecutionCache(t *testing.T) {
 	}
 
 	var executionCache *model.ExecutionCache
-	executionCache, err := executionCacheStore.GetExecutionCache("testKey", -1, -1)
+	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", -1, -1)
 	require.Nil(t, err)
 	require.Equal(t, &executionCacheExpected, executionCache)
 }
@@ -115,7 +120,7 @@ func TestGetExecutionCacheWithEmptyCacheEntry(t *testing.T) {
 
 	executionCacheStore.CreateExecutionCache(createExecutionCache("testKey", "testOutput"))
 	var executionCache *model.ExecutionCache
-	executionCache, err := executionCacheStore.GetExecutionCache("wrongKey", -1, -1)
+	executionCache, err := executionCacheStore.GetExecutionCache("default", "wrongKey", -1, -1)
 	require.Nil(t, executionCache)
 	require.Contains(t, err.Error(), `Execution cache not found with cache key: "wrongKey"`)
 }
@@ -129,6 +134,7 @@ func TestGetExecutionCacheWithLatestCacheEntry(t *testing.T) {
 	executionCacheStore.CreateExecutionCache(createExecutionCache("testKey", "testOutput2"))
 
 	executionCacheExpected := model.ExecutionCache{
+		Namespace:         "default",
 		ID:                1,
 		ExecutionCacheKey: "testKey",
 		ExecutionTemplate: "testTemplate",
@@ -138,7 +144,7 @@ func TestGetExecutionCacheWithLatestCacheEntry(t *testing.T) {
 		EndedAtInSec:      1,
 	}
 	var executionCache *model.ExecutionCache
-	executionCache, err := executionCacheStore.GetExecutionCache("testKey", -1, -1)
+	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", -1, -1)
 	require.Nil(t, err)
 	require.Equal(t, &executionCacheExpected, executionCache)
 }
@@ -148,6 +154,7 @@ func TestGetExecutionCacheWithExpiredDatabaseCacheStaleness(t *testing.T) {
 	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect)
 	executionCacheToPersist := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "testKey",
 		ExecutionTemplate: "testTemplate",
 		ExecutionOutput:   "testOutput",
@@ -156,7 +163,7 @@ func TestGetExecutionCacheWithExpiredDatabaseCacheStaleness(t *testing.T) {
 	executionCacheStore.CreateExecutionCache(executionCacheToPersist)
 
 	var executionCache *model.ExecutionCache
-	executionCache, err := executionCacheStore.GetExecutionCache("testKey", -1, -1)
+	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", -1, -1)
 	require.Contains(t, err.Error(), "Execution cache not found")
 	require.Nil(t, executionCache)
 }
@@ -166,6 +173,7 @@ func TestGetExecutionCacheWithExpiredAnnotationCacheStaleness(t *testing.T) {
 	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect)
 	executionCacheToPersist := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "testKey",
 		ExecutionTemplate: "testTemplate",
 		ExecutionOutput:   "testOutput",
@@ -174,7 +182,7 @@ func TestGetExecutionCacheWithExpiredAnnotationCacheStaleness(t *testing.T) {
 	executionCacheStore.CreateExecutionCache(executionCacheToPersist)
 
 	var executionCache *model.ExecutionCache
-	executionCache, err := executionCacheStore.GetExecutionCache("testKey", 0, -1)
+	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", 0, -1)
 	log.Println(executionCache)
 	log.Println("error: " + err.Error())
 	require.Contains(t, err.Error(), "CacheStaleness=0, Cache is disabled.")
@@ -186,6 +194,7 @@ func TestGetExecutionCacheWithExpiredMaximumCacheStaleness(t *testing.T) {
 	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect)
 	executionCacheToPersist := &model.ExecutionCache{
+		Namespace:         "default",
 		ExecutionCacheKey: "testKey",
 		ExecutionTemplate: "testTemplate",
 		ExecutionOutput:   "testOutput",
@@ -194,7 +203,7 @@ func TestGetExecutionCacheWithExpiredMaximumCacheStaleness(t *testing.T) {
 	executionCacheStore.CreateExecutionCache(executionCacheToPersist)
 
 	var executionCache *model.ExecutionCache
-	executionCache, err := executionCacheStore.GetExecutionCache("testKey", -1, 0)
+	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", -1, 0)
 	log.Println(executionCache)
 	log.Println("error: " + err.Error())
 	require.Contains(t, err.Error(), "Execution cache not found")
@@ -212,7 +221,7 @@ func TestGetExecutionCacheWithEmptyKey(t *testing.T) {
 	_, err := executionCacheStore.CreateExecutionCache(createExecutionCache("someKey", "output1"))
 	require.NoError(t, err)
 
-	result, err := executionCacheStore.GetExecutionCache("", -1, -1)
+	result, err := executionCacheStore.GetExecutionCache("default", "", -1, -1)
 	require.Nil(t, result)
 	require.Contains(t, err.Error(), "Execution cache not found")
 }

--- a/backend/src/cache/storage/execution_cache_store_test.go
+++ b/backend/src/cache/storage/execution_cache_store_test.go
@@ -122,7 +122,8 @@ func TestGetExecutionCacheWithEmptyCacheEntry(t *testing.T) {
 	var executionCache *model.ExecutionCache
 	executionCache, err := executionCacheStore.GetExecutionCache("default", "wrongKey", -1, -1)
 	require.Nil(t, executionCache)
-	require.Contains(t, err.Error(), `Execution cache not found with cache key: "wrongKey"`)
+	require.ErrorIs(t, err, ErrExecutionCacheNotFound)
+	require.Contains(t, err.Error(), `"wrongKey"`)
 }
 
 func TestGetExecutionCacheWithLatestCacheEntry(t *testing.T) {
@@ -164,7 +165,7 @@ func TestGetExecutionCacheWithExpiredDatabaseCacheStaleness(t *testing.T) {
 
 	var executionCache *model.ExecutionCache
 	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", -1, -1)
-	require.Contains(t, err.Error(), "Execution cache not found")
+	require.ErrorIs(t, err, ErrExecutionCacheNotFound)
 	require.Nil(t, executionCache)
 }
 
@@ -206,7 +207,7 @@ func TestGetExecutionCacheWithExpiredMaximumCacheStaleness(t *testing.T) {
 	executionCache, err := executionCacheStore.GetExecutionCache("default", "testKey", -1, 0)
 	log.Println(executionCache)
 	log.Println("error: " + err.Error())
-	require.Contains(t, err.Error(), "Execution cache not found")
+	require.ErrorIs(t, err, ErrExecutionCacheNotFound)
 	require.Nil(t, executionCache)
 }
 
@@ -223,7 +224,7 @@ func TestGetExecutionCacheWithEmptyKey(t *testing.T) {
 
 	result, err := executionCacheStore.GetExecutionCache("default", "", -1, -1)
 	require.Nil(t, result)
-	require.Contains(t, err.Error(), "Execution cache not found")
+	require.ErrorIs(t, err, ErrExecutionCacheNotFound)
 }
 
 // Guardrail: the WHERE predicate must use the model-tag column name

--- a/backend/src/cache/storage/legacy_fallback_test.go
+++ b/backend/src/cache/storage/legacy_fallback_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/cache/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLegacyExecutionCacheSelectsLatestLegacyEntry(t *testing.T) {
+	db, dialect := NewFakeDBOrFatal()
+	defer closeDB(t, db)
+	store := NewExecutionCacheStore(db, util.NewFakeTime(time.Unix(100, 0)), dialect)
+	for i, namespace := range []string{"", "", "tenant-a", "tenant-b"} {
+		row := createExecutionCache("shared-key", "output-"+namespace)
+		row.Namespace = namespace
+		row.StartedAtInSec = int64(i + 1)
+		require.NoError(t, db.Create(row).Error)
+	}
+
+	cached, err := store.GetLegacyExecutionCache("shared-key", -1, -1)
+	require.NoError(t, err)
+	require.Empty(t, cached.Namespace)
+	require.Equal(t, int64(2), cached.StartedAtInSec, "newer namespaced entries must not be selected")
+	var rowCount int64
+	require.NoError(t, db.Model(&model.ExecutionCache{}).Count(&rowCount).Error)
+	require.Equal(t, int64(4), rowCount, "legacy reads must not copy or rewrite cache entries")
+}
+
+func TestExecutionCacheLookupStalenessAndMissClassification(t *testing.T) {
+	for _, namespace := range []string{"default", ""} {
+		lookupName := "namespaced"
+		if namespace == "" {
+			lookupName = "legacy"
+		}
+		t.Run(lookupName, func(t *testing.T) {
+			for _, tc := range []struct {
+				name                  string
+				key                   string
+				rowStaleness          int64
+				cacheStaleness        int64
+				maximumCacheStaleness int64
+				wantMiss              bool
+				wantDisabled          bool
+			}{
+				{name: "valid", key: "key", rowStaleness: -1, cacheStaleness: -1, maximumCacheStaleness: -1},
+				{name: "missing key", key: "missing", rowStaleness: -1, cacheStaleness: -1, maximumCacheStaleness: -1, wantMiss: true},
+				{name: "empty key", key: "", rowStaleness: -1, cacheStaleness: -1, maximumCacheStaleness: -1, wantMiss: true},
+				{name: "expired row", key: "key", rowStaleness: 5, cacheStaleness: -1, maximumCacheStaleness: -1, wantMiss: true},
+				{name: "disabled row", key: "key", rowStaleness: 0, cacheStaleness: -1, maximumCacheStaleness: -1, wantMiss: true},
+				{name: "expired request", key: "key", rowStaleness: -1, cacheStaleness: 5, maximumCacheStaleness: -1, wantMiss: true},
+				{name: "expired maximum", key: "key", rowStaleness: -1, cacheStaleness: -1, maximumCacheStaleness: 5, wantMiss: true},
+				{name: "disabled request", key: "key", rowStaleness: -1, cacheStaleness: 0, maximumCacheStaleness: -1, wantDisabled: true},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					db, dialect := NewFakeDBOrFatal()
+					defer closeDB(t, db)
+					store := NewExecutionCacheStore(db, util.NewFakeTime(time.Unix(100, 0)), dialect)
+					row := createExecutionCache("key", "output")
+					row.Namespace = namespace
+					row.MaxCacheStaleness = tc.rowStaleness
+					require.NoError(t, db.Create(row).Error)
+					lookup := store.GetLegacyExecutionCache
+					if namespace != "" {
+						lookup = func(key string, staleness, maximumStaleness int64) (*model.ExecutionCache, error) {
+							return store.GetExecutionCache(namespace, key, staleness, maximumStaleness)
+						}
+					}
+					cached, err := lookup(tc.key, tc.cacheStaleness, tc.maximumCacheStaleness)
+					switch {
+					case tc.wantMiss:
+						require.Nil(t, cached)
+						require.ErrorIs(t, err, ErrExecutionCacheNotFound)
+					case tc.wantDisabled:
+						require.Nil(t, cached)
+						require.ErrorContains(t, err, "Cache is disabled")
+						require.NotErrorIs(t, err, ErrExecutionCacheNotFound)
+					default:
+						require.NoError(t, err)
+						require.Equal(t, row, cached)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestExecutionCacheDatabaseErrorsAreNotMisses(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		maximumCacheStaleness int64
+		message               string
+	}{
+		{name: "query failure", maximumCacheStaleness: -1, message: "failed to get execution cache"},
+		{name: "cleanup failure", maximumCacheStaleness: 5, message: "Failed to cleanup old cache entries"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, dialect := NewFakeDBOrFatal()
+			defer closeDB(t, db)
+			store := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect)
+			require.NoError(t, db.Migrator().DropTable(&model.ExecutionCache{}))
+			cached, err := store.GetExecutionCache("default", "key", -1, tc.maximumCacheStaleness)
+			require.Nil(t, cached)
+			require.ErrorContains(t, err, tc.message)
+			require.NotErrorIs(t, err, ErrExecutionCacheNotFound)
+			cached, err = store.GetLegacyExecutionCache("key", -1, tc.maximumCacheStaleness)
+			require.Nil(t, cached)
+			require.ErrorContains(t, err, tc.message)
+			require.NotErrorIs(t, err, ErrExecutionCacheNotFound)
+		})
+	}
+}

--- a/backend/src/cache/storage/namespace_isolation_test.go
+++ b/backend/src/cache/storage/namespace_isolation_test.go
@@ -79,9 +79,13 @@ func TestCacheNamespaceMigrationAndStorage(t *testing.T) {
 
 			s := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect.NewDBDialect(backend))
 			_, err = s.GetExecutionCache("tenant-a", "shared-key", -1, -1)
-			require.Error(t, err, "legacy rows must not satisfy scoped lookups")
+			require.ErrorIs(t, err, ErrExecutionCacheNotFound, "legacy rows must not satisfy scoped lookups")
+			cachedLegacy, err := s.GetLegacyExecutionCache("shared-key", -1, -1)
+			require.NoError(t, err)
+			require.Equal(t, &migrated, cachedLegacy)
 			_, err = s.GetExecutionCache("", "shared-key", -1, -1)
 			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrExecutionCacheNotFound, "invalid namespaces must not trigger legacy fallback")
 			_, err = s.CreateExecutionCache(&model.ExecutionCache{ExecutionCacheKey: "shared-key"})
 			require.Error(t, err, "new rows require ownership")
 			for _, ns := range []string{"tenant-a", "tenant-b"} {
@@ -101,7 +105,10 @@ func TestCacheNamespaceMigrationAndStorage(t *testing.T) {
 				require.Equal(t, ns+"-output", cached.ExecutionOutput)
 			}
 			_, err = s.GetExecutionCache("tenant-c", "shared-key", -1, -1)
-			require.Error(t, err)
+			require.ErrorIs(t, err, ErrExecutionCacheNotFound)
+			cachedLegacy, err = s.GetLegacyExecutionCache("shared-key", -1, -1)
+			require.NoError(t, err)
+			require.Equal(t, &migrated, cachedLegacy, "legacy lookups must exclude namespaced entries with the same key")
 		})
 	}
 }

--- a/backend/src/cache/storage/namespace_isolation_test.go
+++ b/backend/src/cache/storage/namespace_isolation_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common/sql/dialect"
+	"github.com/kubeflow/pipelines/backend/src/cache/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// The pre-isolation schema, including its indexes, exercises upgrades with data.
+type legacyExecutionCache struct {
+	ID                int64  `gorm:"column:ID; not null; primaryKey; AUTO_INCREMENT; index:composite_id_idx"`
+	ExecutionCacheKey string `gorm:"column:ExecutionCacheKey; not null; index:idx_cache_key;"`
+	ExecutionTemplate string `gorm:"column:ExecutionTemplate; not null;"`
+	ExecutionOutput   string `gorm:"column:ExecutionOutput; not null;"`
+	MaxCacheStaleness int64  `gorm:"column:MaxCacheStaleness; not null;"`
+	StartedAtInSec    int64  `gorm:"column:StartedAtInSec; not null; index:composite_id_idx;"`
+	EndedAtInSec      int64  `gorm:"column:EndedAtInSec; not null;"`
+}
+
+func (legacyExecutionCache) TableName() string { return "execution_caches" }
+
+func TestCacheNamespaceMigrationAndStorage(t *testing.T) {
+	for _, backend := range []string{"sqlite", "mysql", "pgx"} {
+		t.Run(backend, func(t *testing.T) {
+			var driver gorm.Dialector
+			switch backend {
+			case "mysql":
+				dsn := os.Getenv("KFP_CACHE_TEST_MYSQL_DSN")
+				if dsn == "" {
+					t.Skip("set KFP_CACHE_TEST_MYSQL_DSN to an empty disposable database")
+				}
+				driver = mysql.New(mysql.Config{DSN: dsn, DefaultStringSize: 255})
+			case "pgx":
+				dsn := os.Getenv("KFP_CACHE_TEST_POSTGRES_DSN")
+				if dsn == "" {
+					t.Skip("set KFP_CACHE_TEST_POSTGRES_DSN to an empty disposable database")
+				}
+				driver = postgres.Open(dsn)
+			default:
+				driver = sqlite.Open(":memory:")
+			}
+			db, err := gorm.Open(driver, &gorm.Config{})
+			require.NoError(t, err)
+			defer closeDB(t, db)
+			// Never overwrite an existing cache database when integration tests are opted in.
+			require.False(t, db.Migrator().HasTable(&legacyExecutionCache{}), "use an empty disposable database")
+			require.NoError(t, db.AutoMigrate(&legacyExecutionCache{}))
+			legacy := legacyExecutionCache{ExecutionCacheKey: "shared-key", ExecutionTemplate: "{}", ExecutionOutput: "legacy-output", MaxCacheStaleness: -1, StartedAtInSec: 1, EndedAtInSec: 1}
+			require.NoError(t, db.Create(&legacy).Error)
+			require.NoError(t, db.AutoMigrate(&model.ExecutionCache{}))
+			require.NoError(t, db.AutoMigrate(&model.ExecutionCache{}), "migration must be idempotent")
+			require.True(t, db.Migrator().HasIndex(&model.ExecutionCache{}, "idx_cache_namespace_key"))
+			var migrated model.ExecutionCache
+			require.NoError(t, db.First(&migrated, legacy.ID).Error)
+			require.Empty(t, migrated.Namespace, "do not infer ownership for historical rows")
+			require.Equal(t, "legacy-output", migrated.ExecutionOutput)
+
+			s := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch(), dialect.NewDBDialect(backend))
+			_, err = s.GetExecutionCache("tenant-a", "shared-key", -1, -1)
+			require.Error(t, err, "legacy rows must not satisfy scoped lookups")
+			_, err = s.GetExecutionCache("", "shared-key", -1, -1)
+			require.Error(t, err)
+			_, err = s.CreateExecutionCache(&model.ExecutionCache{ExecutionCacheKey: "shared-key"})
+			require.Error(t, err, "new rows require ownership")
+			for _, ns := range []string{"tenant-a", "tenant-b"} {
+				row := createExecutionCache("shared-key", ns+"-output")
+				row.Namespace = ns
+				_, err := s.CreateExecutionCache(row)
+				require.NoError(t, err, "same key may exist in different namespaces and alongside legacy rows")
+				duplicate := createExecutionCache("shared-key", "replacement")
+				duplicate.Namespace = ns
+				_, err = s.CreateExecutionCache(duplicate)
+				require.Error(t, err, "duplicate detection remains scoped to its namespace")
+			}
+			for _, ns := range []string{"tenant-a", "tenant-b"} {
+				cached, err := s.GetExecutionCache(ns, "shared-key", -1, -1)
+				require.NoError(t, err)
+				require.Equal(t, ns, cached.Namespace)
+				require.Equal(t, ns+"-output", cached.ExecutionOutput)
+			}
+			_, err = s.GetExecutionCache("tenant-c", "shared-key", -1, -1)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

By default, isolate the legacy V1/raw-Argo execution cache by Kubernetes namespace on both the read and write paths.

- Preserve @vcrll's namespace-aware cache-key commit and authorship.
- Recompute completed pods' cache keys from the observed namespace and Argo template. Reject missing, malformed, or mismatched identities instead of trusting the mutable cache-key annotation.
- Persist the observed namespace separately and scope lookups and duplicate detection by namespace and key. Database predicates enforce ownership; namespace-bound hashes provide an additional safeguard.
- Exclude legacy namespace-less rows by default. Administrators can explicitly enable `ALLOW_LEGACY_CACHE_FALLBACK=true` to read only those rows using the original template-only hash after a genuine namespaced miss.
- Preserve disabled-cache behavior, expiry limits, scoped-hit precedence, and validated namespaced writes. Database errors do not trigger fallback, and another nonempty namespace is never a fallback source.
- Keep normal within-namespace reuse and standard V2 webhook bypass behavior.

Hashing alone is not the complete isolation guarantee: the watcher also validates identity and storage scopes ownership. This is namespace isolation, not an integrity boundary among users who can modify workloads in the same namespace.

## Upgrade impact

Startup migration adds the namespace column and composite index. Existing rows remain namespace-less and are not reused by default, so operators should plan for a cold cache and extra step executions.

The optional fallback is disabled by default. Enabling it explicitly accepts possible reuse of another tenant's historical outputs, including poisoned entries, because legacy ownership is unknown. The full isolation guarantee requires fallback to remain disabled. Legacy hits are not promoted or backfilled and do not warm the new namespaced cache; disabling fallback later can still cause cold-cache executions. The cache README documents enabling it for a bounded upgrade period and turning it off.

Stop old cache-server replicas before starting the fixed version, coordinate webhook downtime with submissions, and allow migration to finish before resuming submissions. Mixed old/new replicas do not provide the isolation guarantee. Standard V2 caching is separate and unchanged.

## Verification

- `go test ./backend/src/cache/... -count=1` — passed, including default-off/opt-in admission behavior, old-hash compatibility, namespace isolation, precedence, expiry, disabled caching, database errors, malformed templates, and no legacy promotion.
- `golangci-lint run --new-from-rev 96e17d9c ./backend/src/cache/...` — passed. Changed-file pre-commit formatting and hygiene hooks passed; Go analysis was run separately for the affected packages.
- Populated/idempotent schema migration and legacy/scoped lookups — passed on SQLite, MySQL 8.4.11, and PostgreSQL 16.15. Optional database test configuration is documented in the cache README.
- Kubernetes-backed end-to-end execution was not run; admission/watcher regressions use production handlers, real SQLite storage, and a fake Kubernetes patch client.

## Checklist

- [x] Commits are signed off.
- [x] PR title follows the repository convention.
