### PR TITLE
fix(backend): secure delegated recurring-run execution

### DIFF
--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -48,4 +48,4 @@ COPY --from=builder /bin/controller /bin/controller
 ENV NAMESPACE=""
 ENV LOG_LEVEL=info
 
-CMD ["/bin/sh", "-c", "/bin/controller --logtostderr=true --namespace=${NAMESPACE} --logLevel=${LOG_LEVEL} --clientQPS=${CLIENT_QPS:-5} --clientBurst=${CLIENT_BURST:-10} --recurringRunResyncIntervalSeconds=${RESYNC_INTERVAL_SECONDS:-30} --metricsPort=${METRICS_PORT:-9090} --userIdentityHeader=\"${USER_IDENTITY_HEADER:-}\" --userIdentityValue=\"${USER_IDENTITY_VALUE:-}\""]
+CMD ["/bin/sh", "-c", "/bin/controller --logtostderr=true --multiUser=${MULTIUSER:-false} --namespace=${NAMESPACE} --logLevel=${LOG_LEVEL} --clientQPS=${CLIENT_QPS:-5} --clientBurst=${CLIENT_BURST:-10} --recurringRunResyncIntervalSeconds=${RESYNC_INTERVAL_SECONDS:-30} --metricsPort=${METRICS_PORT:-9090} --userIdentityHeader=\"${USER_IDENTITY_HEADER:-}\" --userIdentityValue=\"${USER_IDENTITY_VALUE:-}\""]

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -31,6 +31,7 @@ const (
 	CacheEnabled                            string = "CacheEnabled"
 	DefaultPipelineRunnerServiceAccountFlag string = "DEFAULTPIPELINERUNNERSERVICEACCOUNT"
 	AllowedServiceAccountsFlag              string = "ALLOWEDSERVICEACCOUNTS"
+	WorkflowServiceAccountAudit             string = "WORKFLOW_SERVICE_ACCOUNT_AUDIT"
 	KubeflowUserIDHeader                    string = "KUBEFLOW_USERID_HEADER"
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
@@ -90,6 +91,11 @@ func IsPipelineVersionUpdatedByDefault() bool {
 
 func IsNamespaceRequiredForPipelines() bool {
 	return GetBoolConfigWithDefault(RequireNamespaceForPipelines, false)
+}
+
+// IsWorkflowServiceAccountAuditEnabled makes additional workflow identity checks advisory.
+func IsWorkflowServiceAccountAuditEnabled() bool {
+	return GetBoolConfigWithDefault(WorkflowServiceAccountAudit, false)
 }
 
 func GetStringConfig(configName string) string {

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -31,6 +31,7 @@ const (
 	CacheEnabled                            string = "CacheEnabled"
 	DefaultPipelineRunnerServiceAccountFlag string = "DEFAULTPIPELINERUNNERSERVICEACCOUNT"
 	AllowedServiceAccountsFlag              string = "ALLOWEDSERVICEACCOUNTS"
+	ServiceAccountAuthorizationMode         string = "SERVICEACCOUNTAUTHORIZATIONMODE"
 	KubeflowUserIDHeader                    string = "KUBEFLOW_USERID_HEADER"
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
@@ -353,4 +354,18 @@ func ValidateServiceAccountAllowList(serviceAccount string) error {
 		}
 	}
 	return fmt.Errorf("service account %q is not allowed; contact your administrator to configure the allowed service accounts", serviceAccount)
+}
+
+// GetServiceAccountAuthorizationMode validates the temporary migration mode.
+// Empty configuration preserves enforcement, including on upgrades.
+func GetServiceAccountAuthorizationMode() (string, error) {
+	mode := GetStringConfigWithDefault(ServiceAccountAuthorizationMode, "enforce")
+	switch mode {
+	case "", "enforce":
+		return "enforce", nil
+	case "audit":
+		return mode, nil
+	default:
+		return "", fmt.Errorf("%s must be enforce or audit", ServiceAccountAuthorizationMode)
+	}
 }

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -911,3 +911,35 @@ func TestValidateServiceAccountAllowList_ConfiguredDefaultAllowed(t *testing.T) 
 	err := ValidateServiceAccountAllowList("my-runner")
 	assert.Nil(t, err)
 }
+
+func TestGetServiceAccountAuthorizationMode(t *testing.T) {
+	for _, tc := range []struct {
+		name, value, want string
+		invalid           bool
+	}{
+		{name: "unset", want: "enforce"},
+		{name: "empty", want: "enforce"},
+		{name: "enforce", value: "enforce", want: "enforce"},
+		{name: "audit", value: "audit", want: "audit"},
+		{name: "typo", value: "audti", invalid: true},
+		{name: "legacy", value: "legacy", invalid: true},
+		{name: "case", value: "AUDIT", invalid: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			viper.AutomaticEnv()
+			viper.AllowEmptyEnv(true)
+			if tc.name != "unset" {
+				t.Setenv(ServiceAccountAuthorizationMode, tc.value)
+			}
+			got, err := GetServiceAccountAuthorizationMode()
+			if tc.invalid {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -26,6 +26,18 @@ import (
 // NOTE: These tests use viper.Reset() which mutates the global viper singleton.
 // Do not add t.Parallel() to these subtests — the shared viper state would race.
 
+func TestIsWorkflowServiceAccountAuditEnabled(t *testing.T) {
+	for _, value := range []string{"", "false", "true"} {
+		t.Run("value="+value, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			t.Setenv(WorkflowServiceAccountAudit, value)
+			viper.AutomaticEnv()
+			assert.Equal(t, value == "true", IsWorkflowServiceAccountAuditEnabled())
+		})
+	}
+}
+
 func TestGetStringConfigWithDefault(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -760,6 +760,10 @@ func initConfig() error {
 		glog.Fatalf("Invalid plugin limits configuration: %v", err)
 	}
 
+	if err := validateServiceAccountAuthorizationMode(); err != nil {
+		return err
+	}
+
 	// Watch for configuration change
 	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {
@@ -768,6 +772,9 @@ func initConfig() error {
 		}
 		if _, err := common.GetPluginLimitsConfig(); err != nil {
 			glog.Fatalf("Invalid plugin limits configuration: %v", err)
+		}
+		if err := validateServiceAccountAuthorizationMode(); err != nil {
+			glog.Fatalf("Invalid service-account authorization configuration: %v", err)
 		}
 	})
 
@@ -835,4 +842,15 @@ func getPVCSpec() (*corev1.PersistentVolumeClaimSpec, error) {
 	}
 
 	return &pvcSpec, nil
+}
+
+func validateServiceAccountAuthorizationMode() error {
+	mode, err := common.GetServiceAccountAuthorizationMode()
+	if err != nil {
+		return err
+	}
+	if mode == "audit" {
+		glog.Warning("SERVICEACCOUNTAUTHORIZATIONMODE=audit: service-account policy denials are allowed; this restores the security exposure addressed by service-account authorization. Migrate to enforce before 3.0.0, when audit mode is planned for removal (https://github.com/kubeflow/pipelines/issues/14367).")
+	}
+	return nil
 }

--- a/backend/src/apiserver/main_test.go
+++ b/backend/src/apiserver/main_test.go
@@ -902,3 +902,15 @@ func TestBuildHTTPRouter_UnmatchedAPIsGoToGateway(t *testing.T) {
 
 	assert.True(t, gatewayHandlerCalled, "requests to /apis/ paths not matching explicit routes should reach the gRPC gateway handler")
 }
+
+func TestInitConfigRejectsInvalidServiceAccountAuthorizationMode(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv(common.ServiceAccountAuthorizationMode, "audti")
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "config.json"), []byte(`{}`), 0600))
+	original := *configPath
+	*configPath = tempDir
+	t.Cleanup(func() { *configPath = original })
+	require.ErrorContains(t, initConfig(), "SERVICEACCOUNTAUTHORIZATIONMODE must be enforce or audit")
+}

--- a/backend/src/apiserver/model/common.go
+++ b/backend/src/apiserver/model/common.go
@@ -83,6 +83,7 @@ func AllModels() []any {
 		&PipelineTag{},
 		&PipelineVersionTag{},
 		&Job{},
+		&RecurringRunState{},
 		&Run{},
 		&RunMetric{},
 		&Task{},

--- a/backend/src/apiserver/model/recurring_run_state.go
+++ b/backend/src/apiserver/model/recurring_run_state.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// RecurringRunState stores API-owned scheduling progress. A pending claim keeps
+// its index and timestamps until workflow creation has been persisted.
+type RecurringRunState struct {
+	JobUUID              string `gorm:"column:JobUUID; not null; primaryKey; type:varchar(191);"`
+	RequestKey           string `gorm:"column:RequestKey; not null; type:text;"`
+	PipelineVersionID    string `gorm:"column:PipelineVersionID; not null; type:varchar(191);"`
+	LastRunIndex         int64  `gorm:"column:LastRunIndex; not null; default:0;"`
+	LastScheduledAtInSec int64  `gorm:"column:LastScheduledAtInSec; not null; default:0;"`
+	LastCreatedAtInSec   int64  `gorm:"column:LastCreatedAtInSec; not null; default:0;"`
+	Pending              bool   `gorm:"column:Pending; not null; default:false;"`
+}
+
+func (RecurringRunState) TableName() string {
+	return "recurring_run_states"
+}

--- a/backend/src/apiserver/plugins/creation.go
+++ b/backend/src/apiserver/plugins/creation.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+// AnnotationKeyPluginParents records parent IDs without plugin configuration or credentials.
+const AnnotationKeyPluginParents = "pipelines.kubeflow.org/plugin-parents"
+
+// SetExecutionPluginParents records ownership before Kubernetes arbitrates run creation.
+// An empty map distinguishes a creator with no parents from an older execution
+// whose plugin resources are unknown.
+func SetExecutionPluginParents(run *PendingRun, execution util.ExecutionSpec) error {
+	outputs, err := DeserializePluginsOutput((*model.LargeText)(run.PluginsOutput))
+	if err != nil {
+		return err
+	}
+	parents := map[string]string{}
+	for name, output := range outputs {
+		if parentID := GetParentRunID(output); parentID != "" {
+			parents[name] = parentID
+		}
+	}
+	raw, err := json.Marshal(parents)
+	if err != nil {
+		return err
+	}
+	execution.SetAnnotations(AnnotationKeyPluginParents, string(raw))
+	return nil
+}
+
+// OnRunCreationDiscarded finalizes parents belonging only to this request.
+// Cleanup is best effort: failures are returned for logging, never persisted
+// over the winning run's plugin output.
+func (d *RunPluginDispatcherImpl) OnRunCreationDiscarded(ctx context.Context, run *PendingRun, existing util.ExecutionSpec) error {
+	if d == nil || run == nil || existing == nil {
+		return fmt.Errorf("dispatcher, run, and existing execution must be non-nil")
+	}
+	outputs, err := DeserializePluginsOutput((*model.LargeText)(run.PluginsOutput))
+	if err != nil || len(outputs) == 0 {
+		return err
+	}
+	var parents map[string]string
+	raw := existing.ExecutionObjectMeta().Annotations[AnnotationKeyPluginParents]
+	if err := json.Unmarshal([]byte(raw), &parents); err != nil || parents == nil {
+		return fmt.Errorf("cannot clean up discarded creation for run %q: existing execution plugin parents are unknown", run.RunID)
+	}
+	discarded := &PersistedRun{
+		RunID: run.RunID, Namespace: run.Namespace, State: string(model.RuntimeStateCanceled),
+		PluginsOutput: map[string]*apiv2beta1.PluginOutput{},
+	}
+	for name, output := range outputs {
+		if parentID := GetParentRunID(output); parentID != "" && parentID != parents[name] {
+			discarded.PluginsOutput[name] = output
+		}
+	}
+	if len(discarded.PluginsOutput) == 0 {
+		return nil
+	}
+	configs, err := d.RetrieveMultiUserModeConfigOverrides(ctx, run.RunID, run.Namespace)
+	if err != nil {
+		return err
+	}
+	var cleanupErrors []error
+	for _, handler := range d.handlers {
+		if discarded.PluginsOutput[handler.Name()] == nil {
+			continue
+		}
+		cfg, err := handler.ResolveRunPluginConfig(ctx, d.kubeClients.GetClientSet(), configs[handler.Name()], run.Namespace)
+		if err != nil || cfg == nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("cannot resolve %s config for discarded creation: %v", handler.Name(), err))
+			continue
+		}
+		pluginCtx, cancel := context.WithTimeout(ctx, handler.GetPluginOperationTimeout(cfg))
+		retryable, err := handler.OnRunEnd(pluginCtx, discarded, cfg)
+		cancel()
+		if err != nil || retryable || discarded.PluginsOutput[handler.Name()].GetState() == apiv2beta1.PluginState_PLUGIN_FAILED {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to finalize %s parent for discarded creation: %v", handler.Name(), err))
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}

--- a/backend/src/apiserver/plugins/creation_test.go
+++ b/backend/src/apiserver/plugins/creation_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"context"
+	"testing"
+
+	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func creationPluginOutput(parentID string) *apiv2beta1.PluginOutput {
+	return &apiv2beta1.PluginOutput{Entries: map[string]*apiv2beta1.MetadataValue{
+		EntryRootRunID: {Value: structpb.NewStringValue(parentID)},
+	}}
+}
+
+func TestSetExecutionPluginParents(t *testing.T) {
+	for _, populated := range []bool{false, true} {
+		run := &PendingRun{}
+		execution := newFakeExecutionSpec()
+		execution.SetAnnotations(AnnotationKeyPluginParents, `{"spoofed":"parent"}`)
+		expected := `{}`
+		if populated {
+			output := creationPluginOutput("parent-1")
+			output.StateMessage = "not runtime ownership metadata"
+			require.NoError(t, SetPendingRunPluginOutput(run, "test", output))
+			expected = `{"test":"parent-1"}`
+		}
+		require.NoError(t, SetExecutionPluginParents(run, execution))
+		require.JSONEq(t, expected, execution.ExecutionObjectMeta().Annotations[AnnotationKeyPluginParents])
+	}
+}
+
+type discardedCreationHandler struct {
+	fakeHandler
+	ended []*PersistedRun
+}
+
+func (h *discardedCreationHandler) OnRunEnd(_ context.Context, run *PersistedRun, _ interface{}) (bool, error) {
+	h.ended = append(h.ended, run)
+	if h.endBool {
+		run.PluginsOutput[h.name].State = apiv2beta1.PluginState_PLUGIN_FAILED
+	}
+	return h.endBool, h.endErr
+}
+
+func TestOnRunCreationDiscardedPreservesWinningParentsAndOutput(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		parents    string
+		wantCalls  int
+		wantError  bool
+		cleanupErr bool
+	}{
+		{name: "distinct parent", parents: `{"test":"parent-1"}`, wantCalls: 1},
+		{name: "shared parent", parents: `{"test":"parent-2"}`},
+		{name: "creator had no parents", parents: `{}`, wantCalls: 1},
+		{name: "legacy execution", wantError: true},
+		{name: "malformed metadata", parents: `{`, wantError: true},
+		{name: "null metadata", parents: `null`, wantError: true},
+		{name: "cleanup failure", parents: `{}`, wantCalls: 1, wantError: true, cleanupErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler := &discardedCreationHandler{fakeHandler: fakeHandler{
+				name: "test", pluginConfig: &PluginConfig{}, endBool: test.cleanupErr,
+			}}
+			store := &fakeRunPluginOutputStoreWithError{}
+			dispatcher, err := NewRunPluginDispatcherImpl([]RunPluginHandler{handler}, &fakeKubeClientProvider{}, store)
+			require.NoError(t, err)
+			run := &PendingRun{RunID: "run-1", Namespace: "ns1"}
+			require.NoError(t, SetPendingRunPluginOutput(run, "test", creationPluginOutput("parent-2")))
+			execution := newFakeExecutionSpec()
+			if test.parents != "" {
+				execution.SetAnnotations(AnnotationKeyPluginParents, test.parents)
+			}
+			err = dispatcher.OnRunCreationDiscarded(context.Background(), run, execution)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, handler.ended, test.wantCalls)
+			if test.wantCalls > 0 {
+				require.Equal(t, string(model.RuntimeStateCanceled), handler.ended[0].State)
+				require.Equal(t, "parent-2", GetParentRunID(handler.ended[0].PluginsOutput["test"]))
+			}
+			require.Zero(t, store.callCount, "cleanup must never persist the discarded request's output")
+		})
+	}
+}

--- a/backend/src/apiserver/plugins/dispatcher.go
+++ b/backend/src/apiserver/plugins/dispatcher.go
@@ -42,6 +42,11 @@ type RunPluginDispatcher interface {
 	// run creation.
 	OnBeforeRunCreation(ctx context.Context, run *PendingRun, executionSpec util.ExecutionSpec) error
 
+	// OnRunCreationDiscarded cleans up resources created only by a losing request.
+	// It must preserve resources referenced by the existing execution and must
+	// not persist the losing request's plugin output.
+	OnRunCreationDiscarded(ctx context.Context, run *PendingRun, existing util.ExecutionSpec) error
+
 	// OnRunEnd is called when a run reaches a terminal state. Returns
 	// true if all plugin syncs succeeded.
 	OnRunEnd(ctx context.Context, run *PersistedRun) bool
@@ -60,6 +65,9 @@ var _ RunPluginDispatcher = NoOpDispatcher{}
 
 func (NoOpDispatcher) PluginsRegistered() bool { return false }
 func (NoOpDispatcher) OnBeforeRunCreation(context.Context, *PendingRun, util.ExecutionSpec) error {
+	return nil
+}
+func (NoOpDispatcher) OnRunCreationDiscarded(context.Context, *PendingRun, util.ExecutionSpec) error {
 	return nil
 }
 func (NoOpDispatcher) OnRunEnd(context.Context, *PersistedRun) bool { return true }

--- a/backend/src/apiserver/resource/recurring_run.go
+++ b/backend/src/apiserver/resource/recurring_run.go
@@ -91,6 +91,33 @@ func (r *ResourceManager) PrepareRecurringRun(ctx context.Context, run *model.Ru
 	return nil
 }
 
+// Replay authorizes the retained execution, not a newer template or mutable schedule.
+func (r *ResourceManager) authorizeStoredRunServiceAccount(ctx context.Context, run *model.Run) error {
+	serviceAccount, namespace := run.ServiceAccount, run.Namespace
+	if serviceAccount == "" {
+		// Persistence-agent recovery may omit the account column while retaining
+		// the execution manifest in either runtime field.
+		manifest := storedWorkflowIdentityManifest(run)
+		if manifest == "" {
+			return util.NewFailedPreconditionError(fmt.Errorf("stored execution identity is missing"),
+				"Restore the execution metadata for run %s before retrying its acknowledgement", run.UUID)
+		}
+		execution, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(manifest))
+		if err != nil {
+			return util.Wrap(err, "Failed to read the stored execution account for recurring-run acknowledgement")
+		}
+		if execution.ExecutionName() == "" {
+			return util.NewFailedPreconditionError(fmt.Errorf("stored execution name is missing"),
+				"Restore the execution metadata for run %s before retrying its acknowledgement", run.UUID)
+		}
+		serviceAccount = execution.ServiceAccount()
+		if namespace == "" {
+			namespace = execution.ExecutionNamespace()
+		}
+	}
+	return r.authorizeServiceAccount(ctx, serviceAccount, namespace)
+}
+
 // V1 workflows may carry the effective account inside their embedded Argo spec.
 func scheduledServiceAccount(swf *scheduledworkflow.ScheduledWorkflow, fallback string) (string, error) {
 	if swf.Spec.Workflow != nil && swf.Spec.Workflow.Spec != nil {

--- a/backend/src/apiserver/resource/recurring_run.go
+++ b/backend/src/apiserver/resource/recurring_run.go
@@ -1,0 +1,107 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resource coordinates API resource persistence and execution.
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+)
+
+// PrepareRecurringRun resolves execution inputs from the API-created job rather than
+// the editable ScheduledWorkflow. Service-account and pipeline authorization must still run afterwards.
+func (r *ResourceManager) PrepareRecurringRun(ctx context.Context, run *model.Run) error {
+	if !common.IsMultiUserMode() || run.RecurringRunId == "" {
+		return nil
+	}
+	job, err := r.GetJob(run.RecurringRunId)
+	if err != nil {
+		return util.Wrap(err, "Failed to resolve the authorized recurring run; create schedules through the KFP API")
+	}
+	namespace := job.Namespace
+	if r.IsEmptyNamespace(namespace) {
+		namespace, err = r.GetNamespaceFromExperimentId(job.ExperimentId)
+		if err != nil {
+			return err
+		}
+	}
+	if r.IsEmptyNamespace(namespace) {
+		return util.NewPermissionDeniedError(fmt.Errorf("recurring run has no namespace"),
+			"Recreate the recurring run in a namespaced experiment")
+	}
+	// Authorize access before exposing schedule state or copying its execution inputs.
+	if err := r.IsAuthorized(ctx, &authorizationv1.ResourceAttributes{
+		Namespace: namespace, Verb: common.RbacResourceVerbCreate,
+		Group: common.RbacPipelinesGroup, Version: common.RbacPipelinesVersion, Resource: common.RbacResourceTypeRuns,
+	}); err != nil {
+		return util.Wrap(err, "Failed to authorize scheduled run creation")
+	}
+	if (!r.IsEmptyNamespace(run.Namespace) && run.Namespace != namespace) ||
+		(run.ExperimentId != "" && run.ExperimentId != job.ExperimentId) {
+		return util.NewPermissionDeniedError(fmt.Errorf("recurring run destination differs from its authorized job"),
+			"A recurring run can only create runs in its own namespace and experiment")
+	}
+	if job.ExperimentId != "" {
+		experimentNamespace, err := r.GetNamespaceFromExperimentId(job.ExperimentId)
+		if err != nil {
+			return err
+		}
+		if !r.IsEmptyNamespace(experimentNamespace) && experimentNamespace != namespace {
+			return util.NewPermissionDeniedError(fmt.Errorf("recurring run and experiment namespaces differ"),
+				"A recurring run can only create runs in its own namespace and experiment")
+		}
+	}
+	swf, err := r.getScheduledWorkflowClient(namespace).Get(ctx, job.K8SName, v1.GetOptions{})
+	if err != nil {
+		return util.Wrap(err, "Failed to retrieve the authorized ScheduledWorkflow")
+	}
+	if swf == nil || string(swf.UID) != job.UUID || swf.Name != job.K8SName || swf.Namespace != namespace {
+		return util.NewPermissionDeniedError(fmt.Errorf("ScheduledWorkflow identity does not match its job"),
+			"Recreate the recurring run through the KFP API")
+	}
+	if !job.Enabled || !swf.Spec.Enabled {
+		return util.NewPermissionDeniedError(fmt.Errorf("recurring run is disabled"),
+			"Enable the recurring run through the KFP API before triggering runs")
+	}
+	run.Namespace = namespace
+	run.ExperimentId = job.ExperimentId
+	run.PipelineSpec = job.PipelineSpec
+	run.ServiceAccount = job.ServiceAccount
+	run.PluginsInputString = job.PluginsInputString
+	return nil
+}
+
+// V1 workflows may carry the effective account inside their embedded Argo spec.
+func scheduledServiceAccount(swf *scheduledworkflow.ScheduledWorkflow, fallback string) (string, error) {
+	if swf.Spec.Workflow != nil && swf.Spec.Workflow.Spec != nil {
+		execution, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, swf.Spec.Workflow)
+		if err != nil {
+			return "", util.Wrap(err, "Failed to resolve the scheduled service account")
+		}
+		return execution.ServiceAccount(), nil
+	}
+	if swf.Spec.ServiceAccount != "" {
+		return swf.Spec.ServiceAccount, nil
+	}
+	return fallback, nil
+}

--- a/backend/src/apiserver/resource/recurring_run_execution.go
+++ b/backend/src/apiserver/resource/recurring_run_execution.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// createRunExecution uses Kubernetes name uniqueness to arbitrate concurrent
+// recurring-run submissions before either request has persisted its run.
+// The boolean reports whether this request created the execution.
+func (r *ResourceManager) createRunExecution(ctx context.Context, run *model.Run, execution util.ExecutionSpec) (util.ExecutionSpec, bool, error) {
+	if run.RecurringRunId != "" {
+		execution.SetExecutionName("run-" + util.NewDeterministicUUID(run.UUID))
+	}
+	client := r.getWorkflowClient(execution.ExecutionNamespace())
+	created, err := client.Create(ctx, execution, metav1.CreateOptions{})
+	if err == nil {
+		return created, true, nil
+	}
+	if run.RecurringRunId == "" || !apierrors.IsAlreadyExists(err) {
+		return nil, false, err
+	}
+	existing, err := client.Get(ctx, execution.ExecutionName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, false, util.Wrap(err, "Failed to retrieve the existing recurring-run workflow")
+	}
+	if !sameRecurringRunExecution(run, execution, existing) {
+		return nil, false, util.NewPermissionDeniedError(
+			fmt.Errorf("existing workflow identity does not match recurring run %q", run.RecurringRunId),
+			"Cannot reuse the conflicting recurring-run workflow; resolve the conflicting Kubernetes object")
+	}
+	return existing, false, nil
+}
+
+func sameRecurringRunExecution(run *model.Run, requested, existing util.ExecutionSpec) bool {
+	if existing == nil || existing.ExecutionUID() == "" ||
+		existing.ExecutionName() != requested.ExecutionName() ||
+		existing.ExecutionNamespace() != requested.ExecutionNamespace() ||
+		existing.ServiceAccount() != requested.ServiceAccount() ||
+		existing.ScheduledWorkflowUUIDAsStringOrEmpty() != run.RecurringRunId {
+		return false
+	}
+	metadata := existing.ExecutionObjectMeta()
+	if metadata.Labels[util.LabelKeyWorkflowRunId] != run.UUID ||
+		metadata.Annotations[util.AnnotationKeyRunName] != run.DisplayName {
+		return false
+	}
+	for _, expectedOwner := range requested.ExecutionObjectMeta().OwnerReferences {
+		if string(expectedOwner.UID) != run.RecurringRunId {
+			continue
+		}
+		for _, actualOwner := range metadata.OwnerReferences {
+			if actualOwner.UID == expectedOwner.UID && actualOwner.Name == expectedOwner.Name &&
+				actualOwner.APIVersion == expectedOwner.APIVersion && actualOwner.Kind == expectedOwner.Kind {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/src/apiserver/resource/recurring_run_execution_test.go
+++ b/backend/src/apiserver/resource/recurring_run_execution_test.go
@@ -16,6 +16,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,7 @@ import (
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -156,16 +158,19 @@ func (c fixedRecurringTime) Now() time.Time { return time.Unix(c.epoch, 0) }
 
 type pausedRecurringRunDispatcher struct {
 	apiserverPlugins.NoOpDispatcher
-	calls       atomic.Int32
-	endCalls    atomic.Int32
-	outputs     bool
-	firstHook   chan struct{}
-	resumeFirst chan struct{}
+	calls           atomic.Int32
+	endCalls        atomic.Int32
+	outputs         bool
+	onlyFirstOutput bool
+	firstHook       chan struct{}
+	resumeFirst     chan struct{}
 }
+
+func (d *pausedRecurringRunDispatcher) PluginsRegistered() bool { return d.outputs }
 
 func (d *pausedRecurringRunDispatcher) OnBeforeRunCreation(_ context.Context, run *apiserverPlugins.PendingRun, execution util.ExecutionSpec) error {
 	call := d.calls.Add(1)
-	if d.outputs {
+	if d.outputs && (!d.onlyFirstOutput || call == 1) {
 		output := fmt.Sprintf(`{"test":{"entries":{"id":{"value":"parent-%d"}}}}`, call)
 		run.PluginsOutput = &output
 		execution.SetAnnotations("test/plugin-parent", fmt.Sprintf("parent-%d", call))
@@ -265,6 +270,139 @@ func TestCreateRunConcurrentAuthorizedTickCreatesOneWorkflow(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, int64(1), state.LastRunIndex)
 			require.False(t, state.Pending)
+		})
+	}
+}
+
+// Pause the creator after Kubernetes accepts its Workflow but before the API
+// persists the run. A lost response leaves recovery to the persistence agent.
+type pausedRecurringExecutionClient struct {
+	util.ExecutionInterface
+	calls        atomic.Int32
+	created      chan util.ExecutionSpec
+	resume       chan struct{}
+	loseResponse bool
+}
+
+func (c *pausedRecurringExecutionClient) Create(ctx context.Context, execution util.ExecutionSpec, options metav1.CreateOptions) (util.ExecutionSpec, error) {
+	call := c.calls.Add(1)
+	created, err := c.ExecutionInterface.Create(ctx, execution, options)
+	if call == 1 && err == nil {
+		c.created <- created
+		<-c.resume
+		if c.loseResponse {
+			return nil, errors.New("workflow creation response was lost")
+		}
+	}
+	return created, err
+}
+
+func TestCreateRunExistingExecutionWaitsForCreatorPersistence(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		plugins      bool
+		loseResponse bool
+	}{
+		{name: "fixed-name V1 with differing plugin configurations", plugins: true},
+		{name: "V2 without plugins"},
+		{name: "V2 recovered by the persistence agent", loseResponse: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store, manager, experiment := initWithExperiment(t)
+			defer store.Close()
+			for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
+				previous := viper.Get(key)
+				viper.Set(key, value)
+				t.Cleanup(func() { viper.Set(key, previous) })
+			}
+			manager.time = fixedRecurringTime{epoch: 200}
+			ctx := multiUserContext()
+			dispatcher := &pausedRecurringRunDispatcher{outputs: test.plugins, onlyFirstOutput: true}
+			manager.pluginDispatcher = dispatcher
+			pipeline := model.PipelineSpec{
+				PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+				RuntimeConfig:        model.RuntimeConfig{Parameters: `{"text":"world"}`, PipelineRoot: "schedule-root"},
+			}
+			if test.plugins {
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.SetExecutionName("fixed-plugin-workflow")
+				pipeline = model.PipelineSpec{WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore())}
+			}
+			job, err := manager.CreateJob(ctx, &model.Job{
+				DisplayName: "pending-creator", Namespace: "ns1", ExperimentId: experiment.UUID,
+				Enabled: true, MaxConcurrency: 1, PipelineSpec: pipeline,
+				Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+					PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+				}},
+			})
+			require.NoError(t, err)
+			client := &pausedRecurringExecutionClient{
+				ExecutionInterface: &uniqueRecurringWorkflowClient{ExecutionInterface: store.ExecClientFake.Execution(job.Namespace)},
+				created:            make(chan util.ExecutionSpec, 1), resume: make(chan struct{}), loseResponse: test.loseResponse,
+			}
+			manager.execClient = &retryWorkflowExecClient{workflowClient: client}
+			resumeCreator := sync.OnceFunc(func() { close(client.resume) })
+			defer resumeCreator()
+			makeRun := func() *model.Run {
+				run := &model.Run{DisplayName: "same-tick", RecurringRunId: job.UUID}
+				require.NoError(t, manager.PrepareRecurringRun(ctx, run))
+				return run
+			}
+			firstInput, secondInput := makeRun(), makeRun()
+			type result struct {
+				run *model.Run
+				err error
+			}
+			firstDone := make(chan result, 1)
+			go func() {
+				run, err := manager.CreateRun(ctx, firstInput)
+				firstDone <- result{run, err}
+			}()
+			var workflow util.ExecutionSpec
+			select {
+			case workflow = <-client.created:
+			case first := <-firstDone:
+				t.Fatalf("creator did not submit its Workflow: %v", first.err)
+			case <-time.After(10 * time.Second):
+				t.Fatal("creator did not submit its Workflow")
+			}
+			second, err := manager.CreateRun(ctx, secondInput)
+			require.Nil(t, second)
+			require.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable), "error: %v", err)
+			_, err = manager.GetRun(firstInput.UUID)
+			require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound), "the loser must not insert a run: %v", err)
+			require.Zero(t, dispatcher.endCalls.Load(), "the loser must not end the creator's plugin resources")
+			pending, err := store.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			require.True(t, pending.Pending)
+
+			resumeCreator()
+			first := <-firstDone
+			if test.loseResponse {
+				require.ErrorContains(t, first.err, "workflow creation response was lost")
+				_, err = manager.ReportWorkflowResource(ctx, workflow)
+				require.NoError(t, err)
+			} else {
+				require.NoError(t, first.err)
+			}
+			retried, err := manager.CreateRun(ctx, makeRun())
+			require.NoError(t, err)
+			require.Equal(t, firstInput.UUID, retried.UUID)
+			require.Equal(t, workflow.ExecutionName(), retried.K8SName)
+			require.Equal(t, "same-tick", retried.DisplayName)
+			require.Equal(t, int64(110), retried.ScheduledAtInSec)
+			require.Equal(t, int64(200), retried.CreatedAtInSec)
+			require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+			if test.plugins {
+				require.NotNil(t, retried.PluginsOutputString)
+				require.Equal(t, first.run.PluginsOutputString, retried.PluginsOutputString)
+				require.Contains(t, string(*retried.PluginsOutputString), "parent-1")
+				require.Equal(t, "parent-1", workflow.ExecutionObjectMeta().Annotations["test/plugin-parent"])
+			}
+			state, err := store.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			require.False(t, state.Pending)
+			require.Equal(t, int64(1), state.LastRunIndex)
 		})
 	}
 }

--- a/backend/src/apiserver/resource/recurring_run_execution_test.go
+++ b/backend/src/apiserver/resource/recurring_run_execution_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// The shared fake overwrites fixed names. Match Kubernetes' atomic name
+// uniqueness here so a second submission cannot silently replace a workflow.
+type uniqueRecurringWorkflowClient struct {
+	util.ExecutionInterface
+	mu sync.Mutex
+}
+
+func (c *uniqueRecurringWorkflowClient) Create(ctx context.Context, execution util.ExecutionSpec, options metav1.CreateOptions) (util.ExecutionSpec, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if execution.ExecutionName() != "" {
+		_, err := c.Get(ctx, execution.ExecutionName(), metav1.GetOptions{})
+		if err == nil {
+			return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execution.ExecutionName())
+		}
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+	}
+	return c.ExecutionInterface.Create(ctx, execution, options)
+}
+
+func recurringExecutionFixture(run *model.Run) *util.Workflow {
+	workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	workflow.SetExecutionNamespace("ns1")
+	workflow.SetLabels(util.LabelKeyWorkflowRunId, run.UUID)
+	workflow.SetAnnotations(util.AnnotationKeyRunName, run.DisplayName)
+	workflow.SetOwnerReferences(&swfapi.ScheduledWorkflow{ObjectMeta: metav1.ObjectMeta{
+		Name: "schedule", UID: "schedule-uid",
+	}})
+	return workflow
+}
+
+func TestCreateRunExecutionReusesRecurringWorkflow(t *testing.T) {
+	store, manager, _ := initWithExperiment(t)
+	defer store.Close()
+	manager.execClient = &retryWorkflowExecClient{workflowClient: &uniqueRecurringWorkflowClient{ExecutionInterface: store.ExecClientFake.Execution("ns1")}}
+	run := &model.Run{UUID: "tick-uuid", DisplayName: "tick", RecurringRunId: "schedule-uid"}
+	ctx := context.Background()
+	first, created, err := manager.createRunExecution(ctx, run, recurringExecutionFixture(run))
+	require.NoError(t, err)
+	require.True(t, created)
+	second, created, err := manager.createRunExecution(ctx, run, recurringExecutionFixture(run))
+	require.NoError(t, err)
+	require.False(t, created)
+	require.Equal(t, first.ExecutionUID(), second.ExecutionUID())
+	require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+
+	run.UUID = "next-tick-uuid"
+	run.DisplayName = "next-tick"
+	next, created, err := manager.createRunExecution(ctx, run, recurringExecutionFixture(run))
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NotEqual(t, first.ExecutionName(), next.ExecutionName())
+	require.Equal(t, 2, store.ExecClientFake.GetWorkflowCount())
+}
+
+func TestCreateRunExecutionPreservesOrdinaryWorkflowNames(t *testing.T) {
+	store, manager, _ := initWithExperiment(t)
+	defer store.Close()
+	run := &model.Run{UUID: "ordinary-run"}
+	workflow := recurringExecutionFixture(run)
+	workflow.Name = ""
+	workflow.GenerateName = "ordinary-"
+	created, newExecution, err := manager.createRunExecution(context.Background(), run, workflow)
+	require.NoError(t, err)
+	require.True(t, newExecution)
+	require.Equal(t, "ordinary-0", created.ExecutionName())
+}
+
+func TestCreateRunExecutionRejectsConflictingWorkflow(t *testing.T) {
+	for name, mutate := range map[string]func(*util.Workflow){
+		"name":          func(w *util.Workflow) { w.Name = "another-workflow" },
+		"namespace":     func(w *util.Workflow) { w.Namespace = "another-namespace" },
+		"missing UID":   func(w *util.Workflow) { w.UID = "" },
+		"account":       func(w *util.Workflow) { w.Spec.ServiceAccountName = "another-account" },
+		"run ID":        func(w *util.Workflow) { w.Labels[util.LabelKeyWorkflowRunId] = "another-run" },
+		"run name":      func(w *util.Workflow) { w.Annotations[util.AnnotationKeyRunName] = "another-tick" },
+		"owner UID":     func(w *util.Workflow) { w.OwnerReferences[0].UID = "another-schedule-uid" },
+		"owner name":    func(w *util.Workflow) { w.OwnerReferences[0].Name = "another-schedule" },
+		"owner kind":    func(w *util.Workflow) { w.OwnerReferences[0].Kind = "Pod" },
+		"owner version": func(w *util.Workflow) { w.OwnerReferences[0].APIVersion = "v1" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, manager, _ := initWithExperiment(t)
+			defer store.Close()
+			manager.execClient = &retryWorkflowExecClient{workflowClient: &uniqueRecurringWorkflowClient{ExecutionInterface: store.ExecClientFake.Execution("ns1")}}
+			run := &model.Run{UUID: "tick-uuid", DisplayName: "tick", RecurringRunId: "schedule-uid"}
+			first := recurringExecutionFixture(run)
+			_, _, err := manager.createRunExecution(context.Background(), run, first)
+			require.NoError(t, err)
+			mutate(first)
+			_, created, err := manager.createRunExecution(context.Background(), run, recurringExecutionFixture(run))
+			require.ErrorContains(t, err, "existing workflow identity does not match")
+			require.False(t, created)
+			require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+		})
+	}
+}
+
+func TestCreateRunRecurringTicksReplaceFixedWorkflowName(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	manager.execClient = &retryWorkflowExecClient{workflowClient: &uniqueRecurringWorkflowClient{ExecutionInterface: store.ExecClientFake.Execution(job.Namespace)}}
+	var names []string
+	for _, displayName := range []string{"first-tick", "second-tick"} {
+		run, err := manager.CreateRun(context.Background(), &model.Run{
+			DisplayName: displayName, RecurringRunId: job.UUID, ExperimentId: job.ExperimentId, PipelineSpec: job.PipelineSpec,
+		})
+		require.NoError(t, err)
+		names = append(names, run.K8SName)
+	}
+	require.NotEqual(t, names[0], names[1])
+	require.Equal(t, 2, store.ExecClientFake.GetWorkflowCount())
+}
+
+type fixedRecurringTime struct{ epoch int64 }
+
+func (c fixedRecurringTime) Now() time.Time { return time.Unix(c.epoch, 0) }
+
+type pausedRecurringRunDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
+	calls       atomic.Int32
+	endCalls    atomic.Int32
+	outputs     bool
+	firstHook   chan struct{}
+	resumeFirst chan struct{}
+}
+
+func (d *pausedRecurringRunDispatcher) OnBeforeRunCreation(_ context.Context, run *apiserverPlugins.PendingRun, execution util.ExecutionSpec) error {
+	call := d.calls.Add(1)
+	if d.outputs {
+		output := fmt.Sprintf(`{"test":{"entries":{"id":{"value":"parent-%d"}}}}`, call)
+		run.PluginsOutput = &output
+		execution.SetAnnotations("test/plugin-parent", fmt.Sprintf("parent-%d", call))
+	}
+	if call == 1 && d.firstHook != nil {
+		close(d.firstHook)
+		<-d.resumeFirst
+	}
+	return nil
+}
+
+func (d *pausedRecurringRunDispatcher) OnRunEnd(context.Context, *apiserverPlugins.PersistedRun) bool {
+	d.endCalls.Add(1)
+	return true
+}
+
+func TestCreateRunConcurrentAuthorizedTickCreatesOneWorkflow(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		version string
+		plugins bool
+	}{
+		{name: "v1", version: "v1"},
+		{name: "v2", version: "v2"},
+		{name: "v2 with plugin output", version: "v2", plugins: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store, manager, experiment := initWithExperiment(t)
+			defer store.Close()
+			for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
+				previous := viper.Get(key)
+				viper.Set(key, value)
+				t.Cleanup(func() { viper.Set(key, previous) })
+			}
+			manager.time = fixedRecurringTime{epoch: 200}
+			ctx := multiUserContext()
+			job := &model.Job{
+				DisplayName: "pinned-schedule", Namespace: "ns1", ExperimentId: experiment.UUID,
+				Enabled: true, MaxConcurrency: 1,
+				Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+					PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+				}},
+				PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore())},
+			}
+			if test.version == "v2" {
+				job.PipelineSpec = model.PipelineSpec{
+					PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+					RuntimeConfig:        model.RuntimeConfig{Parameters: `{"text":"world"}`, PipelineRoot: "schedule-root"},
+				}
+			}
+			job, err := manager.CreateJob(ctx, job)
+			require.NoError(t, err)
+			manager.execClient = &retryWorkflowExecClient{workflowClient: &uniqueRecurringWorkflowClient{ExecutionInterface: store.ExecClientFake.Execution(job.Namespace)}}
+			paused := &pausedRecurringRunDispatcher{firstHook: make(chan struct{}), resumeFirst: make(chan struct{}), outputs: test.plugins}
+			manager.pluginDispatcher = paused
+			makeRun := func() *model.Run {
+				run := &model.Run{DisplayName: "same-tick", RecurringRunId: job.UUID}
+				require.NoError(t, manager.PrepareRecurringRun(ctx, run))
+				return run
+			}
+			firstInput, secondInput := makeRun(), makeRun()
+			type result struct {
+				run *model.Run
+				err error
+			}
+			firstDone := make(chan result, 1)
+			go func() {
+				run, err := manager.CreateRun(ctx, firstInput)
+				firstDone <- result{run, err}
+			}()
+			select {
+			case <-paused.firstHook:
+			case first := <-firstDone:
+				t.Fatalf("first request did not reach workflow submission: %v", first.err)
+			case <-time.After(10 * time.Second):
+				t.Fatal("first request did not reach workflow submission")
+			}
+			second, secondErr := manager.CreateRun(ctx, secondInput)
+			close(paused.resumeFirst)
+			first := <-firstDone
+			require.NoError(t, secondErr)
+			require.NoError(t, first.err)
+			require.Equal(t, first.run.UUID, second.UUID)
+			require.Equal(t, first.run.K8SName, second.K8SName)
+			require.Equal(t, int64(110), second.ScheduledAtInSec)
+			require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+			if test.plugins {
+				require.NotNil(t, second.PluginsOutputString)
+				require.Contains(t, string(*second.PluginsOutputString), "parent-2")
+				require.Equal(t, second.PluginsOutputString, first.run.PluginsOutputString)
+				workflow, err := manager.getWorkflowClient(job.Namespace).Get(ctx, second.K8SName, metav1.GetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, "parent-2", workflow.ExecutionObjectMeta().Annotations["test/plugin-parent"])
+				require.Zero(t, paused.endCalls.Load())
+			}
+			state, err := store.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), state.LastRunIndex)
+			require.False(t, state.Pending)
+		})
+	}
+}

--- a/backend/src/apiserver/resource/recurring_run_plugin_test.go
+++ b/backend/src/apiserver/resource/recurring_run_plugin_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type concurrentCreationPluginHandler struct {
+	calls        atomic.Int32
+	sharedParent bool
+	secondHook   chan struct{}
+	resumeSecond chan struct{}
+	endedParents chan string
+}
+
+func (*concurrentCreationPluginHandler) Name() string { return "test" }
+func (*concurrentCreationPluginHandler) ResolveRunPluginInput(*string) (interface{}, bool, error) {
+	return nil, true, nil
+}
+func (*concurrentCreationPluginHandler) ResolveRunPluginConfig(context.Context, kubernetes.Interface, string, string) (interface{}, error) {
+	return struct{}{}, nil
+}
+func (*concurrentCreationPluginHandler) GetPluginOperationTimeout(interface{}) time.Duration {
+	return time.Minute
+}
+func (h *concurrentCreationPluginHandler) OnBeforeRunCreation(context.Context, *apiserverPlugins.PendingRun, interface{}, interface{}) (*apiv2beta1.PluginOutput, []corev1.EnvVar, error) {
+	call := h.calls.Add(1)
+	parentID := fmt.Sprintf("parent-%d", call)
+	if h.sharedParent {
+		parentID = "parent-1"
+	}
+	if call == 2 {
+		close(h.secondHook)
+		<-h.resumeSecond
+	}
+	return &apiv2beta1.PluginOutput{Entries: map[string]*apiv2beta1.MetadataValue{
+		apiserverPlugins.EntryRootRunID: {Value: structpb.NewStringValue(parentID)},
+	}}, nil, nil
+}
+func (*concurrentCreationPluginHandler) HandleRetry(context.Context, *apiserverPlugins.PersistedRun, interface{}) error {
+	return nil
+}
+func (h *concurrentCreationPluginHandler) OnRunEnd(_ context.Context, run *apiserverPlugins.PersistedRun, _ interface{}) (bool, error) {
+	h.endedParents <- apiserverPlugins.GetParentRunID(run.PluginsOutput[h.Name()])
+	run.PluginsOutput[h.Name()].State = apiv2beta1.PluginState_PLUGIN_SUCCEEDED
+	return false, nil
+}
+func (*concurrentCreationPluginHandler) GetGenericFailedPluginOutput(string, string, interface{}) *apiv2beta1.PluginOutput {
+	return nil
+}
+
+func TestCreateRunConcurrentPluginParents(t *testing.T) {
+	for _, creatorPersisted := range []bool{false, true} {
+		for _, sharedParent := range []bool{false, true} {
+			t.Run(fmt.Sprintf("creatorPersisted=%t/sharedParent=%t", creatorPersisted, sharedParent), func(t *testing.T) {
+				store, manager, experiment := initWithExperiment(t)
+				defer store.Close()
+				for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
+					previous := viper.Get(key)
+					viper.Set(key, value)
+					t.Cleanup(func() { viper.Set(key, previous) })
+				}
+				manager.time = fixedRecurringTime{epoch: 200}
+				ctx := multiUserContext()
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.SetExecutionName("fixed-plugin-workflow")
+				job, err := manager.CreateJob(ctx, &model.Job{
+					DisplayName: "plugin-schedule", Namespace: "ns1", ExperimentId: experiment.UUID,
+					Enabled: true, MaxConcurrency: 1,
+					PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore())},
+					Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+						PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+					}},
+				})
+				require.NoError(t, err)
+				client := &pausedRecurringExecutionClient{
+					ExecutionInterface: &uniqueRecurringWorkflowClient{ExecutionInterface: store.ExecClientFake.Execution(job.Namespace)},
+					created:            make(chan util.ExecutionSpec, 1), resume: make(chan struct{}),
+				}
+				manager.execClient = &retryWorkflowExecClient{workflowClient: client}
+				resumeCreator := sync.OnceFunc(func() { close(client.resume) })
+				defer resumeCreator()
+				handler := &concurrentCreationPluginHandler{
+					sharedParent: sharedParent, secondHook: make(chan struct{}), resumeSecond: make(chan struct{}), endedParents: make(chan string, 4),
+				}
+				resumeLoser := sync.OnceFunc(func() { close(handler.resumeSecond) })
+				defer resumeLoser()
+				manager.pluginDispatcher, err = apiserverPlugins.NewRunPluginDispatcherImpl(
+					[]apiserverPlugins.RunPluginHandler{handler}, manager.k8sCoreClient, manager.runStore)
+				require.NoError(t, err)
+				makeRun := func() *model.Run {
+					run := &model.Run{DisplayName: "same-tick", RecurringRunId: job.UUID}
+					require.NoError(t, manager.PrepareRecurringRun(ctx, run))
+					return run
+				}
+				firstInput, secondInput := makeRun(), makeRun()
+				type result struct {
+					run *model.Run
+					err error
+				}
+				create := func(run *model.Run) <-chan result {
+					done := make(chan result, 1)
+					go func() {
+						created, err := manager.CreateRun(ctx, run)
+						done <- result{created, err}
+					}()
+					return done
+				}
+				firstDone := create(firstInput)
+				var execution util.ExecutionSpec
+				select {
+				case execution = <-client.created:
+				case first := <-firstDone:
+					t.Fatalf("creator did not submit its Workflow: %v", first.err)
+				case <-time.After(10 * time.Second):
+					t.Fatal("creator did not submit its Workflow")
+				}
+				secondDone := create(secondInput)
+				select {
+				case <-handler.secondHook:
+				case second := <-secondDone:
+					t.Fatalf("second request did not reach its plugin hook: %v", second.err)
+				case <-time.After(10 * time.Second):
+					t.Fatal("second request did not reach its plugin hook")
+				}
+				var first result
+				if creatorPersisted {
+					resumeCreator()
+					first = <-firstDone
+					require.NoError(t, first.err)
+				}
+				resumeLoser()
+				second := <-secondDone
+				if creatorPersisted {
+					require.NoError(t, second.err)
+					require.Equal(t, first.run.PluginsOutputString, second.run.PluginsOutputString)
+				} else {
+					require.True(t, util.IsUserErrorCodeMatch(second.err, codes.Unavailable), "error: %v", second.err)
+					_, err := manager.GetRun(firstInput.UUID)
+					require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound), "loser must not insert a run: %v", err)
+					resumeCreator()
+					first = <-firstDone
+					require.NoError(t, first.err)
+				}
+				if sharedParent {
+					require.Empty(t, handler.endedParents, "the shared parent must remain open")
+				} else {
+					require.Len(t, handler.endedParents, 1)
+					require.Equal(t, "parent-2", <-handler.endedParents)
+				}
+				persisted, err := manager.GetRun(firstInput.UUID)
+				require.NoError(t, err)
+				require.Equal(t, first.run.PluginsOutputString, persisted.PluginsOutputString)
+				require.Contains(t, string(*persisted.PluginsOutputString), "parent-1")
+				require.NotContains(t, string(*persisted.PluginsOutputString), "parent-2")
+				require.JSONEq(t, `{"test":"parent-1"}`, execution.ExecutionObjectMeta().Annotations[apiserverPlugins.AnnotationKeyPluginParents])
+				require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+				ended, err := apiserverPlugins.ModelToPersistedRun(persisted, job.Namespace)
+				require.NoError(t, err)
+				ended.State = string(model.RuntimeStateSucceeded)
+				require.True(t, manager.pluginDispatcher.OnRunEnd(ctx, ended))
+				require.Len(t, handler.endedParents, 1)
+				require.Equal(t, "parent-1", <-handler.endedParents)
+			})
+		}
+	}
+}

--- a/backend/src/apiserver/resource/recurring_run_service_account_test.go
+++ b/backend/src/apiserver/resource/recurring_run_service_account_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type recurringRunAccountReview struct {
+	allowedAccount string
+	reviews        []*authzv1.SubjectAccessReview
+}
+
+func (c *recurringRunAccountReview) Create(_ context.Context, review *authzv1.SubjectAccessReview, _ metav1.CreateOptions) (*authzv1.SubjectAccessReview, error) {
+	c.reviews = append(c.reviews, review.DeepCopy())
+	return &authzv1.SubjectAccessReview{Status: authzv1.SubjectAccessReviewStatus{
+		Allowed: review.Spec.ResourceAttributes.Resource != "serviceaccounts" ||
+			review.Spec.ResourceAttributes.Name == c.allowedAccount,
+	}}, nil
+}
+
+type recurringRunPluginDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
+}
+
+func (recurringRunPluginDispatcher) PluginsRegistered() bool { return true }
+
+func configureRecurringRunAccountTest(t *testing.T) {
+	t.Helper()
+	for key, value := range map[string]string{
+		common.MultiUserMode:              "true",
+		common.AllowedServiceAccountsFlag: "embedded-runner,override-runner",
+		v1AllowedNamespaces:               "ns1",
+	} {
+		previous := viper.Get(key)
+		viper.Set(key, value)
+		t.Cleanup(func() { viper.Set(key, previous) })
+	}
+}
+
+func TestCreateJobFollowLatestV1AuthorizesEmbeddedServiceAccount(t *testing.T) {
+	for _, permitted := range []bool{false, true} {
+		name := "denied"
+		if permitted {
+			name = "authorized"
+		}
+		t.Run(name, func(t *testing.T) {
+			configureRecurringRunAccountTest(t)
+			store, _, experiment := initWithExperiment(t)
+			defer store.Close()
+			review := &recurringRunAccountReview{}
+			if permitted {
+				review.allowedAccount = "embedded-runner"
+			}
+			store.SubjectAccessReviewClientFake = review
+			manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+			workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+			workflow.Spec.ServiceAccountName = "embedded-runner"
+			pipeline, err := manager.CreatePipeline(createPipeline("schedule-pipeline", "", "ns1"))
+			require.NoError(t, err)
+			_, err = manager.CreatePipelineVersion(createPipelineVersion(
+				pipeline.UUID, "schedule-pipeline/v1", "v1", "", workflow.ToStringForStore(), "", "ns1"))
+			require.NoError(t, err)
+
+			job, err := manager.CreateJob(multiUserContext(), &model.Job{
+				DisplayName:  "follow-latest",
+				Namespace:    "ns1",
+				ExperimentId: experiment.UUID,
+				Enabled:      true,
+				PipelineSpec: model.PipelineSpec{PipelineId: pipeline.UUID},
+			})
+			if !permitted {
+				require.ErrorContains(t, err, "Unauthorized")
+				require.Nil(t, job)
+			} else {
+				require.NoError(t, err)
+				stored, err := manager.GetJob(job.UUID)
+				require.NoError(t, err)
+				require.Equal(t, "embedded-runner", stored.ServiceAccount)
+				require.Empty(t, stored.PipelineVersionId, "the schedule must continue following the latest version")
+			}
+			require.NotEmpty(t, review.reviews)
+			last := review.reviews[len(review.reviews)-1]
+			require.Equal(t, authzv1.ResourceAttributes{
+				Verb: "use", Resource: "serviceaccounts", Name: "embedded-runner", Namespace: "ns1",
+			}, *last.Spec.ResourceAttributes)
+		})
+	}
+}
+
+func TestCreateJobPluginV1PreservesAuthorizedServiceAccountOverride(t *testing.T) {
+	configureRecurringRunAccountTest(t)
+	store, _, experiment := initWithExperiment(t)
+	defer store.Close()
+	review := &recurringRunAccountReview{allowedAccount: "override-runner"}
+	store.SubjectAccessReviewClientFake = review
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	manager.pluginDispatcher = recurringRunPluginDispatcher{}
+	workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	workflow.Spec.ServiceAccountName = "embedded-runner"
+	job, err := manager.CreateJob(multiUserContext(), &model.Job{
+		DisplayName:    "plugin-schedule",
+		Namespace:      "ns1",
+		ExperimentId:   experiment.UUID,
+		Enabled:        true,
+		ServiceAccount: "override-runner",
+		PipelineSpec:   model.PipelineSpec{WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore())},
+	})
+	require.NoError(t, err)
+	stored, err := manager.GetJob(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, "override-runner", stored.ServiceAccount)
+	swf, err := store.SwfClient().ScheduledWorkflow(job.Namespace).Get(context.Background(), job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Nil(t, swf.Spec.Workflow, "plugin-enabled schedules use the API instead of embedding a workflow")
+
+	run := &model.Run{DisplayName: "scheduled-tick", RecurringRunId: job.UUID, ServiceAccount: "embedded-runner"}
+	require.NoError(t, manager.PrepareRecurringRun(multiUserContext(), run))
+	require.Equal(t, "override-runner", run.ServiceAccount)
+	require.Equal(t, stored.PipelineSpec, run.PipelineSpec)
+	created, err := manager.CreateRun(multiUserContext(), run)
+	require.NoError(t, err)
+	require.Equal(t, "override-runner", created.ServiceAccount)
+	require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+	require.GreaterOrEqual(t, len(review.reviews), 2)
+	for _, check := range review.reviews {
+		if check.Spec.ResourceAttributes.Resource == "serviceaccounts" {
+			require.Equal(t, "override-runner", check.Spec.ResourceAttributes.Name)
+		}
+	}
+}

--- a/backend/src/apiserver/resource/recurring_run_service_account_test.go
+++ b/backend/src/apiserver/resource/recurring_run_service_account_test.go
@@ -151,3 +151,95 @@ func TestCreateJobPluginV1PreservesAuthorizedServiceAccountOverride(t *testing.T
 		}
 	}
 }
+
+func TestAuthorizeStoredRunServiceAccount(t *testing.T) {
+	for key, value := range map[string]string{
+		common.MultiUserMode:                           "false",
+		common.DefaultPipelineRunnerServiceAccountFlag: "pipeline-runner",
+	} {
+		previous := viper.Get(key)
+		viper.Set(key, value)
+		t.Cleanup(func() { viper.Set(key, previous) })
+	}
+	manifest := func(account string) model.LargeText {
+		workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+		workflow.Spec.ServiceAccountName = account
+		workflow.SetExecutionName("stored-workflow")
+		workflow.SetExecutionNamespace("ns1")
+		return model.LargeText(workflow.ToStringForStore())
+	}
+	for _, test := range []struct {
+		name             string
+		storedAccount    string
+		workflowManifest model.LargeText
+		pipelineManifest model.LargeText
+		allowedAccount   string
+		wantError        string
+	}{
+		{
+			name: "stored account takes precedence", storedAccount: "stored-runner",
+			workflowManifest: manifest("embedded-runner"), allowedAccount: "stored-runner",
+		},
+		{
+			name: "stored account cannot be bypassed by an allowed manifest account", storedAccount: "stored-runner",
+			workflowManifest: manifest("embedded-runner"), allowedAccount: "embedded-runner", wantError: "not allowed",
+		},
+		{
+			name: "stored account does not require a runtime manifest", storedAccount: "stored-runner",
+			allowedAccount: "stored-runner",
+		},
+		{
+			name: "stored account does not parse an unused manifest", storedAccount: "stored-runner",
+			workflowManifest: "{", allowedAccount: "stored-runner",
+		},
+		{
+			name: "workflow runtime account allowed", workflowManifest: manifest("embedded-runner"),
+			allowedAccount: "embedded-runner",
+		},
+		{
+			name: "workflow runtime account denied", workflowManifest: manifest("embedded-runner"),
+			wantError: "not allowed",
+		},
+		{
+			name: "pipeline runtime account allowed", pipelineManifest: manifest("embedded-runner"),
+			allowedAccount: "embedded-runner",
+		},
+		{
+			name: "pipeline runtime account denied", pipelineManifest: manifest("embedded-runner"),
+			wantError: "not allowed",
+		},
+		{
+			name:             "workflow runtime takes precedence over pipeline runtime",
+			workflowManifest: manifest("stored-runner"), pipelineManifest: manifest("embedded-runner"),
+			allowedAccount: "embedded-runner", wantError: "not allowed",
+		},
+		{name: "legitimate empty account", workflowManifest: manifest("")},
+		{name: "missing execution identity", wantError: "execution identity is missing"},
+		{name: "malformed workflow runtime", workflowManifest: "{", wantError: "stored execution account"},
+		{name: "malformed pipeline runtime", pipelineManifest: "{", wantError: "stored execution account"},
+		{name: "null execution identity", workflowManifest: "null", wantError: "execution name is missing"},
+		{name: "empty execution identity", workflowManifest: "{}", wantError: "execution name is missing"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			previous := viper.Get(common.AllowedServiceAccountsFlag)
+			viper.Set(common.AllowedServiceAccountsFlag, test.allowedAccount)
+			t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, previous) })
+			run := &model.Run{
+				UUID: "stored-run", Namespace: "ns1", ServiceAccount: test.storedAccount,
+				RunDetails: model.RunDetails{
+					WorkflowRuntimeManifest: test.workflowManifest,
+					PipelineRuntimeManifest: test.pipelineManifest,
+				},
+			}
+			before := *run
+			manager := &ResourceManager{}
+			err := manager.authorizeStoredRunServiceAccount(context.Background(), run)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, before, *run, "authorization must not replace retained execution metadata")
+		})
+	}
+}

--- a/backend/src/apiserver/resource/recurring_run_tick.go
+++ b/backend/src/apiserver/resource/recurring_run_tick.go
@@ -35,7 +35,6 @@ type recurringRunTick struct {
 	scheduledAt   int64
 	createdAt     int64
 	replay        *model.Run
-	deleted       bool
 }
 
 func (r *ResourceManager) prepareRecurringRunTick(run *model.Run, owner *scheduledworkflow.ScheduledWorkflow, now int64) (*recurringRunTick, error) {
@@ -83,7 +82,6 @@ func (r *ResourceManager) prepareRecurringRunTick(run *model.Run, owner *schedul
 			// The controller may not have acknowledged the tick before its run was
 			// deleted. Return retained metadata without recreating either resource.
 			// CreateRun still authorizes the caller before returning this replay.
-			tick.deleted = true
 			tick.replay = &model.Run{
 				UUID:           util.NewDeterministicUUID(job.UUID + "/tick/" + strconv.FormatInt(state.LastRunIndex, 10)),
 				DisplayName:    state.RequestKey,

--- a/backend/src/apiserver/resource/recurring_run_tick.go
+++ b/backend/src/apiserver/resource/recurring_run_tick.go
@@ -16,10 +16,12 @@ package resource
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/validation"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	scheduleutil "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
 	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
@@ -33,9 +35,13 @@ type recurringRunTick struct {
 	scheduledAt   int64
 	createdAt     int64
 	replay        *model.Run
+	deleted       bool
 }
 
 func (r *ResourceManager) prepareRecurringRunTick(run *model.Run, owner *scheduledworkflow.ScheduledWorkflow, now int64) (*recurringRunTick, error) {
+	if err := validation.ValidateRecurringRunRequestKey(run.DisplayName); err != nil {
+		return nil, err
+	}
 	job, err := r.jobStore.GetJob(run.RecurringRunId)
 	if err != nil {
 		return nil, err
@@ -68,15 +74,32 @@ func (r *ResourceManager) prepareRecurringRunTick(run *model.Run, owner *schedul
 		}, nil
 	}
 	if state.LastRunIndex > 0 && state.RequestKey == run.DisplayName {
-		if !state.Pending {
-			return nil, util.NewFailedPreconditionError(fmt.Errorf("the scheduled run was already dispatched"),
-				"This tick has already executed; wait for the next scheduled tick")
-		}
 		run.PipelineVersionId = state.PipelineVersionID
-		return &recurringRunTick{
+		tick := &recurringRunTick{
 			previousIndex: state.LastRunIndex - 1, index: state.LastRunIndex,
 			scheduledAt: state.LastScheduledAtInSec, createdAt: state.LastCreatedAtInSec,
-		}, nil
+		}
+		if !state.Pending {
+			// The controller may not have acknowledged the tick before its run was
+			// deleted. Return retained metadata without recreating either resource.
+			// CreateRun still authorizes the caller before returning this replay.
+			tick.deleted = true
+			tick.replay = &model.Run{
+				UUID:           util.NewDeterministicUUID(job.UUID + "/tick/" + strconv.FormatInt(state.LastRunIndex, 10)),
+				DisplayName:    state.RequestKey,
+				RecurringRunId: job.UUID,
+				Namespace:      run.Namespace,
+				ExperimentId:   job.ExperimentId,
+				ServiceAccount: job.ServiceAccount,
+				PipelineSpec:   run.PipelineSpec,
+				RunDetails: model.RunDetails{
+					CreatedAtInSec:   state.LastCreatedAtInSec,
+					ScheduledAtInSec: state.LastScheduledAtInSec,
+					State:            model.RuntimeStateUnspecified,
+				},
+			}
+		}
+		return tick, nil
 	}
 	if state.Pending {
 		return nil, util.NewFailedPreconditionError(fmt.Errorf("a previous tick is still pending"),

--- a/backend/src/apiserver/resource/recurring_run_tick.go
+++ b/backend/src/apiserver/resource/recurring_run_tick.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	scheduleutil "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
+	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// A preview does not reserve capacity until normal pipeline and account checks pass.
+type recurringRunTick struct {
+	previousIndex int64
+	index         int64
+	scheduledAt   int64
+	createdAt     int64
+	replay        *model.Run
+}
+
+func (r *ResourceManager) prepareRecurringRunTick(run *model.Run, owner *scheduledworkflow.ScheduledWorkflow, now int64) (*recurringRunTick, error) {
+	job, err := r.jobStore.GetJob(run.RecurringRunId)
+	if err != nil {
+		return nil, err
+	}
+	if owner == nil || string(owner.UID) != job.UUID || owner.Name != job.K8SName || owner.Namespace != run.Namespace {
+		return nil, util.NewPermissionDeniedError(fmt.Errorf("ScheduledWorkflow identity changed"),
+			"Recreate the recurring run through the KFP API")
+	}
+	if !job.Enabled || !owner.Spec.Enabled {
+		return nil, util.NewFailedPreconditionError(fmt.Errorf("the recurring run is disabled"),
+			"Enable the recurring run through the KFP API before triggering runs")
+	}
+	state, err := r.jobStore.GetRecurringRunState(job.UUID)
+	if err != nil {
+		return nil, err
+	}
+	existingID, err := r.runStore.GetRunByRecurringRunIDAndDisplayName(job.UUID, run.DisplayName)
+	if err != nil {
+		return nil, err
+	}
+	if existingID != "" {
+		existing, err := r.runStore.GetRun(existingID)
+		if err != nil {
+			return nil, err
+		}
+		run.PipelineVersionId = existing.PipelineVersionId
+		return &recurringRunTick{
+			index: state.LastRunIndex, scheduledAt: existing.ScheduledAtInSec,
+			createdAt: existing.CreatedAtInSec, replay: existing,
+		}, nil
+	}
+	if state.LastRunIndex > 0 && state.RequestKey == run.DisplayName {
+		if !state.Pending {
+			return nil, util.NewFailedPreconditionError(fmt.Errorf("the scheduled run was already dispatched"),
+				"This tick has already executed; wait for the next scheduled tick")
+		}
+		run.PipelineVersionId = state.PipelineVersionID
+		return &recurringRunTick{
+			previousIndex: state.LastRunIndex - 1, index: state.LastRunIndex,
+			scheduledAt: state.LastScheduledAtInSec, createdAt: state.LastCreatedAtInSec,
+		}, nil
+	}
+	if state.Pending {
+		return nil, util.NewFailedPreconditionError(fmt.Errorf("a previous tick is still pending"),
+			"Retry the previous scheduled tick before submitting another one")
+	}
+	schedule, err := template.NewGenericScheduledWorkflow(job)
+	if err != nil {
+		return nil, err
+	}
+	// Kubernetes owns creationTimestamp; unlike spec/status it is immutable.
+	schedule.CreationTimestamp = owner.CreationTimestamp
+	if schedule.CreationTimestamp.IsZero() {
+		schedule.CreationTimestamp = metav1.NewTime(time.Unix(job.CreatedAtInSec, 0))
+	}
+	if state.LastRunIndex > 0 {
+		last := metav1.NewTime(time.Unix(state.LastScheduledAtInSec, 0))
+		schedule.Status.Trigger.LastTriggeredTime = &last
+	}
+	location, err := scheduleutil.GetLocation()
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to resolve the recurring-run timezone")
+	}
+	scheduledAt, due := scheduleutil.NewScheduledWorkflow(schedule).GetNextScheduledEpoch(0, now, *location)
+	if !due {
+		return nil, util.NewFailedPreconditionError(fmt.Errorf("no authorized tick is due"),
+			"Wait for the next tick allowed by the API-stored recurring-run schedule")
+	}
+	return &recurringRunTick{
+		previousIndex: state.LastRunIndex, index: state.LastRunIndex + 1,
+		scheduledAt: scheduledAt, createdAt: now,
+	}, nil
+}
+
+func (r *ResourceManager) claimRecurringRunTick(run *model.Run, tick *recurringRunTick) error {
+	state, err := r.jobStore.ClaimRecurringRun(run.RecurringRunId, run.DisplayName,
+		tick.previousIndex, tick.scheduledAt, tick.createdAt, run.PipelineVersionId)
+	if err != nil {
+		return err
+	}
+	// A concurrent claimant may have frozen a different CurrentTime/NoCatchup time.
+	// Retry preparation so compilation uses precisely that durable claim.
+	if state.LastRunIndex != tick.index || state.LastScheduledAtInSec != tick.scheduledAt || state.LastCreatedAtInSec != tick.createdAt || state.PipelineVersionID != run.PipelineVersionId {
+		return util.NewUnavailableServerError(fmt.Errorf("the tick was claimed concurrently"),
+			"Retry this tick to use its persisted execution inputs")
+	}
+	return nil
+}

--- a/backend/src/apiserver/resource/recurring_run_tick_test.go
+++ b/backend/src/apiserver/resource/recurring_run_tick_test.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
@@ -117,94 +118,108 @@ func TestCreateRunPendingFollowLatestTickKeepsClaimedPipelineVersion(t *testing.
 	require.Empty(t, storedJob.PipelineVersionId)
 }
 
-func TestCreateRunAcknowledgesDeletedTickAfterPipelineVersionDeletion(t *testing.T) {
-	initEnvVars()
-	for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
-		previous := viper.Get(key)
-		viper.Set(key, value)
-		t.Cleanup(func() { viper.Set(key, previous) })
-	}
-	store := NewFakeClientManagerOrFatalV2()
-	defer store.Close()
-	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
-	manager.time = fixedRecurringTime{epoch: 200}
-	ctx := multiUserContext()
-	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "deleted-tick", Namespace: "ns1"})
-	require.NoError(t, err)
-	pipeline, err := manager.CreatePipeline(createPipeline("deleted-tick", "", "ns1"))
-	require.NoError(t, err)
-	publishVersion := func(name string) *model.PipelineVersion {
-		workflow := util.NewWorkflow(testWorkflow.DeepCopy())
-		workflow.Spec.Templates[0].Container.Args = []string{name}
-		version, err := manager.CreatePipelineVersion(createPipelineVersion(
-			pipeline.UUID, name, name, "", workflow.ToStringForStore(), "", "ns1"))
-		require.NoError(t, err)
-		return version
-	}
-	versionA := publishVersion("version-a")
-	job, err := manager.CreateJob(ctx, &model.Job{
-		DisplayName: "follow-latest", Namespace: "ns1", ExperimentId: experiment.UUID,
-		Enabled: true, MaxConcurrency: 1,
-		Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
-			PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
-		}},
-		PipelineSpec: model.PipelineSpec{
-			PipelineId: pipeline.UUID,
-			Parameters: `[{"name":"param1","value":"tick-[[Index]]"}]`,
-		},
-	})
-	require.NoError(t, err)
-	createTick := func(requestKey string) *model.Run {
-		run := &model.Run{DisplayName: requestKey, RecurringRunId: job.UUID}
-		require.NoError(t, manager.PrepareRecurringRun(ctx, run))
-		created, err := manager.CreateRun(ctx, run)
-		require.NoError(t, err)
-		return created
-	}
-	first := createTick("unacknowledged-tick")
-	require.Equal(t, versionA.UUID, first.PipelineVersionId)
-	first.State = model.RuntimeStateSucceeded
-	first.FinishedAtInSec = 201
-	require.NoError(t, store.RunStore().UpdateRun(first))
-	completedState, err := store.JobStore().GetRecurringRunState(job.UUID)
-	require.NoError(t, err)
-	require.False(t, completedState.Pending)
+func TestCreateRunAcknowledgesTickAfterPipelineVersionDeletion(t *testing.T) {
+	for _, deleted := range []bool{false, true} {
+		t.Run(fmt.Sprintf("deleted=%t", deleted), func(t *testing.T) {
+			initEnvVars()
+			for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
+				previous := viper.Get(key)
+				viper.Set(key, value)
+				t.Cleanup(func() { viper.Set(key, previous) })
+			}
+			store := NewFakeClientManagerOrFatalV2()
+			defer store.Close()
+			manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+			manager.time = fixedRecurringTime{epoch: 200}
+			ctx := multiUserContext()
+			experiment, err := manager.CreateExperiment(&model.Experiment{Name: "deleted-tick", Namespace: "ns1"})
+			require.NoError(t, err)
+			pipeline, err := manager.CreatePipeline(createPipeline("deleted-tick", "", "ns1"))
+			require.NoError(t, err)
+			publishVersion := func(name string) *model.PipelineVersion {
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.Spec.Templates[0].Container.Args = []string{name}
+				version, err := manager.CreatePipelineVersion(createPipelineVersion(
+					pipeline.UUID, name, name, "", workflow.ToStringForStore(), "", "ns1"))
+				require.NoError(t, err)
+				return version
+			}
+			versionA := publishVersion("version-a")
+			job, err := manager.CreateJob(ctx, &model.Job{
+				DisplayName: "follow-latest", Namespace: "ns1", ExperimentId: experiment.UUID,
+				Enabled: true, MaxConcurrency: 1,
+				Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+					PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+				}},
+				PipelineSpec: model.PipelineSpec{
+					PipelineId: pipeline.UUID,
+					Parameters: `[{"name":"param1","value":"tick-[[Index]]"}]`,
+				},
+			})
+			require.NoError(t, err)
+			createTick := func(requestKey string) *model.Run {
+				run := &model.Run{DisplayName: requestKey, RecurringRunId: job.UUID}
+				require.NoError(t, manager.PrepareRecurringRun(ctx, run))
+				created, err := manager.CreateRun(ctx, run)
+				require.NoError(t, err)
+				return created
+			}
+			first := createTick("unacknowledged-tick")
+			require.Equal(t, versionA.UUID, first.PipelineVersionId)
+			first.State = model.RuntimeStateSucceeded
+			first.FinishedAtInSec = 201
+			require.NoError(t, store.RunStore().UpdateRun(first))
+			completedState, err := store.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			require.False(t, completedState.Pending)
 
-	// Retention can remove both the completed run and its historical template
-	// before the controller persists its acknowledgement of the tick.
-	versionB := publishVersion("version-b")
-	require.NoError(t, manager.DeleteRun(ctx, first.UUID))
-	require.NoError(t, manager.DeletePipelineVersion(versionA.UUID))
-	latest, err := manager.GetLatestPipelineVersion(pipeline.UUID)
-	require.NoError(t, err)
-	require.Equal(t, versionB.UUID, latest.UUID)
-	manager.time = fixedRecurringTime{epoch: 210}
-	acknowledged := createTick("unacknowledged-tick")
-	require.Equal(t, first.UUID, acknowledged.UUID)
-	require.Equal(t, first.DisplayName, acknowledged.DisplayName)
-	require.Equal(t, job.UUID, acknowledged.RecurringRunId)
-	require.Equal(t, first.Namespace, acknowledged.Namespace)
-	require.Equal(t, first.ExperimentId, acknowledged.ExperimentId)
-	require.Equal(t, first.ServiceAccount, acknowledged.ServiceAccount)
-	require.Equal(t, versionA.UUID, acknowledged.PipelineVersionId)
-	require.Equal(t, first.CreatedAtInSec, acknowledged.CreatedAtInSec)
-	require.Equal(t, first.ScheduledAtInSec, acknowledged.ScheduledAtInSec)
-	require.Equal(t, model.RuntimeStateUnspecified, acknowledged.State)
-	_, err = manager.GetRun(first.UUID)
-	require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
-	require.Zero(t, store.ExecClientFake.GetWorkflowCount())
-	stateAfterAcknowledgement, err := store.JobStore().GetRecurringRunState(job.UUID)
-	require.NoError(t, err)
-	require.Equal(t, completedState, stateAfterAcknowledgement)
+			// The historical template can disappear before acknowledgement, whether
+			// or not retention has also removed the completed run.
+			versionB := publishVersion("version-b")
+			if deleted {
+				require.NoError(t, manager.DeleteRun(ctx, first.UUID))
+			}
+			require.NoError(t, manager.DeletePipelineVersion(versionA.UUID))
+			latest, err := manager.GetLatestPipelineVersion(pipeline.UUID)
+			require.NoError(t, err)
+			require.Equal(t, versionB.UUID, latest.UUID)
+			manager.time = fixedRecurringTime{epoch: 210}
+			acknowledged := createTick("unacknowledged-tick")
+			require.Equal(t, first.UUID, acknowledged.UUID)
+			require.Equal(t, first.DisplayName, acknowledged.DisplayName)
+			require.Equal(t, job.UUID, acknowledged.RecurringRunId)
+			require.Equal(t, first.Namespace, acknowledged.Namespace)
+			require.Equal(t, first.ExperimentId, acknowledged.ExperimentId)
+			require.Equal(t, first.ServiceAccount, acknowledged.ServiceAccount)
+			require.Equal(t, versionA.UUID, acknowledged.PipelineVersionId)
+			require.Equal(t, first.CreatedAtInSec, acknowledged.CreatedAtInSec)
+			require.Equal(t, first.ScheduledAtInSec, acknowledged.ScheduledAtInSec)
+			workflowCount := 1
+			if deleted {
+				require.Equal(t, model.RuntimeStateUnspecified, acknowledged.State)
+				_, err = manager.GetRun(first.UUID)
+				require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+				workflowCount = 0
+			} else {
+				persisted, err := manager.GetRun(first.UUID)
+				require.NoError(t, err)
+				require.Equal(t, persisted, acknowledged)
+			}
+			require.Equal(t, workflowCount, store.ExecClientFake.GetWorkflowCount())
+			stateAfterAcknowledgement, err := store.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			require.Equal(t, completedState, stateAfterAcknowledgement)
 
-	next := createTick("next-tick")
-	require.Equal(t, versionB.UUID, next.PipelineVersionId)
-	require.NotEqual(t, first.UUID, next.UUID)
-	require.Equal(t, int64(120), next.ScheduledAtInSec)
-	execution, err := store.ExecClientFake.Execution(job.Namespace).Get(ctx, next.K8SName, metav1.GetOptions{})
-	require.NoError(t, err)
-	workflow := execution.(*util.Workflow)
-	require.Equal(t, []string{"version-b"}, workflow.Spec.Templates[0].Container.Args)
-	require.Equal(t, "tick-2", workflow.GetWorkflowParametersAsMap()["param1"])
-	require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+			next := createTick("next-tick")
+			require.Equal(t, versionB.UUID, next.PipelineVersionId)
+			require.NotEqual(t, first.UUID, next.UUID)
+			require.Equal(t, int64(120), next.ScheduledAtInSec)
+			execution, err := store.ExecClientFake.Execution(job.Namespace).Get(ctx, next.K8SName, metav1.GetOptions{})
+			require.NoError(t, err)
+			workflow := execution.(*util.Workflow)
+			require.Equal(t, []string{"version-b"}, workflow.Spec.Templates[0].Container.Args)
+			require.Equal(t, "tick-2", workflow.GetWorkflowParametersAsMap()["param1"])
+			require.Equal(t, workflowCount+1, store.ExecClientFake.GetWorkflowCount())
+		})
+	}
 }

--- a/backend/src/apiserver/resource/recurring_run_tick_test.go
+++ b/backend/src/apiserver/resource/recurring_run_tick_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateRunPendingFollowLatestTickKeepsClaimedPipelineVersion(t *testing.T) {
+	initEnvVars()
+	for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
+		previous := viper.Get(key)
+		viper.Set(key, value)
+		t.Cleanup(func() { viper.Set(key, previous) })
+	}
+	store := NewFakeClientManagerOrFatalV2()
+	defer store.Close()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	manager.time = fixedRecurringTime{epoch: 200}
+	ctx := multiUserContext()
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "version-freeze", Namespace: "ns1"})
+	require.NoError(t, err)
+	pipeline, err := manager.CreatePipeline(createPipeline("version-freeze", "", "ns1"))
+	require.NoError(t, err)
+	publishVersion := func(name string) *model.PipelineVersion {
+		workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+		workflow.Spec.Templates[0].Container.Args = []string{name}
+		version, err := manager.CreatePipelineVersion(createPipelineVersion(
+			pipeline.UUID, name, name, "", workflow.ToStringForStore(), "", "ns1"))
+		require.NoError(t, err)
+		return version
+	}
+	versionA := publishVersion("version-a")
+	job, err := manager.CreateJob(ctx, &model.Job{
+		DisplayName: "follow-latest", Namespace: "ns1", ExperimentId: experiment.UUID,
+		Enabled: true, MaxConcurrency: 1,
+		Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+			PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+		}},
+		PipelineSpec: model.PipelineSpec{
+			PipelineId: pipeline.UUID,
+			Parameters: `[{"name":"param1","value":"tick-[[Index]]-[[ScheduledTime]]-[[CurrentTime]]"}]`,
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, job.PipelineVersionId)
+
+	// Simulate interruption after the first version and tick inputs were claimed,
+	// but before the workflow and run were persisted.
+	claim, err := store.JobStore().ClaimRecurringRun(job.UUID, "interrupted-tick", 0, 110, 150, versionA.UUID)
+	require.NoError(t, err)
+	require.True(t, claim.Pending)
+	versionB := publishVersion("version-b")
+	latest, err := manager.GetLatestPipelineVersion(pipeline.UUID)
+	require.NoError(t, err)
+	require.Equal(t, versionB.UUID, latest.UUID)
+
+	createTick := func(requestKey string) *model.Run {
+		run := &model.Run{DisplayName: requestKey, RecurringRunId: job.UUID}
+		require.NoError(t, manager.PrepareRecurringRun(ctx, run))
+		created, err := manager.CreateRun(ctx, run)
+		require.NoError(t, err)
+		return created
+	}
+	checkWorkflow := func(run *model.Run, marker, parameters string) {
+		execution, err := store.ExecClientFake.Execution(job.Namespace).Get(ctx, run.K8SName, metav1.GetOptions{})
+		require.NoError(t, err)
+		workflow := execution.(*util.Workflow)
+		require.Equal(t, []string{marker}, workflow.Spec.Templates[0].Container.Args)
+		require.Equal(t, parameters, workflow.GetWorkflowParametersAsMap()["param1"])
+	}
+	retried := createTick("interrupted-tick")
+	require.Equal(t, versionA.UUID, retried.PipelineVersionId)
+	require.Equal(t, int64(110), retried.ScheduledAtInSec)
+	require.Equal(t, int64(150), retried.CreatedAtInSec)
+	checkWorkflow(retried, "version-a", "tick-1-19700101000150-19700101000230")
+	state, err := store.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.False(t, state.Pending)
+	require.Equal(t, versionA.UUID, state.PipelineVersionID)
+
+	// Finishing the first run releases the concurrency limit. A distinct due tick
+	// resolves latest again instead of pinning the whole recurring run to A.
+	retried.State = model.RuntimeStateSucceeded
+	retried.FinishedAtInSec = 201
+	require.NoError(t, store.RunStore().UpdateRun(retried))
+	manager.time = fixedRecurringTime{epoch: 210}
+	next := createTick("next-tick")
+	require.Equal(t, versionB.UUID, next.PipelineVersionId)
+	require.Equal(t, int64(120), next.ScheduledAtInSec)
+	require.Equal(t, int64(210), next.CreatedAtInSec)
+	require.NotEqual(t, retried.UUID, next.UUID)
+	checkWorkflow(next, "version-b", "tick-2-19700101000200-19700101000330")
+	require.Equal(t, 2, store.ExecClientFake.GetWorkflowCount())
+	storedJob, err := manager.GetJob(job.UUID)
+	require.NoError(t, err)
+	require.Empty(t, storedJob.PipelineVersionId)
+}

--- a/backend/src/apiserver/resource/recurring_run_tick_test.go
+++ b/backend/src/apiserver/resource/recurring_run_tick_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -114,4 +115,96 @@ func TestCreateRunPendingFollowLatestTickKeepsClaimedPipelineVersion(t *testing.
 	storedJob, err := manager.GetJob(job.UUID)
 	require.NoError(t, err)
 	require.Empty(t, storedJob.PipelineVersionId)
+}
+
+func TestCreateRunAcknowledgesDeletedTickAfterPipelineVersionDeletion(t *testing.T) {
+	initEnvVars()
+	for key, value := range map[string]string{common.MultiUserMode: "true", v1AllowedNamespaces: "ns1"} {
+		previous := viper.Get(key)
+		viper.Set(key, value)
+		t.Cleanup(func() { viper.Set(key, previous) })
+	}
+	store := NewFakeClientManagerOrFatalV2()
+	defer store.Close()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	manager.time = fixedRecurringTime{epoch: 200}
+	ctx := multiUserContext()
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "deleted-tick", Namespace: "ns1"})
+	require.NoError(t, err)
+	pipeline, err := manager.CreatePipeline(createPipeline("deleted-tick", "", "ns1"))
+	require.NoError(t, err)
+	publishVersion := func(name string) *model.PipelineVersion {
+		workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+		workflow.Spec.Templates[0].Container.Args = []string{name}
+		version, err := manager.CreatePipelineVersion(createPipelineVersion(
+			pipeline.UUID, name, name, "", workflow.ToStringForStore(), "", "ns1"))
+		require.NoError(t, err)
+		return version
+	}
+	versionA := publishVersion("version-a")
+	job, err := manager.CreateJob(ctx, &model.Job{
+		DisplayName: "follow-latest", Namespace: "ns1", ExperimentId: experiment.UUID,
+		Enabled: true, MaxConcurrency: 1,
+		Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+			PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+		}},
+		PipelineSpec: model.PipelineSpec{
+			PipelineId: pipeline.UUID,
+			Parameters: `[{"name":"param1","value":"tick-[[Index]]"}]`,
+		},
+	})
+	require.NoError(t, err)
+	createTick := func(requestKey string) *model.Run {
+		run := &model.Run{DisplayName: requestKey, RecurringRunId: job.UUID}
+		require.NoError(t, manager.PrepareRecurringRun(ctx, run))
+		created, err := manager.CreateRun(ctx, run)
+		require.NoError(t, err)
+		return created
+	}
+	first := createTick("unacknowledged-tick")
+	require.Equal(t, versionA.UUID, first.PipelineVersionId)
+	first.State = model.RuntimeStateSucceeded
+	first.FinishedAtInSec = 201
+	require.NoError(t, store.RunStore().UpdateRun(first))
+	completedState, err := store.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.False(t, completedState.Pending)
+
+	// Retention can remove both the completed run and its historical template
+	// before the controller persists its acknowledgement of the tick.
+	versionB := publishVersion("version-b")
+	require.NoError(t, manager.DeleteRun(ctx, first.UUID))
+	require.NoError(t, manager.DeletePipelineVersion(versionA.UUID))
+	latest, err := manager.GetLatestPipelineVersion(pipeline.UUID)
+	require.NoError(t, err)
+	require.Equal(t, versionB.UUID, latest.UUID)
+	manager.time = fixedRecurringTime{epoch: 210}
+	acknowledged := createTick("unacknowledged-tick")
+	require.Equal(t, first.UUID, acknowledged.UUID)
+	require.Equal(t, first.DisplayName, acknowledged.DisplayName)
+	require.Equal(t, job.UUID, acknowledged.RecurringRunId)
+	require.Equal(t, first.Namespace, acknowledged.Namespace)
+	require.Equal(t, first.ExperimentId, acknowledged.ExperimentId)
+	require.Equal(t, first.ServiceAccount, acknowledged.ServiceAccount)
+	require.Equal(t, versionA.UUID, acknowledged.PipelineVersionId)
+	require.Equal(t, first.CreatedAtInSec, acknowledged.CreatedAtInSec)
+	require.Equal(t, first.ScheduledAtInSec, acknowledged.ScheduledAtInSec)
+	require.Equal(t, model.RuntimeStateUnspecified, acknowledged.State)
+	_, err = manager.GetRun(first.UUID)
+	require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	require.Zero(t, store.ExecClientFake.GetWorkflowCount())
+	stateAfterAcknowledgement, err := store.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, completedState, stateAfterAcknowledgement)
+
+	next := createTick("next-tick")
+	require.Equal(t, versionB.UUID, next.PipelineVersionId)
+	require.NotEqual(t, first.UUID, next.UUID)
+	require.Equal(t, int64(120), next.ScheduledAtInSec)
+	execution, err := store.ExecClientFake.Execution(job.Namespace).Get(ctx, next.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	workflow := execution.(*util.Workflow)
+	require.Equal(t, []string{"version-b"}, workflow.Spec.Templates[0].Container.Args)
+	require.Equal(t, "tick-2", workflow.GetWorkflowParametersAsMap()["param1"])
+	require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -847,7 +847,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}
 
 	allowCompilerPodSpecPatch := tmpl.GetTemplateType() == template.V2
-	if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace, "create_run"); err != nil {
 		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
 	}
 
@@ -880,7 +880,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}()
 
 	if r.pluginDispatcher.PluginsRegistered() {
-		if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+		if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace, "create_run_after_plugins"); err != nil {
 			return nil, util.Wrap(err, "Failed to create a run due to service account authorization error after plugin processing")
 		}
 	}
@@ -1312,7 +1312,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		}
 		allowCompilerPodSpecPatch = retryTemplate.GetTemplateType() == template.V2
 	}
-	if err := r.authorizeExecutionServiceAccounts(ctx, newExecSpec, allowCompilerPodSpecPatch, namespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, newExecSpec, allowCompilerPodSpecPatch, namespace, "retry_run"); err != nil {
 		return util.Wrapf(err, "Failed to retry run %s due to service account authorization error", runId)
 	}
 
@@ -1752,7 +1752,7 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to inspect the recurring run's service accounts")
 	}
-	if err := r.authorizeExecutionServiceAccounts(ctx, jobExecutionSpec, templateType == template.V2, k8sNamespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, jobExecutionSpec, templateType == template.V2, k8sNamespace, "create_recurring_run"); err != nil {
 		return nil, util.Wrap(err, "Failed to create a recurring run due to service account authorization error")
 	}
 
@@ -1820,7 +1820,7 @@ func (r *ResourceManager) ChangeJobMode(ctx context.Context, jobId string, enabl
 				return util.Wrapf(err, "Failed to enable recurring run %v because its workflow could not be inspected", jobId)
 			}
 			allowCompilerPodSpecPatch := job.WorkflowSpecManifest == "" && job.PipelineSpecManifest != ""
-			if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+			if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace, "enable_recurring_run"); err != nil {
 				return util.Wrapf(err, "Failed to enable recurring run %v due to service account authorization error", jobId)
 			}
 		}
@@ -3835,15 +3835,52 @@ func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAc
 	})
 }
 
-func (r *ResourceManager) authorizeExecutionServiceAccounts(ctx context.Context, executionSpec util.ExecutionSpec, allowCompilerPodSpecPatch bool, namespace string) error {
+func (r *ResourceManager) authorizeExecutionServiceAccounts(ctx context.Context, executionSpec util.ExecutionSpec, allowCompilerPodSpecPatch bool, namespace, operation string) error {
+	audit := common.IsWorkflowServiceAccountAuditEnabled()
+	mainServiceAccount := executionSpec.ServiceAccount()
+	if mainServiceAccount == "" {
+		mainServiceAccount = "default"
+	}
+	if audit {
+		// Audit only the expanded checks; the main-account policy still applies,
+		// including when a dynamic patch prevents identity collection.
+		if err := r.authorizeServiceAccount(ctx, mainServiceAccount, namespace); err != nil {
+			return err
+		}
+	}
 	serviceAccounts, err := executionSpec.ServiceAccounts(allowCompilerPodSpecPatch)
 	if err != nil {
+		if audit {
+			logWorkflowServiceAccountAudit(executionSpec, namespace, operation, "", "inspection_incomplete")
+			return nil
+		}
 		return err
 	}
 	for _, serviceAccount := range serviceAccounts {
+		if audit && serviceAccount == mainServiceAccount {
+			continue
+		}
 		if err := r.authorizeServiceAccount(ctx, serviceAccount, namespace); err != nil {
+			if audit {
+				finding := "authorization_error"
+				if util.IsUserErrorCodeMatch(err, codes.InvalidArgument) {
+					finding = "account_not_allowed"
+				} else if util.IsUserErrorCodeMatch(err, codes.PermissionDenied) {
+					finding = "account_denied"
+				}
+				logWorkflowServiceAccountAudit(executionSpec, namespace, operation, serviceAccount, finding)
+				continue
+			}
 			return err
 		}
 	}
 	return nil
+}
+
+func logWorkflowServiceAccountAudit(executionSpec util.ExecutionSpec, namespace, operation, serviceAccount, finding string) {
+	meta := executionSpec.ExecutionObjectMeta()
+	// Parser errors can contain patch values. Log metadata and a finding code,
+	// never the manifest, patch contents, or raw authorization error.
+	glog.Warningf("Workflow service account audit: operation=%q namespace=%q workflow=%q generate_name=%q run_id=%q service_account=%q finding=%q; continuing because %s=true",
+		operation, namespace, meta.Name, meta.GenerateName, meta.Labels[util.LabelKeyWorkflowRunId], serviceAccount, finding, common.WorkflowServiceAccountAudit)
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -760,12 +760,7 @@ func (r *ResourceManager) GetPipelineLatestTemplate(pipelineId string) ([]byte, 
 // Manifest's namespace gets overwritten with the run.Namespace.
 // Creating a run from recurring run prioritizes recurring run's pipeline spec over the run's one.
 func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model.Run, error) {
-	// Create a template based on the manifest of an existing pipeline version or used-provided manifest.
-	// Update the run.PipelineSpec if an existing pipeline version is used.
-	tmpl, manifest, err := r.fetchTemplateFromPipelineSpec(&run.PipelineSpec)
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to create a run due to error fetching manifest")
-	}
+	var err error
 
 	// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
 	// Proposed flow:
@@ -794,6 +789,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		RunAt: run.CreatedAtInSec,
 	}
 	var owner *scheduledworkflow.ScheduledWorkflow
+	var tick *recurringRunTick
 	if run.RecurringRunId != "" {
 		job, err := r.jobStore.GetJob(run.RecurringRunId)
 		if err != nil {
@@ -808,11 +804,32 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 			return nil, util.Wrap(err, "Failed to retrieve ScheduledWorkflow")
 		}
 		index := int64(1)
-		if owner.Status.Trigger.LastIndex != nil {
+		if common.IsMultiUserMode() {
+			tick, err = r.prepareRecurringRunTick(run, owner, run.CreatedAtInSec)
+			if err != nil {
+				return nil, util.Wrap(err, "Failed to prepare the authorized scheduled tick")
+			}
+			index = tick.index
+			run.UUID = util.NewDeterministicUUID(run.RecurringRunId + "/tick/" + strconv.FormatInt(index, 10))
+			if tick.replay != nil {
+				run.UUID = tick.replay.UUID
+			}
+			run.CreatedAtInSec = tick.createdAt
+			run.ScheduledAtInSec = tick.scheduledAt
+			runWorkflowOptions.RunID = run.UUID
+			runWorkflowOptions.RunAt = run.CreatedAtInSec
+		} else if owner.Status.Trigger.LastIndex != nil {
 			index = *owner.Status.Trigger.LastIndex + 1
 		}
 		runWorkflowOptions.RecurringRunIndex = &index
 	}
+	// Create a template based on the manifest of an existing pipeline version or used-provided manifest.
+	// Update the run.PipelineSpec if an existing pipeline version is used.
+	tmpl, manifest, err := r.fetchTemplateFromPipelineSpec(&run.PipelineSpec)
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to create a run due to error fetching manifest")
+	}
+
 	executionSpec, err := tmpl.RunWorkflow(run, runWorkflowOptions)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to generate the ExecutionSpec")
@@ -848,8 +865,17 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
 	}
 
-	// Guard against duplicate runs from concurrent recurring-run controller replicas.
-	if run.RecurringRunId != "" && run.DisplayName != "" {
+	if tick != nil {
+		if tick.replay != nil {
+			return tick.replay, nil
+		}
+		if err := r.claimRecurringRunTick(run, tick); err != nil {
+			return nil, err
+		}
+	}
+
+	// Replays still pass normal authorization. Kubernetes names arbitrate creation races.
+	if tick == nil && run.RecurringRunId != "" && run.DisplayName != "" {
 		existingRunID, err := r.runStore.GetRunByRecurringRunIDAndDisplayName(run.RecurringRunId, run.DisplayName)
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to check for existing run")
@@ -887,12 +913,24 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		}
 	}()
 
-	newExecSpec, err := r.getWorkflowClient(k8sNamespace).Create(ctx, executionSpec, v1.CreateOptions{})
+	newExecSpec, executionCreated, err := r.createRunExecution(ctx, run, executionSpec)
 	if err != nil {
 		if err, ok := err.(net.Error); ok && err.Timeout() {
 			return nil, util.NewUnavailableServerError(err, "Failed to create a workflow for (%s) - try again later", executionSpec.ExecutionName())
 		}
 		return nil, util.NewInternalServerError(err, "Failed to create a workflow for (%s)", executionSpec.ExecutionName())
+	}
+	if !executionCreated {
+		// This request must not clean up plugin resources belonging to the existing execution.
+		runPersisted = true
+		if run.PluginsOutputString != nil {
+			// Only the creator can persist the plugin output matching its workflow.
+			existing, err := r.runStore.GetRun(run.UUID)
+			if err != nil {
+				return nil, util.NewUnavailableServerError(err, "Retry after the scheduled run creator finishes persistence")
+			}
+			return existing, nil
+		}
 	}
 	// Update the run with the new scheduled workflow
 	run.Namespace = k8sNamespace

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -760,6 +760,22 @@ func (r *ResourceManager) GetPipelineLatestTemplate(pipelineId string) ([]byte, 
 // Manifest's namespace gets overwritten with the run.Namespace.
 // Creating a run from recurring run prioritizes recurring run's pipeline spec over the run's one.
 func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model.Run, error) {
+	if !common.IsMultiUserMode() && run.RecurringRunId != "" && run.DisplayName != "" {
+		existingRunID, err := r.runStore.GetRunByRecurringRunIDAndDisplayName(run.RecurringRunId, run.DisplayName)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to check for an existing scheduled run")
+		}
+		if existingRunID != "" {
+			existing, err := r.runStore.GetRun(existingRunID)
+			if err != nil {
+				return nil, err
+			}
+			if err := r.authorizeStoredRunServiceAccount(ctx, existing); err != nil {
+				return nil, util.Wrap(err, "Failed to acknowledge a scheduled run due to service account authorization error")
+			}
+			return existing, nil
+		}
+	}
 	var err error
 
 	// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
@@ -877,17 +893,6 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	if tick != nil {
 		if err := r.claimRecurringRunTick(run, tick); err != nil {
 			return nil, err
-		}
-	}
-
-	// Replays still pass normal authorization. Kubernetes names arbitrate creation races.
-	if tick == nil && run.RecurringRunId != "" && run.DisplayName != "" {
-		existingRunID, err := r.runStore.GetRunByRecurringRunIDAndDisplayName(run.RecurringRunId, run.DisplayName)
-		if err != nil {
-			return nil, util.Wrap(err, "Failed to check for existing run")
-		}
-		if existingRunID != "" {
-			return r.runStore.GetRun(existingRunID)
 		}
 	}
 

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -823,11 +823,11 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		}
 		runWorkflowOptions.RecurringRunIndex = &index
 	}
-	if tick != nil && tick.deleted {
-		// Acknowledgement cannot depend on a deleted pipeline version. The job
-		// retains its authorized effective account; the server checks pipeline
-		// and namespace access before entering CreateRun.
-		if err := r.authorizeServiceAccount(ctx, tick.replay.ServiceAccount, tick.replay.Namespace); err != nil {
+	if tick != nil && tick.replay != nil {
+		// Acknowledgement cannot depend on a deleted pipeline version. Preparation
+		// restores the job's effective account, including for reporter-recovered
+		// runs without a stored account. The server checks pipeline and namespace access.
+		if err := r.authorizeServiceAccount(ctx, run.ServiceAccount, run.Namespace); err != nil {
 			return nil, util.Wrap(err, "Failed to acknowledge a scheduled run due to service account authorization error")
 		}
 		return tick.replay, nil
@@ -875,9 +875,6 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}
 
 	if tick != nil {
-		if tick.replay != nil {
-			return tick.replay, nil
-		}
 		if err := r.claimRecurringRunTick(run, tick); err != nil {
 			return nil, err
 		}
@@ -922,6 +919,12 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		}
 	}()
 
+	if run.RecurringRunId != "" {
+		if err := apiserverPlugins.SetExecutionPluginParents(pendingRun, executionSpec); err != nil {
+			return nil, util.NewInternalServerError(err, "Failed to record recurring-run plugin parents")
+		}
+	}
+
 	newExecSpec, executionCreated, err := r.createRunExecution(ctx, run, executionSpec)
 	if err != nil {
 		if err, ok := err.(net.Error); ok && err.Timeout() {
@@ -930,8 +933,11 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		return nil, util.NewInternalServerError(err, "Failed to create a workflow for (%s)", executionSpec.ExecutionName())
 	}
 	if !executionCreated {
-		// This request must not clean up plugin resources belonging to the existing execution.
+		// Cleanup must preserve the creator's parents and persisted plugin output.
 		runPersisted = true
+		if err := r.pluginDispatcher.OnRunCreationDiscarded(ctx, pendingRun, newExecSpec); err != nil {
+			glog.Warningf("Failed to clean up discarded creation for run %q: %v", run.UUID, err)
+		}
 		// The absence of local plugin output does not mean the creator had none.
 		// Only the creator or persistence agent may persist the existing execution.
 		existing, err := r.runStore.GetRun(run.UUID)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -3691,6 +3691,9 @@ func (r *ResourceManager) IsAuthorized(ctx context.Context, resourceAttributes *
 			return reportErr
 		}
 	}
+	if !result.Status.Allowed && result.Status.EvaluationError != "" {
+		return util.NewInternalServerError(errors.New("SubjectAccessReview evaluation failed"), "Authorization could not be evaluated; try again later")
+	}
 	if !result.Status.Allowed {
 		err := util.NewPermissionDeniedError(
 			errors.New("Unauthorized access"),
@@ -3849,20 +3852,39 @@ func (r *ResourceManager) GetTask(taskId string) (*model.Task, error) {
 }
 
 func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAccount, namespace string) error {
+	mode, err := common.GetServiceAccountAuthorizationMode()
+	if err != nil {
+		return util.NewInternalServerError(err, "Invalid service-account authorization configuration")
+	}
 	if serviceAccount == "" {
 		return nil
 	}
+	audit := mode == "audit"
 	if err := common.ValidateServiceAccountAllowList(serviceAccount); err != nil {
-		return util.NewInvalidInputError("%s", err)
+		if !audit {
+			return util.NewInvalidInputError("%s", err)
+		}
+		logServiceAccountAuditDenial("allowlist", serviceAccount, namespace)
 	}
 	defaultServiceAccount := common.GetStringConfigWithDefault(common.DefaultPipelineRunnerServiceAccountFlag, common.DefaultPipelineRunnerServiceAccount)
 	if serviceAccount == defaultServiceAccount {
 		return nil
 	}
-	return r.IsAuthorized(ctx, &authorizationv1.ResourceAttributes{
+	err = r.IsAuthorized(ctx, &authorizationv1.ResourceAttributes{
 		Verb:      common.RbacResourceVerbUse,
 		Namespace: namespace,
 		Resource:  "serviceaccounts",
 		Name:      serviceAccount,
 	})
+	// Only a policy denial is bypassed. Authentication and authorization-service
+	// failures must still fail closed, even during migration.
+	if audit && util.IsUserErrorCodeMatch(err, codes.PermissionDenied) {
+		logServiceAccountAuditDenial("use_permission", serviceAccount, namespace)
+		return nil
+	}
+	return err
+}
+
+func logServiceAccountAuditDenial(check, serviceAccount, namespace string) {
+	glog.Warningf("service_account_authorization_audit: check=%s namespace=%q service_account=%q would_deny=true; enforcement disabled until administrator sets SERVICEACCOUNTAUTHORIZATIONMODE=enforce", check, namespace, serviceAccount)
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -846,7 +846,8 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		executionSpec.SetCannonicalLabels(swf.Name, run.CreatedAtInSec, nextIndex)
 	}
 
-	if err := r.authorizeServiceAccount(ctx, executionSpec.ServiceAccount(), k8sNamespace); err != nil {
+	allowCompilerPodSpecPatch := tmpl.GetTemplateType() == template.V2
+	if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
 		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
 	}
 
@@ -877,6 +878,12 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 			}
 		}
 	}()
+
+	if r.pluginDispatcher.PluginsRegistered() {
+		if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+			return nil, util.Wrap(err, "Failed to create a run due to service account authorization error after plugin processing")
+		}
+	}
 
 	newExecSpec, err := r.getWorkflowClient(k8sNamespace).Create(ctx, executionSpec, v1.CreateOptions{})
 	if err != nil {
@@ -1296,6 +1303,19 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		}
 	}
 
+	allowCompilerPodSpecPatch := false
+	// Recurring-run reports store both the source pipeline and compiled workflow.
+	if run.PipelineSpecManifest != "" {
+		retryTemplate, templateErr := template.New([]byte(run.PipelineSpecManifest), template.TemplateOptions{})
+		if templateErr != nil {
+			return util.NewInternalServerError(templateErr, "Failed to retry run %s due to error parsing its pipeline spec", runId)
+		}
+		allowCompilerPodSpecPatch = retryTemplate.GetTemplateType() == template.V2
+	}
+	if err := r.authorizeExecutionServiceAccounts(ctx, newExecSpec, allowCompilerPodSpecPatch, namespace); err != nil {
+		return util.Wrapf(err, "Failed to retry run %s due to service account authorization error", runId)
+	}
+
 	// Atomically claim via database-side CAS to prevent ReportWorkflowResource
 	// from overwriting with a stale terminal state. The returned claimGeneration
 	// acts as a unique fence token: UpdateRun checks it to reject stale reports,
@@ -1640,7 +1660,9 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 
 	var manifest string
 	var scheduledWorkflow *scheduledworkflow.ScheduledWorkflow
+	var renderedScheduledWorkflow *scheduledworkflow.ScheduledWorkflow
 	var tmpl template.Template
+	var templateType template.TemplateType
 
 	// If the pipeline version or pipeline spec is provided, this means the user wants to pin to a specific pipeline.
 	// Otherwise, always let the ScheduledWorkflow controller pick the latest.
@@ -1652,7 +1674,12 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		if err != nil {
 			return nil, util.NewInternalServerError(err, "Failed to create a recurring run with an invalid pipeline spec manifest")
 		}
+		templateType = tmpl.GetTemplateType()
 
+		renderedScheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+		}
 		// When plugins are enabled, the SWF controller must call the CreateRun API
 		// so that per-run plugin logic executes.
 		if r.pluginDispatcher.PluginsRegistered() {
@@ -1660,9 +1687,7 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			// so the SWF controller calls the CreateRun API for per-run plugin logic.
 			scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
 		} else {
-			// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
-			// Convert modelJob into scheduledWorkflow.
-			scheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
+			scheduledWorkflow = renderedScheduledWorkflow
 		}
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
@@ -1687,16 +1712,17 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			DefaultRunAsNonRoot:  r.options.DefaultRunAsNonRoot,
 			DefaultHostUsers:     r.options.DefaultHostUsers,
 		}
-		tmpl, err := template.New(manifest, templateOptions)
+		latestTemplate, err := template.New(manifest, templateOptions)
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to fetch a template with an invalid pipeline spec manifest")
 		}
+		templateType = latestTemplate.GetTemplateType()
 
-		validatedScheduledWorkflow, err := tmpl.ScheduledWorkflow(job)
+		renderedScheduledWorkflow, err = latestTemplate.ScheduledWorkflow(job)
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
 		}
-		if v2Tmpl, ok := tmpl.(*template.V2Spec); ok {
+		if v2Tmpl, ok := latestTemplate.(*template.V2Spec); ok {
 			if err = v2Tmpl.ValidateJobInputs(job); err != nil {
 				return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
 			}
@@ -1715,18 +1741,18 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
 			Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
 		}
-		scheduledWorkflow.Spec.ServiceAccount = validatedScheduledWorkflow.Spec.ServiceAccount
+		scheduledWorkflow.Spec.ServiceAccount = renderedScheduledWorkflow.Spec.ServiceAccount
 	}
 
-	if tmpl != nil && util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
+	if util.IsV1PipelinesBlocked(k8sNamespace) && templateType == template.V1 {
 		return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
 	}
 
-	resolvedJobServiceAccount := scheduledWorkflow.Spec.ServiceAccount
-	if resolvedJobServiceAccount == "" {
-		resolvedJobServiceAccount = job.ServiceAccount
+	jobExecutionSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, renderedScheduledWorkflow.Spec.Workflow)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to inspect the recurring run's service accounts")
 	}
-	if err := r.authorizeServiceAccount(ctx, resolvedJobServiceAccount, k8sNamespace); err != nil {
+	if err := r.authorizeExecutionServiceAccounts(ctx, jobExecutionSpec, templateType == template.V2, k8sNamespace); err != nil {
 		return nil, util.Wrap(err, "Failed to create a recurring run due to service account authorization error")
 	}
 
@@ -1785,6 +1811,18 @@ func (r *ResourceManager) ChangeJobMode(ctx context.Context, jobId string, enabl
 		}
 		if scheduledWorkflow == nil || string(scheduledWorkflow.UID) != jobId {
 			return util.Wrapf(util.NewResourceNotFoundError("recurring run", job.K8SName), "Failed to enable recurring run %v. Check if its k8s resource exists", jobId)
+		}
+		// An embedded workflow is launched directly by the ScheduledWorkflow
+		// controller, so reauthorize its identities whenever a job is enabled.
+		if scheduledWorkflow.Spec.Workflow != nil && scheduledWorkflow.Spec.Workflow.Spec != nil {
+			executionSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, scheduledWorkflow.Spec.Workflow)
+			if err != nil {
+				return util.Wrapf(err, "Failed to enable recurring run %v because its workflow could not be inspected", jobId)
+			}
+			allowCompilerPodSpecPatch := job.WorkflowSpecManifest == "" && job.PipelineSpecManifest != ""
+			if err := r.authorizeExecutionServiceAccounts(ctx, executionSpec, allowCompilerPodSpecPatch, k8sNamespace); err != nil {
+				return util.Wrapf(err, "Failed to enable recurring run %v due to service account authorization error", jobId)
+			}
 		}
 	}
 
@@ -3779,6 +3817,9 @@ func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAc
 	if serviceAccount == "" {
 		return nil
 	}
+	if strings.Contains(serviceAccount, "{{") {
+		return util.NewInvalidInputError("service account %q is templated; use a literal name so it can be authorized before execution", serviceAccount)
+	}
 	if err := common.ValidateServiceAccountAllowList(serviceAccount); err != nil {
 		return util.NewInvalidInputError("%s", err)
 	}
@@ -3792,4 +3833,17 @@ func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAc
 		Resource:  "serviceaccounts",
 		Name:      serviceAccount,
 	})
+}
+
+func (r *ResourceManager) authorizeExecutionServiceAccounts(ctx context.Context, executionSpec util.ExecutionSpec, allowCompilerPodSpecPatch bool, namespace string) error {
+	serviceAccounts, err := executionSpec.ServiceAccounts(allowCompilerPodSpecPatch)
+	if err != nil {
+		return err
+	}
+	for _, serviceAccount := range serviceAccounts {
+		if err := r.authorizeServiceAccount(ctx, serviceAccount, namespace); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -760,17 +760,6 @@ func (r *ResourceManager) GetPipelineLatestTemplate(pipelineId string) ([]byte, 
 // Manifest's namespace gets overwritten with the run.Namespace.
 // Creating a run from recurring run prioritizes recurring run's pipeline spec over the run's one.
 func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model.Run, error) {
-	// Guard against duplicate runs from concurrent recurring-run controller replicas.
-	if run.RecurringRunId != "" && run.DisplayName != "" {
-		existingRunID, err := r.runStore.GetRunByRecurringRunIDAndDisplayName(run.RecurringRunId, run.DisplayName)
-		if err != nil {
-			return nil, util.Wrap(err, "Failed to check for existing run")
-		}
-		if existingRunID != "" {
-			return r.runStore.GetRun(existingRunID)
-		}
-	}
-
 	// Create a template based on the manifest of an existing pipeline version or used-provided manifest.
 	// Update the run.PipelineSpec if an existing pipeline version is used.
 	tmpl, manifest, err := r.fetchTemplateFromPipelineSpec(&run.PipelineSpec)
@@ -804,6 +793,26 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		RunID: run.UUID,
 		RunAt: run.CreatedAtInSec,
 	}
+	var owner *scheduledworkflow.ScheduledWorkflow
+	if run.RecurringRunId != "" {
+		job, err := r.jobStore.GetJob(run.RecurringRunId)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to retrieve recurring run")
+		}
+		ownerNamespace := job.Namespace
+		if common.IsMultiUserMode() && r.IsEmptyNamespace(ownerNamespace) {
+			ownerNamespace = run.Namespace
+		}
+		owner, err = r.swfClient.ScheduledWorkflow(ownerNamespace).Get(ctx, job.K8SName, v1.GetOptions{})
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to retrieve ScheduledWorkflow")
+		}
+		index := int64(1)
+		if owner.Status.Trigger.LastIndex != nil {
+			index = *owner.Status.Trigger.LastIndex + 1
+		}
+		runWorkflowOptions.RecurringRunIndex = &index
+	}
 	executionSpec, err := tmpl.RunWorkflow(run, runWorkflowOptions)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to generate the ExecutionSpec")
@@ -826,28 +835,28 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	}
 
 	executionSpec.SetExecutionNamespace(k8sNamespace)
-
-	// assign OwnerReference and canonical labels to scheduledworkflow
-	if run.RecurringRunId != "" {
-		job, err := r.jobStore.GetJob(run.RecurringRunId)
-		if err != nil {
-			return nil, util.NewInternalServerError(util.NewInvalidInputError("RecurringRunId doesn't exist: %s", run.RecurringRunId), "Failed to create a run due to invalid recurring run id")
+	if owner != nil {
+		executionSpec.SetOwnerReferences(owner)
+		scheduledAt := run.CreatedAtInSec
+		if run.ScheduledAtInSec > 0 {
+			scheduledAt = run.ScheduledAtInSec
 		}
-		swf, err := r.swfClient.ScheduledWorkflow(job.Namespace).Get(ctx, job.K8SName, v1.GetOptions{})
-		if err != nil {
-			return nil, util.NewInternalServerError(util.NewInvalidInputError("ScheduledWorkflow doesn't exist: %s", job.K8SName), "Failed to create a run due to invalid name")
-		}
-		executionSpec.SetOwnerReferences(swf)
-		// canonical labels required for SWF controller label-based workflow tracking
-		nextIndex := int64(1)
-		if swf.Status.Trigger.LastIndex != nil {
-			nextIndex = *swf.Status.Trigger.LastIndex + 1
-		}
-		executionSpec.SetCannonicalLabels(swf.Name, run.CreatedAtInSec, nextIndex)
+		executionSpec.SetCannonicalLabels(owner.Name, scheduledAt, *runWorkflowOptions.RecurringRunIndex)
 	}
 
 	if err := r.authorizeServiceAccount(ctx, executionSpec.ServiceAccount(), k8sNamespace); err != nil {
 		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
+	}
+
+	// Guard against duplicate runs from concurrent recurring-run controller replicas.
+	if run.RecurringRunId != "" && run.DisplayName != "" {
+		existingRunID, err := r.runStore.GetRunByRecurringRunIDAndDisplayName(run.RecurringRunId, run.DisplayName)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to check for existing run")
+		}
+		if existingRunID != "" {
+			return r.runStore.GetRun(existingRunID)
+		}
 	}
 
 	// Run plugin lifecycle hooks before workflow creation.
@@ -1653,20 +1662,22 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			return nil, util.NewInternalServerError(err, "Failed to create a recurring run with an invalid pipeline spec manifest")
 		}
 
-		// When plugins are enabled, the SWF controller must call the CreateRun API
-		// so that per-run plugin logic executes.
-		if r.pluginDispatcher.PluginsRegistered() {
-			// Plugin-enabled: create a lightweight SWF without inline workflow spec
-			// so the SWF controller calls the CreateRun API for per-run plugin logic.
-			scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
-		} else {
-			// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
-			// Convert modelJob into scheduledWorkflow.
-			scheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
-		}
+		scheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
 		if err != nil {
-			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+			return nil, util.Wrap(err, "Failed to validate the recurring run workflow")
 		}
+		job.ServiceAccount, err = scheduledServiceAccount(scheduledWorkflow, job.ServiceAccount)
+		if err != nil {
+			return nil, err
+		}
+		// Plugins execute per run, so omit the embedded workflow after validating it.
+		if r.pluginDispatcher.PluginsRegistered() {
+			scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
+			if err != nil {
+				return nil, util.Wrap(err, "Failed to create a recurring run")
+			}
+		}
+
 	} else if job.PipelineId == "" {
 		return nil, errors.New("Cannot create a job with an empty pipeline ID")
 	} else {
@@ -1715,17 +1726,24 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
 			Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
 		}
-		scheduledWorkflow.Spec.ServiceAccount = validatedScheduledWorkflow.Spec.ServiceAccount
+		scheduledWorkflow.Spec.ServiceAccount, err = scheduledServiceAccount(validatedScheduledWorkflow, job.ServiceAccount)
+		if err != nil {
+			return nil, err
+		}
+		if util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
+			return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to KFP V2 pipelines.", k8sNamespace)
+		}
 	}
 
 	if tmpl != nil && util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
 		return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
 	}
 
-	resolvedJobServiceAccount := scheduledWorkflow.Spec.ServiceAccount
-	if resolvedJobServiceAccount == "" {
-		resolvedJobServiceAccount = job.ServiceAccount
+	resolvedJobServiceAccount, err := scheduledServiceAccount(scheduledWorkflow, job.ServiceAccount)
+	if err != nil {
+		return nil, err
 	}
+	job.ServiceAccount = resolvedJobServiceAccount
 	if err := r.authorizeServiceAccount(ctx, resolvedJobServiceAccount, k8sNamespace); err != nil {
 		return nil, util.Wrap(err, "Failed to create a recurring run due to service account authorization error")
 	}
@@ -1751,20 +1769,11 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 	}
 
 	if tmpl.GetTemplateType() == template.V1 {
-		// Get the service account
-		serviceAccount := ""
-		if swf.Spec.Workflow != nil {
-			execSpec, err := util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, swf.Spec.Workflow)
-			if err == nil {
-				serviceAccount = execSpec.ServiceAccount()
-			}
-		}
-		job.ServiceAccount = serviceAccount
 		job.WorkflowSpecManifest = model.LargeText(manifest)
 	} else {
-		job.ServiceAccount = newScheduledWorkflow.Spec.ServiceAccount
 		job.PipelineSpecManifest = model.LargeText(manifest)
 	}
+
 	return r.jobStore.CreateJob(job)
 }
 
@@ -3131,8 +3140,15 @@ func escapeJSONPointerPathPart(pathPart string) string {
 // Updates a recurring run with a scheduled workflow CR.
 func (r *ResourceManager) ReportScheduledWorkflowResource(swf *util.ScheduledWorkflow) error {
 	// Verify the job exists
-	if _, err := r.GetJob(string(swf.UID)); err != nil {
+	job, err := r.GetJob(string(swf.UID))
+	if err != nil {
 		return util.Wrapf(err, "Failed to report scheduled workflow due to error retrieving recurring run %s", string(swf.UID))
+	}
+	if common.IsMultiUserMode() {
+		if job.K8SName != swf.Name || job.Namespace != swf.Namespace {
+			return util.NewPermissionDeniedError(fmt.Errorf("ScheduledWorkflow identity differs from its job"), "Cannot report a different recurring run")
+		}
+		return r.jobStore.UpdateJobStatus(swf)
 	}
 	return r.jobStore.UpdateJob(swf)
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -823,6 +823,15 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		}
 		runWorkflowOptions.RecurringRunIndex = &index
 	}
+	if tick != nil && tick.deleted {
+		// Acknowledgement cannot depend on a deleted pipeline version. The job
+		// retains its authorized effective account; the server checks pipeline
+		// and namespace access before entering CreateRun.
+		if err := r.authorizeServiceAccount(ctx, tick.replay.ServiceAccount, tick.replay.Namespace); err != nil {
+			return nil, util.Wrap(err, "Failed to acknowledge a scheduled run due to service account authorization error")
+		}
+		return tick.replay, nil
+	}
 	// Create a template based on the manifest of an existing pipeline version or used-provided manifest.
 	// Update the run.PipelineSpec if an existing pipeline version is used.
 	tmpl, manifest, err := r.fetchTemplateFromPipelineSpec(&run.PipelineSpec)
@@ -923,14 +932,13 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	if !executionCreated {
 		// This request must not clean up plugin resources belonging to the existing execution.
 		runPersisted = true
-		if run.PluginsOutputString != nil {
-			// Only the creator can persist the plugin output matching its workflow.
-			existing, err := r.runStore.GetRun(run.UUID)
-			if err != nil {
-				return nil, util.NewUnavailableServerError(err, "Retry after the scheduled run creator finishes persistence")
-			}
-			return existing, nil
+		// The absence of local plugin output does not mean the creator had none.
+		// Only the creator or persistence agent may persist the existing execution.
+		existing, err := r.runStore.GetRun(run.UUID)
+		if err != nil {
+			return nil, util.NewUnavailableServerError(err, "Retry after the scheduled run creator or persistence agent finishes persistence")
 		}
+		return existing, nil
 	}
 	// Update the run with the new scheduled workflow
 	run.Namespace = k8sNamespace

--- a/backend/src/apiserver/resource/resource_manager_recurring_retry_internal_test.go
+++ b/backend/src/apiserver/resource/resource_manager_recurring_retry_internal_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	swfutil "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRetryRun_ReportedRecurringRunPodSpecPatch(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		v2             bool
+		v1PipelineSpec bool
+	}{
+		{name: "compiled v2 workflow", v2: true},
+		{name: "raw v1 workflow cannot impersonate compiler patch"},
+		{name: "v1 pipeline spec cannot impersonate compiler patch", v1PipelineSpec: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var store *FakeClientManager
+			var manager *ResourceManager
+			var job *model.Job
+			switch {
+			case test.v2:
+				store, manager, job = initWithJobV2(t)
+			case test.v1PipelineSpec:
+				var experiment *model.Experiment
+				store, manager, experiment = initWithExperiment(t)
+				var err error
+				job, err = manager.CreateJob(context.Background(), &model.Job{
+					DisplayName: "j1", Enabled: true, ExperimentId: experiment.UUID,
+					PipelineSpec: model.PipelineSpec{PipelineSpecManifest: model.LargeText(testWorkflow.ToStringForStore())},
+				})
+				require.NoError(t, err)
+			default:
+				store, manager, job = initWithJob(t)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			schedule, err := store.SwfClient().ScheduledWorkflow(job.Namespace).Get(ctx, job.K8SName, metav1.GetOptions{})
+			require.NoError(t, err)
+			executionSpec, err := swfutil.NewScheduledWorkflow(schedule).NewWorkflow(11, 11)
+			require.NoError(t, err)
+			workflow := executionSpec.(*util.Workflow)
+			workflow.Namespace = job.Namespace
+			if !test.v2 {
+				// Existing V1 workflows must not gain the compiler-only exemption on retry.
+				workflow.Spec.Templates[0].PodSpecPatch = "{{inputs.parameters.pod-spec-patch}}"
+			}
+			require.Contains(t, workflow.ToStringForStore(), "{{inputs.parameters.pod-spec-patch}}")
+			workflow.Status.Phase = v1alpha1.WorkflowFailed
+			syncWorkflowReportWithFakeCluster(t, store, workflow)
+			_, err = manager.ReportWorkflowResource(ctx, workflow)
+			require.NoError(t, err)
+
+			runID := workflow.Labels[util.LabelKeyWorkflowRunId]
+			run, err := manager.GetRun(runID)
+			require.NoError(t, err)
+			require.Equal(t, job.UUID, run.RecurringRunId)
+			require.NotEmpty(t, run.WorkflowSpecManifest)
+			require.Equal(t, model.RuntimeStateFailed, run.State)
+			if test.v2 || test.v1PipelineSpec {
+				require.NotEmpty(t, run.PipelineSpecManifest)
+			}
+
+			err = manager.RetryRun(ctx, runID)
+			if test.v2 {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, "podSpecPatch")
+			}
+			run, err = manager.GetRun(runID)
+			require.NoError(t, err)
+			liveWorkflow, err := store.ExecClient().Execution(job.Namespace).Get(ctx, workflow.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			if test.v2 {
+				assert.Equal(t, model.RuntimeStateRunning, run.State)
+				assert.Equal(t, string(v1alpha1.WorkflowRunning), string(liveWorkflow.ExecutionStatus().Condition()))
+			} else {
+				assert.Equal(t, model.RuntimeStateFailed, run.State)
+				assert.Zero(t, run.RetryGeneration)
+				assert.Equal(t, string(v1alpha1.WorkflowFailed), string(liveWorkflow.ExecutionStatus().Condition()))
+			}
+		})
+	}
+}

--- a/backend/src/apiserver/resource/resource_manager_service_account_audit_test.go
+++ b/backend/src/apiserver/resource/resource_manager_service_account_audit_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	plugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/plugins/mlflow"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func configureServiceAccountAuditTest(t *testing.T, audit bool) {
+	t.Helper()
+	viper.Set(common.WorkflowServiceAccountAudit, audit)
+	viper.Set(common.MultiUserMode, "true")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa,another-sa")
+	t.Cleanup(func() {
+		viper.Set(common.WorkflowServiceAccountAudit, nil)
+		viper.Set(common.MultiUserMode, "false")
+		viper.Set(common.AllowedServiceAccountsFlag, "")
+	})
+}
+
+// These tests must remain sequential: glog, stderr and Viper are process-global.
+func captureServiceAccountAuditLogs(t *testing.T, action func()) string {
+	t.Helper()
+	output, err := os.CreateTemp(t.TempDir(), "audit-log")
+	require.NoError(t, err)
+	defer output.Close()
+	originalStderr := os.Stderr
+	originalLogToStderr := flag.Lookup("logtostderr").Value.String()
+	require.NoError(t, flag.Set("logtostderr", "true"))
+	os.Stderr = output
+	defer func() {
+		os.Stderr = originalStderr
+		_ = flag.Set("logtostderr", originalLogToStderr)
+	}()
+	action()
+	data, err := os.ReadFile(output.Name())
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestWorkflowServiceAccountAuditChecks(t *testing.T) {
+	for _, test := range []struct {
+		name, finding string
+		modify        func(*util.Workflow, *ResourceManager)
+	}{
+		{name: "SAR denial", finding: "account_denied"},
+		{name: "allow list denial", finding: "account_not_allowed", modify: func(_ *util.Workflow, _ *ResourceManager) {
+			viper.Set(common.AllowedServiceAccountsFlag, "")
+		}},
+		{name: "SAR unavailable", finding: "authorization_error", modify: func(_ *util.Workflow, manager *ResourceManager) {
+			manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientError()
+		}},
+		{name: "dynamic patch", finding: "inspection_incomplete", modify: func(workflow *util.Workflow, _ *ResourceManager) {
+			workflow.Spec.PodSpecPatch = `{{workflow.parameters.private-patch-value}}`
+		}},
+		{name: "malformed patch", finding: "inspection_incomplete", modify: func(workflow *util.Workflow, _ *ResourceManager) {
+			workflow.Spec.PodSpecPatch = `{"containers":"private-patch-value"}`
+		}},
+		{name: "retained external reference", finding: "inspection_incomplete", modify: func(workflow *util.Workflow, _ *ResourceManager) {
+			workflow.Status.StoredWorkflowSpec = &workflowapi.WorkflowSpec{WorkflowTemplateRef: &workflowapi.WorkflowTemplateRef{Name: "external"}}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, audit := range []bool{false, true} {
+				mode := "enforce"
+				if audit {
+					mode = "audit"
+				}
+				t.Run(mode, func(t *testing.T) {
+					configureServiceAccountAuditTest(t, audit)
+					store, manager, _ := initWithExperimentAndUnauthorizedSAR(t)
+					defer store.Close()
+					workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+					workflow.Spec.ServiceAccountName = common.DefaultPipelineRunnerServiceAccount
+					workflow.Spec.Templates[0].ServiceAccountName = "nested-sa"
+					workflow.Spec.TemplateDefaults = &workflowapi.Template{ServiceAccountName: "another-sa"}
+					if test.modify != nil {
+						test.modify(workflow, manager)
+					}
+					logs := captureServiceAccountAuditLogs(t, func() {
+						err := manager.authorizeExecutionServiceAccounts(multiUserContext(), workflow, false, "ns1", "create_run")
+						if audit {
+							require.NoError(t, err)
+						} else {
+							require.Error(t, err)
+						}
+					})
+					if audit {
+						assert.Contains(t, logs, `operation="create_run" namespace="ns1" workflow="workflow-name"`)
+						assert.Contains(t, logs, `finding="`+test.finding+`"`)
+						assert.Contains(t, logs, common.WorkflowServiceAccountAudit+"=true")
+						if test.finding != "inspection_incomplete" {
+							assert.Contains(t, logs, `service_account="nested-sa"`)
+							assert.Contains(t, logs, `service_account="another-sa"`)
+						}
+					} else {
+						assert.NotContains(t, logs, "Workflow service account audit:")
+					}
+					assert.NotContains(t, logs, "private-patch-value")
+				})
+			}
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditStillEnforcesMainAccount(t *testing.T) {
+	for _, allowList := range []string{"", "main-sa"} {
+		t.Run("allowed="+allowList, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			viper.Set(common.AllowedServiceAccountsFlag, allowList)
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+			workflow.Spec.ServiceAccountName = "main-sa"
+			workflow.Spec.PodSpecPatch = `{"serviceAccountName":"{{workflow.parameters.param1}}"}`
+			_, err := manager.CreateRun(multiUserContext(), &model.Run{
+				DisplayName: "audit", ExperimentId: experiment.UUID,
+				PipelineSpec: model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"pipeline-runner"}]`,
+				},
+			})
+			require.Error(t, err)
+			assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditFreshWorkflows(t *testing.T) {
+	for _, version := range []string{"v1", "v2"} {
+		for _, externalReference := range []bool{false, true} {
+			name := version + "/valid"
+			if externalReference {
+				name = version + "/external reference"
+			}
+			t.Run(name, func(t *testing.T) {
+				configureServiceAccountAuditTest(t, true)
+				store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+				defer store.Close()
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.Status.StoredTemplates = map[string]workflowapi.Template{"untrusted": {Name: "untrusted", ServiceAccountName: "nested-sa"}}
+				if externalReference {
+					workflow.Spec.WorkflowTemplateRef = &workflowapi.WorkflowTemplateRef{Name: "external"}
+				}
+				pipelineSpec := model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(workflow.ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"world"}]`,
+				}
+				if version == "v2" {
+					pipelineSpec = model.PipelineSpec{
+						PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+						RuntimeConfig:        model.RuntimeConfig{Parameters: `{"text":"world"}`},
+					}
+					if externalReference {
+						viper.Set(common.CompiledPipelineSpecPatch, `{"workflowTemplateRef":{"name":"external"}}`)
+						t.Cleanup(func() { viper.Set(common.CompiledPipelineSpecPatch, "") })
+					}
+				}
+				logs := captureServiceAccountAuditLogs(t, func() {
+					run, err := manager.CreateRun(multiUserContext(), &model.Run{DisplayName: "audit", ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec})
+					if externalReference {
+						require.ErrorContains(t, err, "external workflow template references")
+						assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+						return
+					}
+					require.NoError(t, err)
+					created, err := store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+					assert.Empty(t, created.(*util.Workflow).Status.StoredTemplates)
+					if version == "v2" {
+						assert.Contains(t, created.ToStringForStore(), "{{inputs.parameters.pod-spec-patch}}")
+					}
+				})
+				assert.NotContains(t, logs, "Workflow service account audit:")
+			})
+		}
+	}
+}
+
+func TestWorkflowServiceAccountAuditEnforcesImplicitMainAccount(t *testing.T) {
+	for _, allowList := range []string{"", "default"} {
+		t.Run("allowed="+allowList, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			viper.Set(common.AllowedServiceAccountsFlag, allowList)
+			store, manager, _ := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+			// Kubernetes uses default when a retained workflow or plugin omits
+			// the main account. An inspection failure must not bypass its policy.
+			workflow.Spec.ServiceAccountName = ""
+			workflow.Spec.PodSpecPatch = `{{workflow.parameters.param1}}`
+			logs := captureServiceAccountAuditLogs(t, func() {
+				err := manager.authorizeExecutionServiceAccounts(multiUserContext(), workflow, false, "ns1", "retry_run")
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "default")
+			})
+			assert.NotContains(t, logs, "Workflow service account audit:")
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditCreateRunAndJob(t *testing.T) {
+	for _, kind := range []string{"run", "dynamic run", "job", "job with plugins", "latest job"} {
+		t.Run(kind, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			pipelineSpec := model.PipelineSpec{WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa")}
+			if kind == "dynamic run" {
+				workflow := util.NewWorkflow(testWorkflow.DeepCopy())
+				workflow.Spec.PodSpecPatch = `{"serviceAccountName":"{{workflow.parameters.param1}}"}`
+				pipelineSpec.WorkflowSpecManifest = model.LargeText(workflow.ToStringForStore())
+			}
+			if kind == "job with plugins" {
+				manager.pluginDispatcher = &countingTerminalReportDispatcher{}
+			}
+			if kind == "latest job" {
+				pipeline, err := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+				require.NoError(t, err)
+				_, err = manager.CreatePipelineVersion(createPipelineVersion(pipeline.UUID, "v1", "v1", "", string(pipelineSpec.WorkflowSpecManifest), "", "ns1"))
+				require.NoError(t, err)
+				pipelineSpec = model.PipelineSpec{PipelineId: pipeline.UUID}
+			}
+			operation := "create_recurring_run"
+			logs := captureServiceAccountAuditLogs(t, func() {
+				if kind == "run" || kind == "dynamic run" {
+					operation = "create_run"
+					pipelineSpec.Parameters = `[{"name":"param1","value":"pipeline-runner"}]`
+					_, err := manager.CreateRun(multiUserContext(), &model.Run{DisplayName: "audit", ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec})
+					require.NoError(t, err)
+					assert.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+				} else {
+					job, err := manager.CreateJob(multiUserContext(), &model.Job{DisplayName: "audit", Enabled: true, ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec})
+					require.NoError(t, err)
+					_, err = store.SwfClient().ScheduledWorkflow(job.Namespace).Get(context.Background(), job.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+				}
+			})
+			assert.Contains(t, logs, `operation="`+operation+`"`)
+		})
+	}
+}
+
+type auditTemplateMutatingDispatcher struct {
+	serviceAccountMutatingDispatcher
+}
+
+func (d *auditTemplateMutatingDispatcher) OnBeforeRunCreation(_ context.Context, run *plugins.PendingRun, executionSpec util.ExecutionSpec) error {
+	executionSpec.(*util.Workflow).Spec.Templates[0].ServiceAccountName = "nested-sa"
+	return plugins.SetPendingRunPluginOutput(run, mlflow.PluginName, d.output)
+}
+
+func TestWorkflowServiceAccountAuditPluginMutation(t *testing.T) {
+	for _, mainAccount := range []bool{false, true} {
+		name := "additional account"
+		if mainAccount {
+			name = "main account"
+		}
+		t.Run(name, func(t *testing.T) {
+			configureServiceAccountAuditTest(t, true)
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			dispatcher := &auditTemplateMutatingDispatcher{serviceAccountMutatingDispatcher{output: mlflow.SuccessfulPluginOutput("exp", "experiment", "parent", "https://mlflow.example/runs/parent")}}
+			manager.pluginDispatcher = dispatcher
+			if mainAccount {
+				manager.pluginDispatcher = &dispatcher.serviceAccountMutatingDispatcher
+			}
+			logs := captureServiceAccountAuditLogs(t, func() {
+				_, err := manager.CreateRun(multiUserContext(), &model.Run{
+					DisplayName: "audit", ExperimentId: experiment.UUID,
+					PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()), Parameters: `[{"name":"param1","value":"world"}]`},
+				})
+				if mainAccount {
+					require.Error(t, err)
+					assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+					require.Len(t, dispatcher.endedRuns, 1)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+					assert.Empty(t, dispatcher.endedRuns)
+				}
+			})
+			if !mainAccount {
+				assert.Contains(t, logs, `operation="create_run_after_plugins"`)
+			}
+		})
+	}
+}
+
+func TestWorkflowServiceAccountAuditRetryAndEnable(t *testing.T) {
+	t.Run("retry", func(t *testing.T) {
+		store, manager, run := initWithOneTimeFailedRun(t)
+		defer store.Close()
+		run, err := manager.GetRun(run.UUID)
+		require.NoError(t, err)
+		workflow, err := util.NewWorkflowFromBytesJSON([]byte(run.WorkflowRuntimeManifest))
+		require.NoError(t, err)
+		require.NoError(t, workflow.Decompress())
+		workflow.Status.StoredTemplates = map[string]workflowapi.Template{"cached": {Name: "cached", ServiceAccountName: "nested-sa"}}
+		run.WorkflowRuntimeManifest = model.LargeText(workflow.ToStringForStore())
+		require.NoError(t, manager.runStore.UpdateRun(run))
+		syncWorkflowReportWithFakeCluster(t, store, workflow)
+		configureServiceAccountAuditTest(t, true)
+		manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+		logs := captureServiceAccountAuditLogs(t, func() {
+			require.NoError(t, manager.RetryRun(multiUserContext(), run.UUID))
+		})
+		assert.Contains(t, logs, `operation="retry_run"`)
+		after, err := manager.GetRun(run.UUID)
+		require.NoError(t, err)
+		assert.Equal(t, model.RuntimeStateRunning, after.State)
+	})
+	t.Run("enable", func(t *testing.T) {
+		configureServiceAccountAuditTest(t, true)
+		store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+		defer store.Close()
+		job, err := manager.CreateJob(multiUserContext(), &model.Job{
+			DisplayName: "audit", Enabled: false, ExperimentId: experiment.UUID,
+			PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa")},
+		})
+		require.NoError(t, err)
+		logs := captureServiceAccountAuditLogs(t, func() {
+			require.NoError(t, manager.ChangeJobMode(multiUserContext(), job.UUID, true))
+		})
+		assert.Contains(t, logs, `operation="enable_recurring_run"`)
+		after, err := manager.GetJob(job.UUID)
+		require.NoError(t, err)
+		assert.True(t, after.Enabled)
+	})
+}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -4023,9 +4023,8 @@ func TestCreateJob_ThroughPipelineID(t *testing.T) {
 		DisplayName: "j1",
 		K8SName:     "job-",
 		Namespace:   "ns1",
-		// Since there is no pipeline version or service account specified, the API server will select the service
-		// account when compiling the run, not within the ScheduledWorkflow.
-		ServiceAccount: "",
+		// Persist the effective account authorized when the follow-latest schedule is created.
+		ServiceAccount: "pipeline-runner",
 		Enabled:        true,
 		CreatedAtInSec: 4,
 		UpdatedAtInSec: 4,

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	swfclientv1beta1 "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned/typed/scheduledworkflow/v1beta1"
 	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/spf13/viper"
@@ -54,6 +55,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -257,6 +259,12 @@ var testWorkflow = util.NewWorkflow(&v1alpha1.Workflow{
 	Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
 })
 
+func testWorkflowWithoutStatus() *util.Workflow {
+	workflow := testWorkflow.DeepCopy()
+	workflow.Status = v1alpha1.WorkflowStatus{}
+	return util.NewWorkflow(workflow)
+}
+
 type retryDuringTerminalReportDispatcher struct {
 	manager  *ResourceManager
 	runID    string
@@ -299,6 +307,48 @@ func (d *countingTerminalReportDispatcher) OnRunRetry(context.Context, *apiserve
 
 func (d *countingTerminalReportDispatcher) PluginsRegistered() bool {
 	return true
+}
+
+type serviceAccountMutatingDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
+	output    *apiv2beta1.PluginOutput
+	endedRuns []*apiserverPlugins.PersistedRun
+}
+
+func (serviceAccountMutatingDispatcher) PluginsRegistered() bool {
+	return true
+}
+
+func (d *serviceAccountMutatingDispatcher) OnBeforeRunCreation(_ context.Context, run *apiserverPlugins.PendingRun, executionSpec util.ExecutionSpec) error {
+	executionSpec.SetServiceAccount("plugin-sa")
+	return apiserverPlugins.SetPendingRunPluginOutput(run, apiservermlflow.PluginName, d.output)
+}
+
+func (d *serviceAccountMutatingDispatcher) OnRunEnd(_ context.Context, run *apiserverPlugins.PersistedRun) bool {
+	d.endedRuns = append(d.endedRuns, run)
+	return true
+}
+
+type patchCountingSwfClient struct {
+	client.SwfClientInterface
+	patchCalls int
+}
+
+func (c *patchCountingSwfClient) ScheduledWorkflow(namespace string) swfclientv1beta1.ScheduledWorkflowInterface {
+	return &patchCountingScheduledWorkflowClient{
+		ScheduledWorkflowInterface: c.SwfClientInterface.ScheduledWorkflow(namespace),
+		patchCalls:                 &c.patchCalls,
+	}
+}
+
+type patchCountingScheduledWorkflowClient struct {
+	swfclientv1beta1.ScheduledWorkflowInterface
+	patchCalls *int
+}
+
+func (c *patchCountingScheduledWorkflowClient) Patch(ctx context.Context, name string, patchType types.PatchType, data []byte, subresources ...string) (*swfapi.ScheduledWorkflow, error) {
+	*c.patchCalls++
+	return c.ScheduledWorkflowInterface.Patch(ctx, name, patchType, data, subresources...)
 }
 
 func TestReadRunLogFromArchiveStreamsObjectStoreFile(t *testing.T) {
@@ -598,6 +648,7 @@ func initWithOneTimeFailedRun(t *testing.T) (*FakeClientManager, *ResourceManage
 	runDetail, err := manager.CreateRun(ctx, apiRun)
 	assert.Nil(t, err)
 	updatedWorkflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	updatedWorkflow.SetServiceAccount(runDetail.ServiceAccount)
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	updatedWorkflow.Status.Nodes = map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
@@ -621,6 +672,7 @@ func initWithOneTimeFailedRunCompressed(t *testing.T) (*FakeClientManager, *Reso
 	runDetail, err := manager.CreateRun(ctx, apiRun)
 	assert.Nil(t, err)
 	updatedWorkflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	updatedWorkflow.SetServiceAccount(runDetail.ServiceAccount)
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	nodes := map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
@@ -647,6 +699,7 @@ func initWithOneTimeFailedRunOffloaded(t *testing.T) (*FakeClientManager, *Resou
 	runDetail, err := manager.CreateRun(ctx, apiRun)
 	assert.Nil(t, err)
 	updatedWorkflow := util.NewWorkflow(testWorkflow.DeepCopy())
+	updatedWorkflow.SetServiceAccount(runDetail.ServiceAccount)
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	updatedWorkflow.Status.OffloadNodeStatusVersion = "offload-hash"
@@ -1645,7 +1698,7 @@ func TestGetPipelineTemplate(t *testing.T) {
 	defer store.Close()
 	actualTemplate, err := manager.GetPipelineLatestTemplate(p.UUID)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte(testWorkflow.ToStringForStore()), actualTemplate)
+	assert.Equal(t, []byte(testWorkflowWithoutStatus().ToStringForStore()), actualTemplate)
 }
 
 // Tests GetPipelineLatestTemplate (from PipelineSpecURI)
@@ -2496,7 +2549,7 @@ func TestCreateRun_ThroughPipelineID(t *testing.T) {
 	runDetail, err := manager.CreateRun(context.Background(), apiRun)
 	assert.Nil(t, err)
 
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2521,7 +2574,7 @@ func TestCreateRun_ThroughPipelineID(t *testing.T) {
 			PipelineVersionId:    version.UUID,
 			PipelineId:           p.UUID,
 			PipelineName:         "version_for_run",
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 		RunDetails: model.RunDetails{
@@ -2587,7 +2640,7 @@ func TestCreateRun_ThroughWorkflowSpecV2(t *testing.T) {
 func TestCreateRun_ThroughWorkflowSpec(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	expectedExperimentUUID := runDetail.ExperimentId
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2639,7 +2692,7 @@ func TestCreateRun_ThroughWorkflowSpecWithPatch(t *testing.T) {
 	viper.Set(common.DefaultBucketNameEnvVar, "test-default-bucket")
 	store, manager, runDetail := initWithPatchedRun(t)
 	expectedExperimentUUID := runDetail.ExperimentId
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2749,7 +2802,7 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 	runDetail, err := manager.CreateRun(context.Background(), apiRun)
 	assert.Nil(t, err)
 
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2775,7 +2828,7 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 			PipelineVersionId:    version.UUID,
 			PipelineId:           version.PipelineId,
 			PipelineName:         version.Name,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 		RunDetails: model.RunDetails{
@@ -2833,7 +2886,7 @@ func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	runDetail, err := manager.CreateRun(context.Background(), apiRun)
 	assert.Nil(t, err)
 
-	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow := testWorkflowWithoutStatus().Workflow
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
@@ -2871,7 +2924,7 @@ func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 			PipelineId:           pipeline.UUID,
 			PipelineVersionId:    version.UUID,
 			PipelineName:         version.Name,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 	}
@@ -3381,6 +3434,61 @@ func TestRetryRun(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(actualRunDetail.WorkflowRuntimeManifest), "Running")
 	assert.Equal(t, actualRunDetail.RunDetails.State, model.RuntimeStateRunning)
+}
+
+func TestRetryRun_V2CompilerPodSpecPatch(t *testing.T) {
+	store, manager, run := initWithOneTimeRunV2(t)
+	defer store.Close()
+	executionSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.PipelineRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, executionSpec.Decompress())
+	workflow := executionSpec.(*util.Workflow)
+	require.Contains(t, workflow.ToStringForStore(), `{{inputs.parameters.pod-spec-patch}}`)
+	workflow.Status.Phase = v1alpha1.WorkflowFailed
+	run.WorkflowRuntimeManifest = model.LargeText(workflow.ToStringForStore())
+	run.State = model.RuntimeStateFailed
+	run.Conditions = string(model.RuntimeStateFailed.ToV1())
+	require.NoError(t, manager.runStore.UpdateRun(run))
+
+	require.NoError(t, manager.RetryRun(context.Background(), run.UUID))
+}
+
+func TestRetryRun_ServiceAccountSAR_Unauthorized_NoWorkflowMutation(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+	workflow := testWorkflow.DeepCopy()
+	workflow.Spec.ServiceAccountName = common.DefaultPipelineRunnerServiceAccount
+	workflow.Spec.Templates[0].ServiceAccountName = "nested-sa"
+	run, err := manager.CreateRun(context.Background(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+			Parameters:           `[{"name":"param1","value":"world"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.NoError(t, err)
+
+	failedWorkflow := util.NewWorkflow(workflow.DeepCopy())
+	failedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, run.UUID)
+	failedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
+	failedWorkflow.Status.Nodes = map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
+	syncWorkflowReportWithFakeCluster(t, store, failedWorkflow)
+	_, err = manager.ReportWorkflowResource(context.Background(), failedWorkflow)
+	require.NoError(t, err)
+
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	err = manager.RetryRun(multiUserContext(), run.UUID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	liveWorkflow, getErr := store.ExecClientFake.Execution("ns1").Get(context.Background(), run.K8SName, v1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.Equal(t, string(v1alpha1.WorkflowFailed), string(liveWorkflow.ExecutionStatus().Condition()))
 }
 
 func TestRetryRun_RefreshesDivergentWorkflowName(t *testing.T) {
@@ -4084,7 +4192,7 @@ func TestCreateJob_ThroughPipelineVersion(t *testing.T) {
 			PipelineId:           version.PipelineId,
 			PipelineName:         version.Name,
 			PipelineVersionId:    version.UUID,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 	}
@@ -4139,7 +4247,7 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 			PipelineName:         version.Name,
 			PipelineId:           pipeline.UUID,
 			PipelineVersionId:    version.UUID,
-			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			WorkflowSpecManifest: model.LargeText(testWorkflowWithoutStatus().ToStringForStore()),
 			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
 		},
 	}
@@ -4268,6 +4376,40 @@ func TestEnableJob(t *testing.T) {
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, expectedJob.ToV1(), job.ToV1())
+}
+
+func TestEnableJob_ReauthorizesEmbeddedWorkflowServiceAccounts(t *testing.T) {
+	viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, "false")
+		viper.Set(common.AllowedServiceAccountsFlag, "")
+	})
+
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+	job, err := manager.CreateJob(context.Background(), &model.Job{
+		DisplayName:  "j1",
+		Enabled:      false,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa"),
+		},
+	})
+	require.NoError(t, err)
+
+	patchCounter := &patchCountingSwfClient{SwfClientInterface: manager.swfClient}
+	manager.swfClient = patchCounter
+	manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	viper.Set(common.MultiUserMode, "true")
+
+	err = manager.ChangeJobMode(multiUserContext(), job.UUID, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	assert.Zero(t, patchCounter.patchCalls, "the ScheduledWorkflow must not be enabled when authorization fails")
+	storedJob, getErr := manager.GetJob(job.UUID)
+	require.NoError(t, getErr)
+	assert.False(t, storedJob.Enabled)
 }
 
 func TestEnableJob_JobNotExist(t *testing.T) {
@@ -6533,6 +6675,7 @@ func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDurin
 			UID:       types.UID(run.UUID),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 		},
+		Spec: v1alpha1.WorkflowSpec{ServiceAccountName: run.ServiceAccount},
 		Status: v1alpha1.WorkflowStatus{
 			Phase:      v1alpha1.WorkflowFailed,
 			FinishedAt: v1.NewTime(time.Unix(123, 0)),
@@ -9270,6 +9413,151 @@ func TestCreateRun_ServiceAccountSAR_Unauthorized_NoWorkflowCreated(t *testing.T
 	_, err := manager.CreateRun(multiUserContext(), apiRun)
 	require.NotNil(t, err)
 	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when SA authorization fails")
+}
+
+func workflowManifestWithTemplateServiceAccount(serviceAccount string) model.LargeText {
+	workflow := testWorkflow.DeepCopy()
+	workflow.Spec.Templates[0].ServiceAccountName = serviceAccount
+	return model.LargeText(util.NewWorkflow(workflow).ToStringForStore())
+}
+
+func TestCreateRun_ServiceAccountSAR_TemplateSA_Unauthorized_NoWorkflowCreated(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+	defer store.Close()
+
+	_, err := manager.CreateRun(multiUserContext(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa"),
+			Parameters:           `[{"name":"param1","value":"world"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when a template SA is unauthorized")
+}
+
+func TestCreateRun_ServiceAccountSAR_PluginMutationUnauthorized_CleansUpPlugins(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "plugin-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+	defer store.Close()
+	dispatcher := &serviceAccountMutatingDispatcher{
+		output: apiservermlflow.SuccessfulPluginOutput("exp-1", "experiment", "parent-run-1", "https://mlflow.example/runs/parent-run-1"),
+	}
+	manager.pluginDispatcher = dispatcher
+
+	run := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           `[{"name":"param1","value":"world"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	}
+	_, err := manager.CreateRun(multiUserContext(), run)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created after an unauthorized plugin mutation")
+	require.NotEmpty(t, run.UUID)
+	_, err = manager.GetRun(run.UUID)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound), "a rejected run should not be persisted")
+	require.Len(t, dispatcher.endedRuns, 1, "plugin resources must be cleaned up after post-hook authorization fails")
+	assert.Equal(t, run.UUID, dispatcher.endedRuns[0].RunID)
+	assert.True(t, proto.Equal(dispatcher.output, dispatcher.endedRuns[0].PluginsOutput[apiservermlflow.PluginName]), "cleanup must receive the output identifying the plugin resources")
+}
+
+func TestCreateJob_ServiceAccountSAR_TemplateSA_Unauthorized_NoScheduledWorkflowCreated(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "nested-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	tests := []struct {
+		name, mode string
+	}{
+		{name: "pinned workflow", mode: "pinned"},
+		{name: "pinned workflow with plugins", mode: "plugins"},
+		{name: "latest pipeline version", mode: "latest"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			if tt.mode == "plugins" {
+				manager.pluginDispatcher = &countingTerminalReportDispatcher{}
+			}
+			pipelineSpec := model.PipelineSpec{WorkflowSpecManifest: workflowManifestWithTemplateServiceAccount("nested-sa")}
+			if tt.mode == "latest" {
+				pipeline, err := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+				require.NoError(t, err)
+				_, err = manager.CreatePipelineVersion(createPipelineVersion(
+					pipeline.UUID, "p1/v1", "v1", "", string(pipelineSpec.WorkflowSpecManifest), "", "ns1",
+				))
+				require.NoError(t, err)
+				pipelineSpec = model.PipelineSpec{PipelineId: pipeline.UUID}
+			}
+
+			_, err := manager.CreateJob(multiUserContext(), &model.Job{
+				DisplayName:  "j1",
+				Enabled:      true,
+				PipelineSpec: pipelineSpec,
+				ExperimentId: experiment.UUID,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Unauthorized")
+			_, getErr := store.SwfClient().ScheduledWorkflow("ns1").Get(context.Background(), "job-", v1.GetOptions{})
+			assert.True(t, apierrors.IsNotFound(getErr), "no ScheduledWorkflow CRD should be created when a template SA is unauthorized")
+		})
+	}
+}
+
+func TestCreateRun_ParameterizedPodSpecPatch_NoWorkflowCreated(t *testing.T) {
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+
+	workflow := testWorkflow.DeepCopy()
+	workflow.Spec.PodSpecPatch = `{"serviceAccountName":"{{workflow.parameters.param1}}"}`
+	_, err := manager.CreateRun(context.Background(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+			Parameters:           `[{"name":"param1","value":"pipeline-runner"}]`,
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "podSpecPatch contains a template expression")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when a podSpecPatch cannot be authorized")
+}
+
+func TestCreateRun_V2ExternalTemplateReference_NoWorkflowCreated(t *testing.T) {
+	viper.Set(common.CompiledPipelineSpecPatch, `{"workflowTemplateRef":{"name":"external"}}`)
+	defer viper.Set(common.CompiledPipelineSpecPatch, "")
+	store, manager, experiment := initWithExperiment(t)
+	defer store.Close()
+
+	_, err := manager.CreateRun(context.Background(), &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+			RuntimeConfig:        model.RuntimeConfig{Parameters: `{"text":"world"}`},
+		},
+		ExperimentId: experiment.UUID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external workflow template references")
+	assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
 }
 
 // --- SA embedded in workflow spec ---

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -258,6 +258,7 @@ var testWorkflow = util.NewWorkflow(&v1alpha1.Workflow{
 })
 
 type retryDuringTerminalReportDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
 	manager  *ResourceManager
 	runID    string
 	retryErr error
@@ -281,6 +282,7 @@ func (d *retryDuringTerminalReportDispatcher) PluginsRegistered() bool {
 }
 
 type countingTerminalReportDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
 	onRunEndCalls int
 }
 
@@ -8570,6 +8572,7 @@ func TestRetryRun_ExpiredClaimWithoutWorkflowIsTakenOver(t *testing.T) {
 }
 
 type retryHookCountingDispatcher struct {
+	apiserverPlugins.NoOpDispatcher
 	onRunRetryCalls int
 }
 

--- a/backend/src/apiserver/resource/resource_manager_workflow_status_internal_test.go
+++ b/backend/src/apiserver/resource/resource_manager_workflow_status_internal_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	apiservermlflow "github.com/kubeflow/pipelines/backend/src/apiserver/plugins/mlflow"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func statusWithCachedServiceAccount(storedSpec bool) v1alpha1.WorkflowStatus {
+	tmpl := *testWorkflow.Spec.Templates[0].DeepCopy()
+	tmpl.Name = "cached-step"
+	status := v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowSucceeded}
+	if storedSpec {
+		status.StoredWorkflowSpec = &v1alpha1.WorkflowSpec{
+			ServiceAccountName: "cached-sa",
+			Templates:          []v1alpha1.Template{tmpl},
+		}
+	} else {
+		tmpl.ServiceAccountName = "cached-sa"
+		status.StoredTemplates = map[string]v1alpha1.Template{"cached-step": tmpl}
+	}
+	return status
+}
+
+func TestCreateRunAndJob_DiscardCallerWorkflowStatus(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	viper.Set(common.AllowedServiceAccountsFlag, "cached-sa")
+	t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, "") })
+
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, recurring := range []bool{false, true} {
+				kind := "run"
+				if recurring {
+					kind = "recurring run"
+				}
+				t.Run(kind, func(t *testing.T) {
+					store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+					defer store.Close()
+					workflow := testWorkflow.DeepCopy()
+					workflow.Status = statusWithCachedServiceAccount(storedSpec)
+					pipelineSpec := model.PipelineSpec{
+						WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+						Parameters:           `[{"name":"param1","value":"world"}]`,
+					}
+					var executionSpec util.ExecutionSpec
+					if recurring {
+						job, err := manager.CreateJob(multiUserContext(), &model.Job{
+							DisplayName: "j1", Enabled: true, ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec,
+						})
+						require.NoError(t, err)
+						schedule, err := store.SwfClient().ScheduledWorkflow(job.Namespace).Get(context.Background(), job.K8SName, metav1.GetOptions{})
+						require.NoError(t, err)
+						executionSpec, err = util.ScheduleSpecToExecutionSpec(util.ArgoWorkflow, schedule.Spec.Workflow)
+						require.NoError(t, err)
+					} else {
+						run, err := manager.CreateRun(multiUserContext(), &model.Run{
+							DisplayName: "run1", ExperimentId: experiment.UUID, PipelineSpec: pipelineSpec,
+						})
+						require.NoError(t, err)
+						executionSpec, err = store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+						require.NoError(t, err)
+					}
+					assert.Equal(t, v1alpha1.WorkflowStatus{}, executionSpec.(*util.Workflow).Status)
+					assert.Equal(t, "testy", executionSpec.(*util.Workflow).Spec.Entrypoint)
+				})
+			}
+		})
+	}
+}
+
+func TestCreateRun_RejectsStatusOnlyEntrypoint(t *testing.T) {
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, manager, experiment := initWithExperiment(t)
+			defer store.Close()
+			workflow := testWorkflow.DeepCopy()
+			workflow.Spec.Entrypoint = "cached-step"
+			workflow.Status = statusWithCachedServiceAccount(storedSpec)
+			run := &model.Run{
+				DisplayName: "run1", ExperimentId: experiment.UUID,
+				PipelineSpec: model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(util.NewWorkflow(workflow).ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"world"}]`,
+				},
+			}
+			_, err := manager.CreateRun(context.Background(), run)
+			require.ErrorContains(t, err, "cached-step")
+			assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+			_, err = manager.GetRun(run.UUID)
+			assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+		})
+	}
+}
+
+func TestRetryRun_AuthorizesAndPreservesCachedWorkflowTemplates(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "cached-sa")
+	t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, "") })
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, authorized := range []bool{false, true} {
+				verdict := "denied"
+				if authorized {
+					verdict = "authorized"
+				}
+				t.Run(verdict, func(t *testing.T) {
+					store, manager, run := initWithOneTimeFailedRun(t)
+					defer store.Close()
+					run, err := manager.GetRun(run.UUID)
+					require.NoError(t, err)
+					workflow, err := util.NewWorkflowFromBytesJSON([]byte(run.WorkflowRuntimeManifest))
+					require.NoError(t, err)
+					require.NoError(t, workflow.Decompress())
+					cached := statusWithCachedServiceAccount(storedSpec)
+					workflow.Status.StoredTemplates = cached.StoredTemplates
+					workflow.Status.StoredWorkflowSpec = cached.StoredWorkflowSpec
+					syncWorkflowReportWithFakeCluster(t, store, workflow)
+					run.WorkflowRuntimeManifest = model.LargeText(workflow.ToStringForStore())
+					require.NoError(t, manager.runStore.UpdateRun(run))
+					before, err := manager.GetRun(run.UUID)
+					require.NoError(t, err)
+					liveBefore, err := store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+					beforeManifest := liveBefore.ToStringForStore()
+
+					viper.Set(common.MultiUserMode, "true")
+					t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+					if authorized {
+						manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClient()
+					} else {
+						manager.subjectAccessReviewClient = client.NewFakeSubjectAccessReviewClientUnauthorized()
+						manager.k8sCoreClient = client.NewFakeKubernetesCoreClientWithBadPodClient()
+					}
+					err = manager.RetryRun(multiUserContext(), run.UUID)
+					if authorized {
+						require.NoError(t, err)
+					} else {
+						require.ErrorContains(t, err, "Unauthorized")
+					}
+					after, err := manager.GetRun(run.UUID)
+					require.NoError(t, err)
+					liveAfter, err := store.ExecClient().Execution(run.Namespace).Get(context.Background(), run.K8SName, metav1.GetOptions{})
+					require.NoError(t, err)
+					if !authorized {
+						assert.Equal(t, before, after, "authorization must precede the retry claim")
+						assert.Equal(t, beforeManifest, liveAfter.ToStringForStore())
+						return
+					}
+					assert.Equal(t, model.RuntimeStateRunning, after.State)
+					assert.Equal(t, v1alpha1.WorkflowRunning, liveAfter.(*util.Workflow).Status.Phase)
+					assert.Equal(t, cached.StoredTemplates, liveAfter.(*util.Workflow).Status.StoredTemplates)
+					assert.Equal(t, cached.StoredWorkflowSpec, liveAfter.(*util.Workflow).Status.StoredWorkflowSpec)
+				})
+			}
+		})
+	}
+}
+
+type cachedTemplateMutatingDispatcher struct {
+	serviceAccountMutatingDispatcher
+	storedSpec bool
+}
+
+func (d *cachedTemplateMutatingDispatcher) OnBeforeRunCreation(_ context.Context, run *apiserverPlugins.PendingRun, executionSpec util.ExecutionSpec) error {
+	executionSpec.(*util.Workflow).Status = statusWithCachedServiceAccount(d.storedSpec)
+	return apiserverPlugins.SetPendingRunPluginOutput(run, apiservermlflow.PluginName, d.output)
+}
+
+func TestCreateRun_PluginCachedTemplateUnauthorizedCleansUp(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	viper.Set(common.AllowedServiceAccountsFlag, "cached-sa")
+	t.Cleanup(func() { viper.Set(common.AllowedServiceAccountsFlag, "") })
+	for _, storedSpec := range []bool{false, true} {
+		name := "stored templates"
+		if storedSpec {
+			name = "stored workflow spec"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+			defer store.Close()
+			dispatcher := &cachedTemplateMutatingDispatcher{
+				serviceAccountMutatingDispatcher: serviceAccountMutatingDispatcher{
+					output: apiservermlflow.SuccessfulPluginOutput("exp-1", "experiment", "parent-run-1", "https://mlflow.example/runs/parent-run-1"),
+				},
+				storedSpec: storedSpec,
+			}
+			manager.pluginDispatcher = dispatcher
+			run := &model.Run{
+				DisplayName: "run1", ExperimentId: experiment.UUID,
+				PipelineSpec: model.PipelineSpec{
+					WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+					Parameters:           `[{"name":"param1","value":"world"}]`,
+				},
+			}
+			_, err := manager.CreateRun(multiUserContext(), run)
+			require.ErrorContains(t, err, "Unauthorized")
+			assert.Zero(t, store.ExecClientFake.GetWorkflowCount())
+			_, err = manager.GetRun(run.UUID)
+			assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+			require.Len(t, dispatcher.endedRuns, 1)
+			assert.Equal(t, run.UUID, dispatcher.endedRuns[0].RunID)
+			assert.True(t, proto.Equal(dispatcher.output, dispatcher.endedRuns[0].PluginsOutput[apiservermlflow.PluginName]))
+		})
+	}
+}

--- a/backend/src/apiserver/resource/service_account_audit_test.go
+++ b/backend/src/apiserver/resource/service_account_audit_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type auditModeReview struct {
+	status  authzv1.SubjectAccessReviewStatus
+	err     error
+	reviews []*authzv1.SubjectAccessReview
+}
+
+func (c *auditModeReview) Create(_ context.Context, review *authzv1.SubjectAccessReview, _ metav1.CreateOptions) (*authzv1.SubjectAccessReview, error) {
+	c.reviews = append(c.reviews, review.DeepCopy())
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &authzv1.SubjectAccessReview{Status: c.status}, nil
+}
+
+func configureServiceAccountAuditTest(t *testing.T, mode, allowed string) {
+	t.Helper()
+	for key, value := range map[string]string{
+		common.ServiceAccountAuthorizationMode: mode,
+		common.MultiUserMode:                   "true",
+		common.AllowedServiceAccountsFlag:      allowed,
+		v1AllowedNamespaces:                    "ns1",
+	} {
+		previous := viper.Get(key)
+		viper.Set(key, value)
+		t.Cleanup(func() { viper.Set(key, previous) })
+	}
+}
+
+func TestServiceAccountAuthorizationModeSubmissionPaths(t *testing.T) {
+	for _, path := range []string{"run", "schedule", "scheduled replay"} {
+		t.Run(path, func(t *testing.T) {
+			for _, mode := range []string{"", "enforce", "audit", "invalid"} {
+				t.Run("mode="+mode, func(t *testing.T) {
+					for _, allowed := range []string{"", "custom-sa"} {
+						t.Run("allowlist="+allowed, func(t *testing.T) {
+							configureServiceAccountAuditTest(t, mode, allowed)
+							store, _, experiment := initWithExperiment(t)
+							defer store.Close()
+							review := &auditModeReview{} // SAR denies the requested account.
+							store.SubjectAccessReviewClientFake = review
+							manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+							spec := model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore())}
+							var err error
+							switch path {
+							case "run":
+								_, err = manager.CreateRun(multiUserContext(), &model.Run{
+									DisplayName: "audit-run", Namespace: "ns1", ExperimentId: experiment.UUID,
+									ServiceAccount: "custom-sa", PipelineSpec: spec,
+								})
+							case "schedule":
+								_, err = manager.CreateJob(multiUserContext(), &model.Job{
+									DisplayName: "audit-schedule", Namespace: "ns1", ExperimentId: experiment.UUID,
+									ServiceAccount: "custom-sa", PipelineSpec: spec, Enabled: true,
+								})
+							case "scheduled replay":
+								err = manager.authorizeStoredRunServiceAccount(multiUserContext(), &model.Run{
+									UUID: "stored-run", Namespace: "ns1", ServiceAccount: "custom-sa",
+								})
+							}
+							if mode == "audit" {
+								require.NoError(t, err)
+								require.NotEmpty(t, review.reviews, "audit must evaluate SAR even when the allowlist denies")
+							} else {
+								require.Error(t, err, "omitting the mode must retain enforcement")
+							}
+							for _, request := range review.reviews {
+								require.Equal(t, "user@google.com", request.Spec.User)
+								require.Equal(t, authzv1.ResourceAttributes{
+									Verb: "use", Namespace: "ns1", Resource: "serviceaccounts", Name: "custom-sa",
+								}, *request.Spec.ResourceAttributes)
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestServiceAccountAuditFailsClosedOnAuthenticationAndReviewErrors(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		ctx       context.Context
+		status    authzv1.SubjectAccessReviewStatus
+		reviewErr error
+		code      codes.Code
+	}{
+		{name: "missing identity", ctx: context.Background(), code: codes.Unauthenticated},
+		{name: "review transport failure", ctx: multiUserContext(), reviewErr: errors.New("review unavailable"), code: codes.Internal},
+		{name: "review evaluation failure", ctx: multiUserContext(), status: authzv1.SubjectAccessReviewStatus{EvaluationError: "authorizer unavailable"}, code: codes.Internal},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// An allowlist denial must not prevent discovering authentication/review failures.
+			configureServiceAccountAuditTest(t, "audit", "")
+			store, _, _ := initWithExperiment(t)
+			defer store.Close()
+			store.SubjectAccessReviewClientFake = &auditModeReview{status: test.status, err: test.reviewErr}
+			manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+			err := manager.authorizeServiceAccount(test.ctx, "custom-sa", "ns1")
+			require.Error(t, err)
+			require.True(t, util.IsUserErrorCodeMatch(err, test.code), "unexpected error: %v", err)
+		})
+	}
+}
+
+func TestServiceAccountAuditDoesNotBypassUnrelatedAuthorization(t *testing.T) {
+	configureServiceAccountAuditTest(t, "audit", "custom-sa")
+	store, _, _ := initWithExperiment(t)
+	defer store.Close()
+	store.SubjectAccessReviewClientFake = &auditModeReview{}
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	err := manager.IsAuthorized(multiUserContext(), &authzv1.ResourceAttributes{
+		Verb: "create", Namespace: "other-namespace", Group: common.RbacPipelinesGroup, Resource: common.RbacResourceTypeRuns,
+	})
+	require.Error(t, err)
+	require.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+}
+
+func TestServiceAccountAuditScheduledTickMigrationAndRevocation(t *testing.T) {
+	initEnvVars()
+	configureServiceAccountAuditTest(t, "audit", "")
+	store := NewFakeClientManagerOrFatalV2()
+	defer store.Close()
+	review := &recurringRunAccountReview{}
+	store.SubjectAccessReviewClientFake = review
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	manager.time = fixedRecurringTime{epoch: 200}
+	ctx := multiUserContext()
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "audit-migration", Namespace: "ns1"})
+	require.NoError(t, err)
+	job, err := manager.CreateJob(ctx, &model.Job{
+		DisplayName: "audit-migration", Namespace: "ns1", ExperimentId: experiment.UUID,
+		ServiceAccount: "custom-sa", Enabled: true, MaxConcurrency: 1,
+		Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+			PeriodicScheduleStartTimeInSec: util.Int64Pointer(100), IntervalSecond: util.Int64Pointer(10),
+		}},
+		PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore())},
+	})
+	require.NoError(t, err)
+	submit := func(key string) (*model.Run, error) {
+		run := &model.Run{DisplayName: key, RecurringRunId: job.UUID}
+		if err := manager.PrepareRecurringRun(ctx, run); err != nil {
+			return nil, err
+		}
+		return manager.CreateRun(ctx, run)
+	}
+	first, err := submit("audit-tick")
+	require.NoError(t, err)
+	require.Equal(t, "custom-sa", first.ServiceAccount)
+	require.Equal(t, 1, store.ExecClientFake.GetWorkflowCount())
+
+	// Completing migration changes policy without recreating the existing schedule.
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	review.allowedAccount = "custom-sa"
+	viper.Set(common.ServiceAccountAuthorizationMode, "enforce")
+	replay, err := submit("audit-tick")
+	require.NoError(t, err)
+	require.Equal(t, first.UUID, replay.UUID)
+	first.State = model.RuntimeStateSucceeded
+	first.FinishedAtInSec = 201
+	require.NoError(t, store.RunStore().UpdateRun(first))
+	manager.time = fixedRecurringTime{epoch: 210}
+	second, err := submit("enforced-tick")
+	require.NoError(t, err)
+	require.NotEqual(t, first.UUID, second.UUID)
+	require.Equal(t, "custom-sa", second.ServiceAccount)
+	require.Equal(t, 2, store.ExecClientFake.GetWorkflowCount())
+
+	// Revoking use permission must reject acknowledgement of a retained execution.
+	review.allowedAccount = ""
+	_, err = submit("enforced-tick")
+	require.Error(t, err)
+	require.True(t, util.IsUserErrorCodeMatch(err, codes.PermissionDenied))
+	require.Equal(t, 2, store.ExecClientFake.GetWorkflowCount())
+}

--- a/backend/src/apiserver/server/job_server_test.go
+++ b/backend/src/apiserver/server/job_server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
@@ -314,6 +315,8 @@ func TestCreateJob_pipelineVersion(t *testing.T) {
 	job, err := server.CreateJob(nil, &apiv1beta1.CreateJobRequest{Job: apiJob})
 	assert.Nil(t, err)
 
+	expectedWorkflow := testWorkflow.DeepCopy()
+	expectedWorkflow.Status = v1alpha1.WorkflowStatus{}
 	expectedJob := &apiv1beta1.Job{
 		Id:             "123e4567-e89b-12d3-a456-426655440000",
 		Name:           "job1",
@@ -330,7 +333,7 @@ func TestCreateJob_pipelineVersion(t *testing.T) {
 		PipelineSpec: &apiv1beta1.PipelineSpec{
 			PipelineId:       "123e4567-e89b-12d3-a456-426655440000",
 			PipelineName:     "p1",
-			WorkflowManifest: testWorkflow.ToStringForStore(),
+			WorkflowManifest: util.NewWorkflow(expectedWorkflow).ToStringForStore(),
 		},
 	}
 	matched := 0

--- a/backend/src/apiserver/server/recurring_run_replay_test.go
+++ b/backend/src/apiserver/server/recurring_run_replay_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type replayCountingPlugin struct {
+	beforeCalls int
+	endCalls    int
+}
+
+func (*replayCountingPlugin) Name() string    { return "replay-test" }
+func (*replayCountingPlugin) IsEnabled() bool { return true }
+func (p *replayCountingPlugin) Create() (plugins.RunPluginHandler, error) {
+	return p, nil
+}
+func (*replayCountingPlugin) ResolveRunPluginInput(*string) (interface{}, bool, error) {
+	return nil, true, nil
+}
+func (*replayCountingPlugin) ResolveRunPluginConfig(context.Context, kubernetes.Interface, string, string) (interface{}, error) {
+	return struct{}{}, nil
+}
+func (*replayCountingPlugin) GetPluginOperationTimeout(interface{}) time.Duration {
+	return time.Minute
+}
+func (p *replayCountingPlugin) OnBeforeRunCreation(context.Context, *plugins.PendingRun, interface{}, interface{}) (*api.PluginOutput, []corev1.EnvVar, error) {
+	p.beforeCalls++
+	return &api.PluginOutput{Entries: map[string]*api.MetadataValue{
+		plugins.EntryRootRunID: {Value: structpb.NewStringValue("original-parent")},
+	}}, nil, nil
+}
+func (*replayCountingPlugin) HandleRetry(context.Context, *plugins.PersistedRun, interface{}) error {
+	return nil
+}
+func (p *replayCountingPlugin) OnRunEnd(context.Context, *plugins.PersistedRun, interface{}) (bool, error) {
+	p.endCalls++
+	return false, nil
+}
+func (*replayCountingPlugin) GetGenericFailedPluginOutput(string, string, interface{}) *api.PluginOutput {
+	return nil
+}
+
+type singleUserRecurringReplay struct {
+	clients *resource.FakeClientManager
+	manager *resource.ResourceManager
+	server  *RunServer
+	plugin  *replayCountingPlugin
+	request *api.CreateRunRequest
+	first   *model.Run
+}
+
+func newSingleUserRecurringReplay(t *testing.T, pinned bool, serviceAccount string) *singleUserRecurringReplay {
+	t.Helper()
+	initEnvVars()
+	for key, value := range map[string]string{
+		common.MultiUserMode:              "false",
+		common.AllowedServiceAccountsFlag: serviceAccount,
+	} {
+		previous := viper.Get(key)
+		viper.Set(key, value)
+		t.Cleanup(func() { viper.Set(key, previous) })
+	}
+	factories := plugins.RegisteredFactories()
+	plugins.ResetRegistry()
+	t.Cleanup(func() {
+		plugins.ResetRegistry()
+		for _, factory := range factories {
+			plugins.RegisterHandlerFactory(factory)
+		}
+	})
+	plugin := &replayCountingPlugin{}
+	plugins.RegisterHandlerFactory(plugin)
+	clients, err := resource.NewFakeClientManager(util.NewFakeTime(time.Unix(200, 0)), util.NewUUIDGenerator())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clients.Close()) })
+	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "replay", Namespace: "ns1"})
+	require.NoError(t, err)
+	pipeline, err := manager.CreatePipeline(&model.Pipeline{Name: "single-user-replay", Namespace: "ns1"})
+	require.NoError(t, err)
+	version, err := manager.CreatePipelineVersion(&model.PipelineVersion{
+		Name: "version-a", PipelineId: pipeline.UUID, PipelineSpec: model.LargeText(v2SpecHelloWorld),
+	})
+	require.NoError(t, err)
+	jobSpec := model.PipelineSpec{
+		PipelineId: pipeline.UUID,
+		RuntimeConfig: model.RuntimeConfig{
+			Parameters: `{"param1":"world"}`, PipelineRoot: "minio://pipeline-root",
+		},
+	}
+	if pinned {
+		jobSpec.PipelineVersionId = version.UUID
+	}
+	ctx := context.Background()
+	job, err := manager.CreateJob(ctx, &model.Job{
+		DisplayName: "replay-schedule", Namespace: "ns1", ExperimentId: experiment.UUID, Enabled: true,
+		Trigger:      model.Trigger{PeriodicSchedule: model.PeriodicSchedule{IntervalSecond: util.Int64Pointer(10)}},
+		PipelineSpec: jobSpec, ServiceAccount: serviceAccount,
+	})
+	require.NoError(t, err)
+	swf, err := clients.SwfClient().ScheduledWorkflow(job.Namespace).Get(ctx, job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	if swf.Spec.Workflow != nil {
+		require.Nil(t, swf.Spec.Workflow.Spec, "this schedule submits through the CreateRun API")
+	}
+	request := &api.CreateRunRequest{Run: &api.Run{
+		DisplayName: "same-tick", RecurringRunId: job.UUID, ExperimentId: job.ExperimentId,
+		PipelineSource: &api.Run_PipelineVersionReference{PipelineVersionReference: &api.PipelineVersionReference{
+			PipelineId: swf.Spec.PipelineId, PipelineVersionId: swf.Spec.PipelineVersionId,
+		}},
+		RuntimeConfig: &api.RuntimeConfig{
+			Parameters: map[string]*structpb.Value{"param1": structpb.NewStringValue("world")}, PipelineRoot: "minio://pipeline-root",
+		},
+		ServiceAccount: swf.Spec.ServiceAccount,
+	}}
+	server := createRunServer(manager)
+	first, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	stored, err := manager.GetRun(first.RunId)
+	require.NoError(t, err)
+	require.Equal(t, version.UUID, stored.PipelineVersionId)
+	require.Equal(t, 1, plugin.beforeCalls)
+	require.Zero(t, plugin.endCalls)
+	require.NotNil(t, stored.PluginsOutputString)
+	require.Contains(t, string(*stored.PluginsOutputString), "original-parent")
+	return &singleUserRecurringReplay{clients: clients, manager: manager, server: server, plugin: plugin, request: request, first: stored}
+}
+
+func (f *singleUserRecurringReplay) requireOriginalRunUnchanged(t *testing.T) {
+	t.Helper()
+	stored, err := f.manager.GetRun(f.first.UUID)
+	require.NoError(t, err)
+	require.Equal(t, f.first, stored)
+	require.Equal(t, 1, f.clients.ExecClientFake.GetWorkflowCount())
+	require.Equal(t, 1, f.plugin.beforeCalls)
+	require.Zero(t, f.plugin.endCalls)
+}
+
+func TestSingleUserRecurringRunReplayAfterIncompatibleLatestVersion(t *testing.T) {
+	fixture := newSingleUserRecurringReplay(t, false, "")
+	versionB, err := fixture.manager.CreatePipelineVersion(&model.PipelineVersion{
+		Name: "version-b", PipelineId: fixture.first.PipelineId,
+		PipelineSpec: model.LargeText(strings.ReplaceAll(v2SpecHelloWorld, "param1", "renamed")),
+	})
+	require.NoError(t, err)
+	latest, err := fixture.manager.GetLatestPipelineVersion(fixture.first.PipelineId)
+	require.NoError(t, err)
+	require.Equal(t, versionB.UUID, latest.UUID)
+
+	replayed, err := fixture.server.CreateRun(context.Background(), fixture.request)
+	require.NoError(t, err)
+	require.Equal(t, fixture.first.UUID, replayed.RunId)
+	fixture.requireOriginalRunUnchanged(t)
+
+	// Acknowledging the old tick must not exempt a new tick from input validation.
+	fixture.request.Run.DisplayName = "next-tick"
+	_, err = fixture.server.CreateRun(context.Background(), fixture.request)
+	require.ErrorContains(t, err, "parameter renamed is not optional")
+	fixture.requireOriginalRunUnchanged(t)
+}
+
+func TestSingleUserRecurringRunReplayAfterPinnedVersionDeletion(t *testing.T) {
+	fixture := newSingleUserRecurringReplay(t, true, "")
+	require.NoError(t, fixture.manager.DeletePipelineVersion(fixture.first.PipelineVersionId))
+
+	replayed, err := fixture.server.CreateRun(context.Background(), fixture.request)
+	require.NoError(t, err)
+	require.Equal(t, fixture.first.UUID, replayed.RunId)
+	fixture.requireOriginalRunUnchanged(t)
+
+	fixture.request.Run.DisplayName = "next-tick"
+	_, err = fixture.server.CreateRun(context.Background(), fixture.request)
+	require.ErrorContains(t, err, "not found")
+	fixture.requireOriginalRunUnchanged(t)
+}
+
+func TestSingleUserRecurringRunReplayAuthorizesStoredAccount(t *testing.T) {
+	for _, storedAccountAllowed := range []bool{false, true} {
+		name := "removed-from-allowlist"
+		if storedAccountAllowed {
+			name = "still-allowed"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := newSingleUserRecurringReplay(t, false, "original-runner")
+			if storedAccountAllowed {
+				// A replay does not execute the account supplied by the new request.
+				fixture.request.Run.ServiceAccount = "unlisted-request-account"
+			} else {
+				viper.Set(common.AllowedServiceAccountsFlag, "")
+				fixture.request.Run.ServiceAccount = common.DefaultPipelineRunnerServiceAccount
+			}
+			replayed, err := fixture.server.CreateRun(context.Background(), fixture.request)
+			if storedAccountAllowed {
+				require.NoError(t, err)
+				require.Equal(t, fixture.first.UUID, replayed.RunId)
+				require.Equal(t, "original-runner", replayed.ServiceAccount)
+			} else {
+				require.ErrorContains(t, err, `service account "original-runner" is not allowed`)
+				require.Nil(t, replayed)
+			}
+			fixture.requireOriginalRunUnchanged(t)
+		})
+	}
+}

--- a/backend/src/apiserver/server/recurring_run_security_test.go
+++ b/backend/src/apiserver/server/recurring_run_security_test.go
@@ -56,16 +56,33 @@ func scheduleContext(user string) context.Context {
 }
 func newAuthorizedSchedule(t *testing.T) (*resource.FakeClientManager, *resource.ResourceManager, *model.Job, *scheduledAccountReview) {
 	t.Helper()
+	return newAuthorizedScheduleWithCatchupPolicy(t, false)
+}
+
+func newAuthorizedScheduleWithCatchupPolicy(t *testing.T, noCatchup bool) (*resource.FakeClientManager, *resource.ResourceManager, *model.Job, *scheduledAccountReview) {
+	t.Helper()
+	return newAuthorizedScheduleWithTrigger(t, noCatchup, model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+		PeriodicScheduleStartTimeInSec: util.Int64Pointer(90), IntervalSecond: util.Int64Pointer(10),
+	}}, time.Unix(99, 0))
+}
+
+func newAuthorizedScheduleWithTrigger(t *testing.T, noCatchup bool, trigger model.Trigger, now time.Time) (*resource.FakeClientManager, *resource.ResourceManager, *model.Job, *scheduledAccountReview) {
+	t.Helper()
 	viper.Set(common.MultiUserMode, "true")
 	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
 	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false"); viper.Set(common.AllowedServiceAccountsFlag, "") })
-	clients, _, experiment := initWithExperiment(t)
+	initEnvVars()
+	clients := resource.NewFakeClientManagerOrFatal(util.NewFakeTime(now))
 	t.Cleanup(func() { require.NoError(t, clients.Close()) })
 	review := &scheduledAccountReview{}
 	clients.SubjectAccessReviewClientFake = review
 	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "exp1", Namespace: "ns1"})
+	require.NoError(t, err)
 	job, err := manager.CreateJob(scheduleContext("user@google.com"), &model.Job{
 		DisplayName: "authorized-schedule", Namespace: "ns1", ExperimentId: experiment.UUID, Enabled: true,
+		MaxConcurrency: 1, NoCatchup: noCatchup,
+		Trigger:        trigger,
 		ServiceAccount: "custom-sa", PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()), Parameters: `[{"name":"param1","value":"authorized-[[Index]]-[[ScheduledTime]]"}]`},
 	})
 	require.NoError(t, err)
@@ -99,6 +116,9 @@ func TestRecurringRunUsesStoredInputsAndStillRequiresCallerServiceAccountPermiss
 	_, err = server.CreateRun(ctx, request)
 	require.ErrorContains(t, err, "Unauthorized")
 	require.Zero(t, clients.ExecClientFake.GetWorkflowCount())
+	state, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Zero(t, state.LastRunIndex, "authorization failure must not claim a tick")
 	last := review.reviews[len(review.reviews)-1]
 	require.Equal(t, scheduleControllerIdentity, last.Spec.User)
 	require.Equal(t, authv1.ResourceAttributes{Verb: "use", Namespace: "ns1", Resource: "serviceaccounts", Name: "custom-sa"}, *last.Spec.ResourceAttributes)
@@ -118,6 +138,7 @@ func TestRecurringRunUsesStoredInputsAndStillRequiresCallerServiceAccountPermiss
 	_, err = server.CreateRun(scheduleContext("unprivileged@google.com"), request)
 	require.ErrorContains(t, err, "Unauthorized")
 	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+	advanceScheduledRunClock(clients, 200)
 	review.controllerAllowed = false
 	request.Run.DisplayName = "revoked-tick"
 	_, err = server.CreateRun(ctx, request)

--- a/backend/src/apiserver/server/recurring_run_security_test.go
+++ b/backend/src/apiserver/server/recurring_run_security_test.go
@@ -1,0 +1,169 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const scheduleControllerIdentity = "system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow"
+
+type scheduledAccountReview struct {
+	controllerAllowed bool
+	denyRunCreation   bool
+	reviews           []*authv1.SubjectAccessReview
+}
+
+func (s *scheduledAccountReview) Create(_ context.Context, review *authv1.SubjectAccessReview, _ metav1.CreateOptions) (*authv1.SubjectAccessReview, error) {
+	s.reviews = append(s.reviews, review.DeepCopy())
+	allowed := !s.denyRunCreation || review.Spec.ResourceAttributes.Resource != "runs"
+	if review.Spec.ResourceAttributes.Resource == "serviceaccounts" {
+		allowed = review.Spec.ResourceAttributes.Name == "custom-sa" &&
+			(review.Spec.User == "user@google.com" || (review.Spec.User == scheduleControllerIdentity && s.controllerAllowed))
+	}
+	return &authv1.SubjectAccessReview{Status: authv1.SubjectAccessReviewStatus{Allowed: allowed}}, nil
+}
+func scheduleContext(user string) context.Context {
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(common.GoogleIAPUserIdentityHeader, common.GoogleIAPUserIdentityPrefix+user))
+}
+func newAuthorizedSchedule(t *testing.T) (*resource.FakeClientManager, *resource.ResourceManager, *model.Job, *scheduledAccountReview) {
+	t.Helper()
+	viper.Set(common.MultiUserMode, "true")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false"); viper.Set(common.AllowedServiceAccountsFlag, "") })
+	clients, _, experiment := initWithExperiment(t)
+	t.Cleanup(func() { require.NoError(t, clients.Close()) })
+	review := &scheduledAccountReview{}
+	clients.SubjectAccessReviewClientFake = review
+	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	job, err := manager.CreateJob(scheduleContext("user@google.com"), &model.Job{
+		DisplayName: "authorized-schedule", Namespace: "ns1", ExperimentId: experiment.UUID, Enabled: true,
+		ServiceAccount: "custom-sa", PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()), Parameters: `[{"name":"param1","value":"authorized-[[Index]]-[[ScheduledTime]]"}]`},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "custom-sa", job.ServiceAccount)
+	return clients, manager, job, review
+}
+
+func TestRecurringRunUsesStoredInputsAndStillRequiresCallerServiceAccountPermission(t *testing.T) {
+	clients, manager, job, review := newAuthorizedSchedule(t)
+	ctx := scheduleContext(scheduleControllerIdentity)
+	swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+	swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	swf.Spec.ServiceAccount = "privileged-sa"
+	swf.Spec.PipelineId = "attacker-pipeline"
+	swf.Spec.Workflow.PipelineRoot = "s3://attacker"
+	swf.Spec.Workflow.Parameters = []swfapi.Parameter{{Name: "param1", Value: "attacker"}}
+	_, err = swfs.Update(ctx, swf)
+	require.NoError(t, err)
+	require.NoError(t, manager.ReportScheduledWorkflowResource(util.NewScheduledWorkflow(swf)))
+	stored, err := manager.GetJob(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, job.PipelineSpec, stored.PipelineSpec)
+	badPlugins := model.LargeText(`{"attacker":{"value":"untrusted"}}`)
+	forged := &model.Run{RecurringRunId: job.UUID, PipelineSpec: model.PipelineSpec{PipelineId: "attacker", RuntimeConfig: model.RuntimeConfig{PipelineRoot: "s3://attacker"}}, PluginsInputString: &badPlugins}
+	require.NoError(t, manager.PrepareRecurringRun(ctx, forged))
+	require.Equal(t, job.PipelineSpec, forged.PipelineSpec)
+	require.Nil(t, forged.PluginsInputString)
+	server := createRunServer(manager)
+	request := &api.CreateRunRequest{Run: &api.Run{DisplayName: "tick", RecurringRunId: job.UUID, ServiceAccount: "privileged-sa", ScheduledAt: timestamppb.New(time.Unix(100, 0))}}
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "Unauthorized")
+	require.Zero(t, clients.ExecClientFake.GetWorkflowCount())
+	last := review.reviews[len(review.reviews)-1]
+	require.Equal(t, scheduleControllerIdentity, last.Spec.User)
+	require.Equal(t, authv1.ResourceAttributes{Verb: "use", Namespace: "ns1", Resource: "serviceaccounts", Name: "custom-sa"}, *last.Spec.ResourceAttributes)
+	review.controllerAllowed = true
+	run, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, "custom-sa", run.ServiceAccount)
+	require.Equal(t, job.ExperimentId, run.ExperimentId)
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+	storedRun, err := manager.GetRun(run.RunId)
+	require.NoError(t, err)
+	workflow, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(storedRun.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	require.Equal(t, "authorized-1-19700101000140", workflow.(*util.Workflow).GetWorkflowParametersAsMap()["param1"])
+	// Supplying a recurring-run ID does not let a different user borrow the controller grant.
+	// Even an idempotent replay must retain the service-account check.
+	_, err = server.CreateRun(scheduleContext("unprivileged@google.com"), request)
+	require.ErrorContains(t, err, "Unauthorized")
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+	review.controllerAllowed = false
+	request.Run.DisplayName = "revoked-tick"
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "Unauthorized")
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+	review.controllerAllowed = true
+	viper.Set(common.AllowedServiceAccountsFlag, "")
+	request.Run.DisplayName = "no-longer-allowlisted"
+	_, err = server.CreateRun(ctx, request)
+	require.Error(t, err)
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+}
+
+func TestPrepareRecurringRunRejectsUntrustedIdentityAndDisabledSchedules(t *testing.T) {
+	for _, kind := range []string{"unknown", "namespace", "experiment", "replaced", "disabled-db", "disabled-cr", "denied-namespace"} {
+		t.Run(kind, func(t *testing.T) {
+			clients, manager, job, review := newAuthorizedSchedule(t)
+			ctx := scheduleContext(scheduleControllerIdentity)
+			run := &model.Run{DisplayName: "tick", RecurringRunId: job.UUID}
+			swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+			switch kind {
+			case "denied-namespace":
+				review.denyRunCreation = true
+			case "unknown":
+				run.RecurringRunId = "unregistered-cr-uid"
+			case "namespace":
+				run.Namespace = "another-tenant"
+			case "experiment":
+				run.ExperimentId = "another-experiment"
+			case "disabled-db":
+				require.NoError(t, clients.JobStore().ChangeJobMode(job.UUID, false))
+			case "disabled-cr":
+				swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+				require.NoError(t, err)
+				swf.Spec.Enabled = false
+				_, err = swfs.Update(ctx, swf)
+				require.NoError(t, err)
+			case "replaced":
+				swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+				require.NoError(t, err)
+				swf.UID = "different-uid"
+				_, err = swfs.Update(ctx, swf)
+				require.NoError(t, err)
+			}
+			require.Error(t, manager.PrepareRecurringRun(ctx, run))
+			require.Zero(t, clients.ExecClientFake.GetWorkflowCount())
+		})
+	}
+}

--- a/backend/src/apiserver/server/recurring_run_tick_security_test.go
+++ b/backend/src/apiserver/server/recurring_run_tick_security_test.go
@@ -261,8 +261,8 @@ func TestRecurringRunResumesOnlyTheAuthorizedPendingTick(t *testing.T) {
 }
 
 func TestRecurringRunReplayStillChecksEnabledStateAndAuthorization(t *testing.T) {
-	for _, deleted := range []bool{false, true} {
-		t.Run(fmt.Sprintf("deleted=%t", deleted), func(t *testing.T) {
+	for _, replaySource := range []string{"retained", "deleted", "reporter-recovered"} {
+		t.Run(replaySource, func(t *testing.T) {
 			for _, denial := range []string{"disabled-db", "disabled-cr", "revoked-service-account", "removed-allowlist", "denied-namespace"} {
 				t.Run(denial, func(t *testing.T) {
 					clients, manager, job, review := newAuthorizedSchedule(t)
@@ -273,15 +273,34 @@ func TestRecurringRunReplayStillChecksEnabledStateAndAuthorization(t *testing.T)
 					run, err := server.CreateRun(ctx, request)
 					require.NoError(t, err)
 					workflowCount := 1
-					if deleted {
+					switch replaySource {
+					case "deleted":
 						require.NoError(t, manager.DeleteRun(ctx, run.RunId))
 						workflowCount = 0
+					case "reporter-recovered":
+						stored, err := manager.GetRun(run.RunId)
+						require.NoError(t, err)
+						workflow, err := clients.ExecClientFake.Execution(job.Namespace).Get(ctx, stored.K8SName, metav1.GetOptions{})
+						require.NoError(t, err)
+						// Recover the missing row from a real Workflow report. The
+						// reporter does not populate the row's ServiceAccount field.
+						require.NoError(t, clients.RunStore().DeleteRun(run.RunId))
+						_, err = manager.ReportWorkflowResource(ctx, workflow)
+						require.NoError(t, err)
+						recovered, err := manager.GetRun(run.RunId)
+						require.NoError(t, err)
+						require.Empty(t, recovered.ServiceAccount)
+						require.Equal(t, job.UUID, recovered.RecurringRunId)
+						request.Run.DisplayName = recovered.DisplayName
 					}
 					before, err := clients.JobStore().GetRecurringRunState(job.UUID)
 					require.NoError(t, err)
+					expectedCode := codes.PermissionDenied
+					var expectedMessage string
 					switch denial {
 					case "disabled-db":
 						require.NoError(t, clients.JobStore().ChangeJobMode(job.UUID, false))
+						expectedMessage = "recurring run is disabled"
 					case "disabled-cr":
 						swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
 						swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
@@ -289,15 +308,29 @@ func TestRecurringRunReplayStillChecksEnabledStateAndAuthorization(t *testing.T)
 						swf.Spec.Enabled = false
 						_, err = swfs.Update(ctx, swf)
 						require.NoError(t, err)
+						expectedMessage = "recurring run is disabled"
 					case "revoked-service-account":
 						review.controllerAllowed = false
+						expectedMessage = "service account authorization error"
 					case "removed-allowlist":
 						viper.Set(common.AllowedServiceAccountsFlag, "")
+						expectedCode = codes.InvalidArgument
+						expectedMessage = `service account "custom-sa" is not allowed`
 					case "denied-namespace":
 						review.denyRunCreation = true
+						expectedMessage = "Failed to authorize scheduled run creation"
 					}
+					review.reviews = nil
 					_, err = server.CreateRun(ctx, request)
-					require.Error(t, err)
+					require.ErrorContains(t, err, expectedMessage)
+					require.True(t, util.IsUserErrorCodeMatch(err, expectedCode), "unexpected error: %v", err)
+					if denial == "revoked-service-account" {
+						require.NotEmpty(t, review.reviews)
+						attributes := review.reviews[len(review.reviews)-1].Spec.ResourceAttributes
+						require.Equal(t, "serviceaccounts", attributes.Resource)
+						require.Equal(t, job.ServiceAccount, attributes.Name)
+						require.Equal(t, job.Namespace, attributes.Namespace)
+					}
 					require.Equal(t, workflowCount, clients.ExecClientFake.GetWorkflowCount())
 					after, err := clients.JobStore().GetRecurringRunState(job.UUID)
 					require.NoError(t, err)

--- a/backend/src/apiserver/server/recurring_run_tick_security_test.go
+++ b/backend/src/apiserver/server/recurring_run_tick_security_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -131,9 +133,39 @@ func TestRecurringRunIgnoresCRSchedulingStateAndClientScheduledAt(t *testing.T) 
 	// The latest completed key remains consumed after its run is deleted.
 	require.NoError(t, manager.DeleteRun(ctx, second.RunId))
 	request.Run.DisplayName = "second-tick"
-	_, err = server.CreateRun(ctx, request)
-	require.ErrorContains(t, err, "already dispatched")
+	acknowledged, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, second.RunId, acknowledged.RunId)
+	require.Equal(t, second.CreatedAt, acknowledged.CreatedAt)
+	require.Equal(t, second.ScheduledAt, acknowledged.ScheduledAt)
+	require.Equal(t, "custom-sa", acknowledged.ServiceAccount)
+	require.Zero(t, acknowledged.State)
+	_, err = manager.GetRun(second.RunId)
+	require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	stateAfterAcknowledgement, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, afterReplay, stateAfterAcknowledgement)
 	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+}
+
+func TestRecurringRunRejectsOverlongRequestKeyBeforeClaim(t *testing.T) {
+	clients, manager, job, review := newAuthorizedSchedule(t)
+	review.controllerAllowed = true
+	ctx := scheduleContext(scheduleControllerIdentity)
+	server := createRunServer(manager)
+	before, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	request := &api.CreateRunRequest{Run: &api.Run{DisplayName: strings.Repeat("x", 256), RecurringRunId: job.UUID}}
+	_, err = server.CreateRun(ctx, request)
+	require.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument))
+	after, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	require.Zero(t, clients.ExecClientFake.GetWorkflowCount())
+	request.Run.DisplayName = "valid-tick"
+	run, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	requireScheduledRunParameters(t, manager, run, 1, 100)
 }
 
 func TestRecurringRunUsesStoredNoCatchupPolicy(t *testing.T) {
@@ -229,40 +261,49 @@ func TestRecurringRunResumesOnlyTheAuthorizedPendingTick(t *testing.T) {
 }
 
 func TestRecurringRunReplayStillChecksEnabledStateAndAuthorization(t *testing.T) {
-	for _, denial := range []string{"disabled-db", "disabled-cr", "revoked-service-account", "removed-allowlist", "denied-namespace"} {
-		t.Run(denial, func(t *testing.T) {
-			clients, manager, job, review := newAuthorizedSchedule(t)
-			review.controllerAllowed = true
-			ctx := scheduleContext(scheduleControllerIdentity)
-			server := createRunServer(manager)
-			request := &api.CreateRunRequest{Run: &api.Run{DisplayName: "same-tick", RecurringRunId: job.UUID}}
-			_, err := server.CreateRun(ctx, request)
-			require.NoError(t, err)
-			before, err := clients.JobStore().GetRecurringRunState(job.UUID)
-			require.NoError(t, err)
-			switch denial {
-			case "disabled-db":
-				require.NoError(t, clients.JobStore().ChangeJobMode(job.UUID, false))
-			case "disabled-cr":
-				swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
-				swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
-				require.NoError(t, err)
-				swf.Spec.Enabled = false
-				_, err = swfs.Update(ctx, swf)
-				require.NoError(t, err)
-			case "revoked-service-account":
-				review.controllerAllowed = false
-			case "removed-allowlist":
-				viper.Set(common.AllowedServiceAccountsFlag, "")
-			case "denied-namespace":
-				review.denyRunCreation = true
+	for _, deleted := range []bool{false, true} {
+		t.Run(fmt.Sprintf("deleted=%t", deleted), func(t *testing.T) {
+			for _, denial := range []string{"disabled-db", "disabled-cr", "revoked-service-account", "removed-allowlist", "denied-namespace"} {
+				t.Run(denial, func(t *testing.T) {
+					clients, manager, job, review := newAuthorizedSchedule(t)
+					review.controllerAllowed = true
+					ctx := scheduleContext(scheduleControllerIdentity)
+					server := createRunServer(manager)
+					request := &api.CreateRunRequest{Run: &api.Run{DisplayName: "same-tick", RecurringRunId: job.UUID}}
+					run, err := server.CreateRun(ctx, request)
+					require.NoError(t, err)
+					workflowCount := 1
+					if deleted {
+						require.NoError(t, manager.DeleteRun(ctx, run.RunId))
+						workflowCount = 0
+					}
+					before, err := clients.JobStore().GetRecurringRunState(job.UUID)
+					require.NoError(t, err)
+					switch denial {
+					case "disabled-db":
+						require.NoError(t, clients.JobStore().ChangeJobMode(job.UUID, false))
+					case "disabled-cr":
+						swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+						swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+						require.NoError(t, err)
+						swf.Spec.Enabled = false
+						_, err = swfs.Update(ctx, swf)
+						require.NoError(t, err)
+					case "revoked-service-account":
+						review.controllerAllowed = false
+					case "removed-allowlist":
+						viper.Set(common.AllowedServiceAccountsFlag, "")
+					case "denied-namespace":
+						review.denyRunCreation = true
+					}
+					_, err = server.CreateRun(ctx, request)
+					require.Error(t, err)
+					require.Equal(t, workflowCount, clients.ExecClientFake.GetWorkflowCount())
+					after, err := clients.JobStore().GetRecurringRunState(job.UUID)
+					require.NoError(t, err)
+					require.Equal(t, before, after)
+				})
 			}
-			_, err = server.CreateRun(ctx, request)
-			require.Error(t, err)
-			require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
-			after, err := clients.JobStore().GetRecurringRunState(job.UUID)
-			require.NoError(t, err)
-			require.Equal(t, before, after)
 		})
 	}
 }

--- a/backend/src/apiserver/server/recurring_run_tick_security_test.go
+++ b/backend/src/apiserver/server/recurring_run_tick_security_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	scheduleutil "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
+	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func advanceScheduledRunClock(clients *resource.FakeClientManager, epoch int64) {
+	for clients.Time().Now().Unix() < epoch {
+	}
+}
+
+func requireScheduledRunParameters(t *testing.T, manager *resource.ResourceManager, run *api.Run, index, scheduledAt int64) {
+	t.Helper()
+	stored, err := manager.GetRun(run.RunId)
+	require.NoError(t, err)
+	execution, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(stored.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	workflow, ok := execution.(*util.Workflow)
+	require.True(t, ok)
+	require.Equal(t, fmt.Sprintf("authorized-%d-%s", index, time.Unix(scheduledAt, 0).UTC().Format("20060102150405")),
+		workflow.GetWorkflowParametersAsMap()["param1"])
+	require.Equal(t, "custom-sa", execution.ServiceAccount())
+	require.Equal(t, scheduledAt, run.ScheduledAt.Seconds)
+}
+
+func TestRecurringRunIgnoresCRSchedulingStateAndClientScheduledAt(t *testing.T) {
+	clients, manager, job, review := newAuthorizedSchedule(t)
+	review.controllerAllowed = true
+	ctx := scheduleContext(scheduleControllerIdentity)
+	swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+	swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	forgedTime := metav1.NewTime(time.Unix(1, 0))
+	swf.Status.Trigger.LastIndex = util.Int64Pointer(9999)
+	swf.Status.Trigger.LastTriggeredTime = &forgedTime
+	swf.Spec.Trigger = swfapi.Trigger{PeriodicSchedule: &swfapi.PeriodicSchedule{
+		StartTime: &forgedTime, IntervalSecond: 1,
+	}}
+	swf.Spec.NoCatchup = util.BoolPointer(true)
+	swf.Spec.MaxConcurrency = util.Int64Pointer(10)
+	_, err = swfs.Update(ctx, swf)
+	require.NoError(t, err)
+	require.NoError(t, manager.ReportScheduledWorkflowResource(util.NewScheduledWorkflow(swf)))
+	storedJob, err := manager.GetJob(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, job.Trigger, storedJob.Trigger)
+	require.Equal(t, job.NoCatchup, storedJob.NoCatchup)
+	require.Equal(t, job.MaxConcurrency, storedJob.MaxConcurrency)
+
+	server := createRunServer(manager)
+	request := &api.CreateRunRequest{Run: &api.Run{
+		DisplayName: "first-tick", RecurringRunId: job.UUID,
+		ScheduledAt: timestamppb.New(time.Unix(999999, 0)),
+		PipelineSource: &api.Run_PipelineVersionReference{PipelineVersionReference: &api.PipelineVersionReference{
+			PipelineId: "attacker-pipeline", PipelineVersionId: "attacker-version",
+		}},
+	}}
+	first, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	requireScheduledRunParameters(t, manager, first, 1, 100)
+	state, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), state.LastRunIndex)
+	require.Equal(t, int64(100), state.LastScheduledAtInSec)
+	require.False(t, state.Pending)
+
+	// A new request key and hostile timestamp cannot accelerate the next tick.
+	request.Run.DisplayName = "second-tick"
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "no authorized tick is due")
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+
+	// Even when another tick is due, the trusted concurrency limit still applies.
+	advanceScheduledRunClock(clients, 200)
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "maximum concurrency")
+	afterDenied, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, state, afterDenied)
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+
+	completed, err := manager.GetRun(first.RunId)
+	require.NoError(t, err)
+	completed.State = model.RuntimeStateSucceeded
+	require.NoError(t, clients.RunStore().UpdateRun(completed))
+	second, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	requireScheduledRunParameters(t, manager, second, 2, 110)
+	require.NotEqual(t, first.RunId, second.RunId)
+	require.Equal(t, 2, clients.ExecClientFake.GetWorkflowCount())
+
+	// Replaying an older key returns its original execution without a new claim.
+	request.Run.DisplayName = "first-tick"
+	replayed, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, first.RunId, replayed.RunId)
+	requireScheduledRunParameters(t, manager, replayed, 1, 100)
+	afterReplay, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), afterReplay.LastRunIndex)
+	require.Equal(t, 2, clients.ExecClientFake.GetWorkflowCount())
+
+	// The latest completed key remains consumed after its run is deleted.
+	require.NoError(t, manager.DeleteRun(ctx, second.RunId))
+	request.Run.DisplayName = "second-tick"
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "already dispatched")
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+}
+
+func TestRecurringRunUsesStoredNoCatchupPolicy(t *testing.T) {
+	for _, noCatchup := range []bool{false, true} {
+		t.Run(fmt.Sprintf("noCatchup=%t", noCatchup), func(t *testing.T) {
+			clients, manager, job, review := newAuthorizedScheduleWithCatchupPolicy(t, noCatchup)
+			review.controllerAllowed = true
+			ctx := scheduleContext(scheduleControllerIdentity)
+			swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+			swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+			require.NoError(t, err)
+			swf.Spec.NoCatchup = util.BoolPointer(!noCatchup)
+			_, err = swfs.Update(ctx, swf)
+			require.NoError(t, err)
+			require.NoError(t, manager.ReportScheduledWorkflowResource(util.NewScheduledWorkflow(swf)))
+			advanceScheduledRunClock(clients, 200)
+			server := createRunServer(manager)
+			run, err := server.CreateRun(ctx, &api.CreateRunRequest{Run: &api.Run{
+				DisplayName: "delayed-tick", RecurringRunId: job.UUID,
+				ScheduledAt: timestamppb.New(time.Unix(999999, 0)),
+			}})
+			require.NoError(t, err)
+			expectedTime := int64(100)
+			if noCatchup {
+				expectedTime = run.CreatedAt.Seconds
+				require.GreaterOrEqual(t, expectedTime, int64(200))
+			}
+			requireScheduledRunParameters(t, manager, run, 1, expectedTime)
+		})
+	}
+}
+
+func TestRecurringRunEvaluatesStoredCronInConfiguredTimezone(t *testing.T) {
+	viper.Set(scheduleutil.TimeZone, "America/New_York")
+	t.Cleanup(func() { viper.Set(scheduleutil.TimeZone, "") })
+	start := time.Date(2026, time.September, 10, 0, 0, 0, 0, time.UTC)
+	clients, manager, job, review := newAuthorizedScheduleWithTrigger(t, false, model.Trigger{CronSchedule: model.CronSchedule{
+		Cron: util.StringPointer("0 0 0 * * *"), CronScheduleStartTimeInSec: util.Int64Pointer(start.Unix()),
+	}}, start.Add(5*time.Hour))
+	review.controllerAllowed = true
+	ctx := scheduleContext(scheduleControllerIdentity)
+	swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+	swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	swf.Spec.CronSchedule.Cron = "* * * * * *"
+	_, err = swfs.Update(ctx, swf)
+	require.NoError(t, err)
+	server := createRunServer(manager)
+	run, err := server.CreateRun(ctx, &api.CreateRunRequest{Run: &api.Run{
+		DisplayName: "midnight-new-york", RecurringRunId: job.UUID,
+		ScheduledAt: timestamppb.New(start),
+	}})
+	require.NoError(t, err)
+	// Midnight in New York is 04:00 UTC during daylight saving time.
+	requireScheduledRunParameters(t, manager, run, 1, start.Add(4*time.Hour).Unix())
+}
+
+func TestRecurringRunResumesOnlyTheAuthorizedPendingTick(t *testing.T) {
+	clients, manager, job, review := newAuthorizedSchedule(t)
+	// Simulate a server stopping after the durable claim, before workflow creation.
+	pending, err := clients.JobStore().ClaimRecurringRun(job.UUID, "pending-tick", 0, 100, 103, "")
+	require.NoError(t, err)
+	advanceScheduledRunClock(clients, 500)
+	ctx := scheduleContext(scheduleControllerIdentity)
+	server := createRunServer(manager)
+	request := &api.CreateRunRequest{Run: &api.Run{
+		DisplayName: "different-tick", RecurringRunId: job.UUID,
+		ScheduledAt: timestamppb.New(time.Unix(999999, 0)),
+	}}
+	review.controllerAllowed = true
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "previous tick is still pending")
+	require.Zero(t, clients.ExecClientFake.GetWorkflowCount())
+
+	request.Run.DisplayName = "pending-tick"
+	review.controllerAllowed = false
+	_, err = server.CreateRun(ctx, request)
+	require.ErrorContains(t, err, "Unauthorized")
+	afterDenied, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, pending, afterDenied)
+
+	review.controllerAllowed = true
+	run, err := server.CreateRun(ctx, request)
+	require.NoError(t, err)
+	requireScheduledRunParameters(t, manager, run, 1, 100)
+	require.Equal(t, int64(103), run.CreatedAt.Seconds)
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+	completed, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), completed.LastRunIndex)
+	require.False(t, completed.Pending)
+}
+
+func TestRecurringRunReplayStillChecksEnabledStateAndAuthorization(t *testing.T) {
+	for _, denial := range []string{"disabled-db", "disabled-cr", "revoked-service-account", "removed-allowlist", "denied-namespace"} {
+		t.Run(denial, func(t *testing.T) {
+			clients, manager, job, review := newAuthorizedSchedule(t)
+			review.controllerAllowed = true
+			ctx := scheduleContext(scheduleControllerIdentity)
+			server := createRunServer(manager)
+			request := &api.CreateRunRequest{Run: &api.Run{DisplayName: "same-tick", RecurringRunId: job.UUID}}
+			_, err := server.CreateRun(ctx, request)
+			require.NoError(t, err)
+			before, err := clients.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			switch denial {
+			case "disabled-db":
+				require.NoError(t, clients.JobStore().ChangeJobMode(job.UUID, false))
+			case "disabled-cr":
+				swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+				swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+				require.NoError(t, err)
+				swf.Spec.Enabled = false
+				_, err = swfs.Update(ctx, swf)
+				require.NoError(t, err)
+			case "revoked-service-account":
+				review.controllerAllowed = false
+			case "removed-allowlist":
+				viper.Set(common.AllowedServiceAccountsFlag, "")
+			case "denied-namespace":
+				review.denyRunCreation = true
+			}
+			_, err = server.CreateRun(ctx, request)
+			require.Error(t, err)
+			require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+			after, err := clients.JobStore().GetRecurringRunState(job.UUID)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+		})
+	}
+}
+
+func TestRecurringRunRejectsLegacyScheduleWithoutTrustedState(t *testing.T) {
+	clients, manager, job, review := newAuthorizedSchedule(t)
+	review.controllerAllowed = true
+	_, err := clients.DB().Exec(`DELETE FROM recurring_run_states WHERE "JobUUID" = ?`, job.UUID)
+	require.NoError(t, err)
+	ctx := scheduleContext(scheduleControllerIdentity)
+	swfs := clients.SwfClient().ScheduledWorkflow(job.Namespace)
+	swf, err := swfs.Get(ctx, job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	swf.Status.Trigger.LastIndex = util.Int64Pointer(99)
+	lastTriggered := metav1.NewTime(time.Unix(1, 0))
+	swf.Status.Trigger.LastTriggeredTime = &lastTriggered
+	_, err = swfs.Update(ctx, swf)
+	require.NoError(t, err)
+	server := createRunServer(manager)
+	_, err = server.CreateRun(ctx, &api.CreateRunRequest{Run: &api.Run{
+		DisplayName: "untrusted-progress", RecurringRunId: job.UUID,
+		ScheduledAt: timestamppb.New(time.Unix(100, 0)),
+	}})
+	require.ErrorContains(t, err, "no trusted scheduling state")
+	require.Zero(t, clients.ExecClientFake.GetWorkflowCount())
+	_, err = clients.JobStore().GetRecurringRunState(job.UUID)
+	require.ErrorContains(t, err, "no trusted scheduling state")
+}

--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -140,6 +140,9 @@ func (s *BaseRunServer) createRun(ctx context.Context, run *model.Run) (*model.R
 	if run.DisplayName == "" {
 		return nil, util.Wrapf(util.NewInvalidInputError("The run name is empty. Please specify a valid name"), "Failed to create a run due to invalid name")
 	}
+	if err := s.resourceManager.PrepareRecurringRun(ctx, run); err != nil {
+		return nil, util.Wrap(err, "Failed to prepare the recurring run")
+	}
 	experimentId, namespace, err := s.resourceManager.GetValidExperimentNamespacePair(run.ExperimentId, run.Namespace)
 	if err != nil {
 		return nil, util.Wrapf(err, "Failed to create a run due to invalid experimentId and namespace combination")

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -268,7 +268,9 @@ func TestCreateRunV1_Manifest_and_pipeline_version(t *testing.T) {
 	assert.Equal(t, DefaultFakeUUID, runDetail.Run.PipelineSpec.PipelineId)
 	assert.Equal(t, apiv1beta1.ResourceType_EXPERIMENT, runDetail.Run.ResourceReferences[0].Key.Type)
 	assert.Equal(t, exp.UUID, runDetail.Run.ResourceReferences[0].Key.Id)
-	assert.Equal(t, testWorkflow.ToStringForStore(), runDetail.Run.PipelineSpec.WorkflowManifest)
+	expectedWorkflow := testWorkflow.DeepCopy()
+	expectedWorkflow.Status = v1alpha1.WorkflowStatus{}
+	assert.Equal(t, util.NewWorkflow(expectedWorkflow).ToStringForStore(), runDetail.Run.PipelineSpec.WorkflowManifest)
 }
 
 func TestCreateRunV1_V1Params(t *testing.T) {
@@ -287,6 +289,7 @@ func TestCreateRunV1_V1Params(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.Status = v1alpha1.WorkflowStatus{}
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{
@@ -794,6 +797,7 @@ func TestCreateRunV1_Multiuser(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.Status = v1alpha1.WorkflowStatus{}
 	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{

--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -75,6 +75,9 @@ type JobStoreInterface interface {
 	// Update a recurring run entry in the database.
 	UpdateJob(swf *util.ScheduledWorkflow) error
 
+	// Update observed status without accepting changes to the authorized recurring run specification.
+	UpdateJobStatus(swf *util.ScheduledWorkflow) error
+
 	// Removes a recurring run entry from the database.
 	DeleteJob(id string) error
 }
@@ -494,6 +497,22 @@ func (s *JobStore) UpdateJob(swf *util.ScheduledWorkflow) error {
 			return util.NewInternalServerError(util.NewInvalidInputError("ScheduledWorkflow has an invalid version: %v", swf.GetVersion()), "Failed to update job %v", swf.UID)
 		}
 	}
+	return s.updateJob(swf, updateSQL)
+}
+
+// UpdateJobStatus keeps the API-created job specification authoritative when
+// reporting a ScheduledWorkflow that namespace users may be able to modify.
+func (s *JobStore) UpdateJobStatus(swf *util.ScheduledWorkflow) error {
+	q := s.dbDialect.QuoteIdentifier
+	updateSQL := s.dbDialect.QueryBuilder().Update(q("jobs")).SetMap(sq.Eq{
+		q("Conditions"):     model.StatusState(swf.ConditionSummary()).ToString(),
+		q("UpdatedAtInSec"): s.time.Now().Unix(),
+	})
+	return s.updateJob(swf, updateSQL)
+}
+
+func (s *JobStore) updateJob(swf *util.ScheduledWorkflow, updateSQL sq.UpdateBuilder) error {
+	q := s.dbDialect.QuoteIdentifier
 	sql, args, err := updateSQL.Where(sq.Eq{q("UUID"): string(swf.UID)}).ToSql()
 	if err != nil {
 		return util.NewInternalServerError(err,

--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -78,6 +78,12 @@ type JobStoreInterface interface {
 	// Update observed status without accepting changes to the authorized recurring run specification.
 	UpdateJobStatus(swf *util.ScheduledWorkflow) error
 
+	// GetRecurringRunState fetches API-owned scheduling progress.
+	GetRecurringRunState(jobID string) (*model.RecurringRunState, error)
+
+	// ClaimRecurringRun atomically reserves the next scheduled execution.
+	ClaimRecurringRun(jobID, requestKey string, expectedIndex, scheduledAt, createdAt int64, pipelineVersionID string) (*model.RecurringRunState, error)
+
 	// Removes a recurring run entry from the database.
 	DeleteJob(id string) error
 }
@@ -351,6 +357,13 @@ func (s *JobStore) DeleteJob(id string) error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to delete job %s from table", id)
 	}
+	stateSQL, stateArgs, err := qb.Delete(q("recurring_run_states")).Where(sq.Eq{q("JobUUID"): id}).ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to build scheduling-state deletion for recurring run %s", id)
+	}
+	if _, err = tx.Exec(stateSQL, stateArgs...); err != nil {
+		return util.NewInternalServerError(err, "Failed to delete scheduling state for recurring run %s", id)
+	}
 	err = s.resourceReferenceStore.DeleteResourceReferences(tx, id, model.JobResourceType)
 	if err != nil {
 		tx.Rollback()
@@ -421,6 +434,14 @@ func (s *JobStore) CreateJob(j *model.Job) (*model.Job, error) {
 	if err != nil {
 		tx.Rollback()
 		return nil, util.NewInternalServerError(err, "Failed to store job %v to table", j.DisplayName)
+	}
+	stateSQL, stateArgs, err := qb.Insert(q("recurring_run_states")).
+		Columns(q("JobUUID"), q("RequestKey"), q("PipelineVersionID")).Values(j.UUID, "", "").ToSql()
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to build scheduling-state initialization for recurring run %s", j.UUID)
+	}
+	if _, err = tx.Exec(stateSQL, stateArgs...); err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to initialize scheduling state for recurring run %s", j.UUID)
 	}
 
 	// TODO(gkcalat): remove this workflow once we fully deprecate resource references

--- a/backend/src/apiserver/storage/job_store_test.go
+++ b/backend/src/apiserver/storage/job_store_test.go
@@ -831,6 +831,79 @@ func TestUpdateJob_Success(t *testing.T) {
 	assert.Equal(t, jobExpected.ToV1(), job.ToV1())
 }
 
+func TestUpdateJobStatus_PreservesAuthorizedSpecification(t *testing.T) {
+	for _, version := range []string{"kubeflow.org/v1beta1", "kubeflow.org/v2beta1"} {
+		t.Run(version, func(t *testing.T) {
+			db, _, jobStore := initializeDBAndStore()
+			defer db.Close()
+
+			job, err := jobStore.GetJob("1")
+			require.NoError(t, err)
+			job.UUID = "status-only"
+			job.ServiceAccount = "authorized-runner"
+			job.Parameters = `[{"name":"command","value":"authorized"}]`
+			job.RuntimeConfig.Parameters = `{"command":"authorized"}`
+			job.PipelineRoot = "s3://authorized-root"
+			job.PipelineSpecManifest = "authorized pipeline"
+			job.WorkflowSpecManifest = "authorized workflow"
+			job.PluginsInputString = testLargeTextPtr(`{"plugin":{"command":"authorized"}}`)
+			_, err = jobStore.CreateJob(job)
+			require.NoError(t, err)
+			before, err := jobStore.GetJob(job.UUID)
+			require.NoError(t, err)
+
+			swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
+				TypeMeta: metav1.TypeMeta{APIVersion: version, Kind: "ScheduledWorkflow"},
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "status-only",
+					Name:      "modified-name",
+					Namespace: "modified-namespace",
+				},
+				Spec: swfapi.ScheduledWorkflowSpec{
+					Enabled:        false,
+					ServiceAccount: "modified-runner",
+					ExperimentId:   "modified-experiment",
+					PipelineId:     "modified-pipeline",
+					MaxConcurrency: util.Int64Pointer(200),
+					NoCatchup:      util.BoolPointer(true),
+					Workflow: &swfapi.WorkflowResource{
+						Parameters:   []swfapi.Parameter{{Name: "command", Value: `"modified"`}},
+						PipelineRoot: "s3://modified-root",
+					},
+					Trigger: swfapi.Trigger{
+						PeriodicSchedule: &swfapi.PeriodicSchedule{IntervalSecond: 999},
+					},
+				},
+				Status: swfapi.ScheduledWorkflowStatus{
+					Conditions: []swfapi.ScheduledWorkflowCondition{{
+						Type:   swfapi.ScheduledWorkflowDisabled,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			})
+
+			require.NoError(t, jobStore.UpdateJobStatus(swf))
+			after, err := jobStore.GetJob(job.UUID)
+			require.NoError(t, err)
+			before.Conditions = "DISABLED"
+			before.UpdatedAtInSec++
+			assert.Equal(t, before, after, "reports must only change observed status and its timestamp")
+		})
+	}
+}
+
+func TestUpdateJobStatus_RecordNotFound(t *testing.T) {
+	db, _, jobStore := initializeDBAndStore()
+	defer db.Close()
+	swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
+		ObjectMeta: metav1.ObjectMeta{UID: "unknown", Name: "unknown", Namespace: "n1"},
+	})
+
+	err := jobStore.UpdateJobStatus(swf)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+}
+
 func TestUpdateJob_MostlyEmptySpec(t *testing.T) {
 	db, _, jobStore := initializeDBAndStore()
 	defer db.Close()

--- a/backend/src/apiserver/storage/recurring_run_state.go
+++ b/backend/src/apiserver/storage/recurring_run_state.go
@@ -1,0 +1,227 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+type recurringRunStateQueryer interface {
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// GetRecurringRunState fetches scheduling progress that cannot be changed by CR reports.
+func (s *JobStore) GetRecurringRunState(jobID string) (*model.RecurringRunState, error) {
+	return s.getRecurringRunState(s.db, jobID, false)
+}
+
+func (s *JobStore) getRecurringRunState(db recurringRunStateQueryer, jobID string, lock bool) (*model.RecurringRunState, error) {
+	q := s.dbDialect.QuoteIdentifier
+	query, args, err := s.dbDialect.QueryBuilder().
+		Select(q("JobUUID"), q("RequestKey"), q("PipelineVersionID"), q("LastRunIndex"), q("LastScheduledAtInSec"), q("LastCreatedAtInSec"), q("Pending")).
+		From(q("recurring_run_states")).Where(sq.Eq{q("JobUUID"): jobID}).ToSql()
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to build scheduling-state query for recurring run %s", jobID)
+	}
+	if lock {
+		query = s.dbDialect.SelectForUpdate(query)
+	}
+	state := &model.RecurringRunState{}
+	err = db.QueryRow(query, args...).Scan(&state.JobUUID, &state.RequestKey, &state.PipelineVersionID, &state.LastRunIndex,
+		&state.LastScheduledAtInSec, &state.LastCreatedAtInSec, &state.Pending)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, util.NewFailedPreconditionError(err,
+			"Recurring run %s has no trusted scheduling state; recreate it through the KFP API", jobID)
+	}
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to read scheduling state for recurring run %s", jobID)
+	}
+	return state, nil
+}
+
+// ClaimRecurringRun serializes reservations with enable/disable and other claims.
+// The caller computes scheduledAt from the stored schedule and expectedIndex.
+func (s *JobStore) ClaimRecurringRun(jobID, requestKey string, expectedIndex, scheduledAt, createdAt int64, pipelineVersionID string) (*model.RecurringRunState, error) {
+	if requestKey == "" {
+		return nil, util.NewInvalidInputError("Provide an idempotency key when claiming a recurring run")
+	}
+	q := s.dbDialect.QuoteIdentifier
+	qb := s.dbDialect.QueryBuilder()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to start a recurring-run claim transaction")
+	}
+	defer tx.Rollback()
+
+	// Lock the job before any consistent reads so the active-run count observes
+	// runs persisted by the preceding claim, including under MySQL REPEATABLE READ.
+	query, args, err := qb.Select(q("Enabled"), q("MaxConcurrency")).
+		From(q("jobs")).Where(sq.Eq{q("UUID"): jobID}).ToSql()
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to build recurring-run claim lock")
+	}
+	var enabled bool
+	var maxConcurrency int64
+	if err = tx.QueryRow(s.dbDialect.SelectForUpdate(query), args...).Scan(&enabled, &maxConcurrency); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, util.NewResourceNotFoundError("Recurring run", jobID)
+		}
+		return nil, util.NewInternalServerError(err, "Failed to lock recurring run %s", jobID)
+	}
+	if !enabled {
+		return nil, util.NewFailedPreconditionError(errors.New("recurring run is disabled"),
+			"Enable recurring run %s through the KFP API before triggering runs", jobID)
+	}
+	state, err := s.getRecurringRunState(tx, jobID, true)
+	if err != nil {
+		return nil, err
+	}
+	if state.Pending {
+		if state.RequestKey != requestKey {
+			return nil, util.NewFailedPreconditionError(errors.New("another tick is pending"),
+				"Retry the pending execution of recurring run %s before claiming another tick", jobID)
+		}
+		// Preserve both timestamps and the index when a request is retried.
+		if err = tx.Commit(); err != nil {
+			return nil, util.NewInternalServerError(err, "Failed to resume recurring-run claim %s", jobID)
+		}
+		return state, nil
+	}
+	if state.RequestKey == requestKey {
+		return nil, util.NewFailedPreconditionError(errors.New("recurring-run request was already completed"),
+			"Recurring run %s already completed request %s; do not recreate a deleted execution", jobID, requestKey)
+	}
+	if expectedIndex < 0 || state.LastRunIndex != expectedIndex || state.LastRunIndex == math.MaxInt64 {
+		return nil, util.NewFailedPreconditionError(errors.New("scheduling progress changed"),
+			"Reload scheduling state for recurring run %s and retry", jobID)
+	}
+	if state.LastRunIndex > 0 && scheduledAt <= state.LastScheduledAtInSec {
+		return nil, util.NewFailedPreconditionError(errors.New("scheduled time does not advance"),
+			"Use the next scheduled time for recurring run %s", jobID)
+	}
+
+	// Match the controller's existing [1, 10] concurrency limits. Legacy rows
+	// without State derive their lifecycle from Conditions.
+	maxConcurrency = min(int64(10), max(int64(1), maxConcurrency))
+	effectiveState := fmt.Sprintf("COALESCE(NULLIF(%s, ''), %s, '')", q("State"), q("Conditions"))
+	query, args, err = qb.Select("COUNT(*)").From(q("run_details")).
+		Where(sq.Eq{q("JobUUID"): jobID}).
+		Where(sq.NotEq{effectiveState: terminalRunStateStrings}).ToSql()
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to build active-run count for recurring run %s", jobID)
+	}
+	var activeRuns int64
+	if err = tx.QueryRow(query, args...).Scan(&activeRuns); err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to count active runs for recurring run %s", jobID)
+	}
+	if activeRuns >= maxConcurrency {
+		return nil, util.NewFailedPreconditionError(errors.New("recurring run reached maximum concurrency"),
+			"Wait for an active execution of recurring run %s to finish before retrying", jobID)
+	}
+	state.LastRunIndex++
+	state.RequestKey = requestKey
+	state.PipelineVersionID = pipelineVersionID
+	state.LastScheduledAtInSec = scheduledAt
+	state.LastCreatedAtInSec = createdAt
+	state.Pending = true
+	query, args, err = qb.Update(q("recurring_run_states")).SetMap(sq.Eq{
+		q("RequestKey"):        requestKey,
+		q("PipelineVersionID"): pipelineVersionID,
+		q("LastRunIndex"):      state.LastRunIndex, q("LastScheduledAtInSec"): scheduledAt,
+		q("LastCreatedAtInSec"): createdAt, q("Pending"): true,
+	}).Where(sq.Eq{q("JobUUID"): jobID}).ToSql()
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to build recurring-run claim %s", jobID)
+	}
+	if _, err = tx.Exec(query, args...); err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to save recurring-run claim %s", jobID)
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to commit recurring-run claim %s", jobID)
+	}
+	return state, nil
+}
+
+// completeRecurringRunWithInsert makes the completed-tick tombstone atomic with
+// run persistence, so deleting a persisted run cannot reopen its pending claim.
+func (s *RunStore) completeRecurringRunWithInsert(tx *sql.Tx, run *model.Run) error {
+	if run.RecurringRunId == "" {
+		return nil
+	}
+	q := s.dbDialect.QuoteIdentifier
+	qb := s.dbDialect.QueryBuilder()
+	query, args, err := qb.Select(q("RequestKey"), q("LastRunIndex"), q("Pending"),
+		q("PipelineVersionID"), q("LastCreatedAtInSec"), q("LastScheduledAtInSec")).
+		From(q("recurring_run_states")).Where(sq.Eq{q("JobUUID"): run.RecurringRunId}).ToSql()
+	if err != nil {
+		return err
+	}
+	var requestKey string
+	var index int64
+	var pending bool
+	var pipelineVersionID string
+	var createdAt, scheduledAt int64
+	err = tx.QueryRow(s.dbDialect.SelectForUpdate(query), args...).Scan(&requestKey, &index, &pending,
+		&pipelineVersionID, &createdAt, &scheduledAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Legacy and single-user recurring runs do not require a scheduling claim.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !pending || run.UUID != util.NewDeterministicUUID(run.RecurringRunId+"/tick/"+strconv.FormatInt(index, 10)) {
+		return nil
+	}
+	// The persistence agent reconstructs DisplayName from the workflow name
+	// when recovering a workflow whose creating API request did not persist.
+	workflowName := "run-" + util.NewDeterministicUUID(run.UUID)
+	reportedExecution := run.DisplayName == workflowName && run.K8SName == workflowName
+	if run.DisplayName != requestKey && !reportedExecution {
+		return nil
+	}
+	if reportedExecution {
+		query, args, err = qb.Update(q("run_details")).SetMap(sq.Eq{
+			q("DisplayName"): requestKey, q("PipelineVersionId"): pipelineVersionID,
+			q("CreatedAtInSec"): createdAt, q("ScheduledAtInSec"): scheduledAt,
+		}).
+			Where(sq.Eq{q("UUID"): run.UUID}).ToSql()
+		if err != nil {
+			return err
+		}
+		if _, err = tx.Exec(query, args...); err != nil {
+			return err
+		}
+		run.DisplayName = requestKey
+		run.PipelineVersionId = pipelineVersionID
+		run.CreatedAtInSec = createdAt
+		run.ScheduledAtInSec = scheduledAt
+	}
+	query, args, err = qb.Update(q("recurring_run_states")).Set(q("Pending"), false).
+		Where(sq.Eq{q("JobUUID"): run.RecurringRunId, q("LastRunIndex"): index}).ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(query, args...)
+	return err
+}

--- a/backend/src/apiserver/storage/recurring_run_state.go
+++ b/backend/src/apiserver/storage/recurring_run_state.go
@@ -23,6 +23,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/validation"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 )
 
@@ -62,8 +63,8 @@ func (s *JobStore) getRecurringRunState(db recurringRunStateQueryer, jobID strin
 // ClaimRecurringRun serializes reservations with enable/disable and other claims.
 // The caller computes scheduledAt from the stored schedule and expectedIndex.
 func (s *JobStore) ClaimRecurringRun(jobID, requestKey string, expectedIndex, scheduledAt, createdAt int64, pipelineVersionID string) (*model.RecurringRunState, error) {
-	if requestKey == "" {
-		return nil, util.NewInvalidInputError("Provide an idempotency key when claiming a recurring run")
+	if err := validation.ValidateRecurringRunRequestKey(requestKey); err != nil {
+		return nil, err
 	}
 	q := s.dbDialect.QuoteIdentifier
 	qb := s.dbDialect.QueryBuilder()

--- a/backend/src/apiserver/storage/recurring_run_state_test.go
+++ b/backend/src/apiserver/storage/recurring_run_state_test.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -312,6 +313,52 @@ func TestCreateRunDoesNotReleaseAnotherRecurringClaim(t *testing.T) {
 			state, err := store.GetRecurringRunState("1")
 			require.NoError(t, err)
 			require.Equal(t, claim, state)
+		})
+	}
+}
+
+func TestRecurringRunClaimValidatesRequestKeyBeforeReservation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		key   string
+		valid bool
+	}{
+		{"ascii-at-limit", strings.Repeat("a", 255), true},
+		{"ascii-over-limit", strings.Repeat("a", 256), false},
+		{"multibyte-at-limit", strings.Repeat("é", 255), true},
+		{"multibyte-over-limit", strings.Repeat("é", 256), false},
+		{"mixed-at-limit", strings.Repeat("a", 254) + "界", true},
+		{"mixed-over-limit", strings.Repeat("a", 255) + "界", false},
+		{"invalid-utf8", "invalid\xff", false},
+		{"empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, d, store := initializeDBAndStore()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			before, err := store.GetRecurringRunState("1")
+			require.NoError(t, err)
+			claim, err := store.ClaimRecurringRun("1", tc.key, 0, 100, 110, "version-a")
+			if !tc.valid {
+				require.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument), "%v", err)
+				require.Nil(t, claim)
+				after, getErr := store.GetRecurringRunState("1")
+				require.NoError(t, getErr)
+				require.Equal(t, before, after)
+				claim, err = store.ClaimRecurringRun("1", "valid-next-attempt", 0, 100, 110, "version-a")
+			}
+			require.NoError(t, err)
+			require.Equal(t, int64(1), claim.LastRunIndex)
+			require.True(t, claim.Pending)
+			run, err := NewRunStore(db, util.NewFakeTimeForEpoch(), d).CreateRun(&model.Run{
+				UUID: util.NewDeterministicUUID("1/tick/1"), DisplayName: claim.RequestKey,
+				RecurringRunId: "1", ExperimentId: defaultFakeExpId, Namespace: "n1",
+				RunDetails: model.RunDetails{State: model.RuntimeStateSucceeded},
+			})
+			require.NoError(t, err)
+			require.Equal(t, claim.RequestKey, run.DisplayName)
+			state, err := store.GetRecurringRunState("1")
+			require.NoError(t, err)
+			require.False(t, state.Pending)
 		})
 	}
 }

--- a/backend/src/apiserver/storage/recurring_run_state_test.go
+++ b/backend/src/apiserver/storage/recurring_run_state_test.go
@@ -1,0 +1,317 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func TestRecurringRunStateLifecycle(t *testing.T) {
+	db, d, store := initializeDBAndStore()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	initial, err := store.GetRecurringRunState("1")
+	require.NoError(t, err)
+	require.Equal(t, &model.RecurringRunState{JobUUID: "1"}, initial)
+
+	claim, err := store.ClaimRecurringRun("1", "first-tick", 0, 100, 110, "version-a")
+	require.NoError(t, err)
+	require.Equal(t, &model.RecurringRunState{
+		JobUUID: "1", RequestKey: "first-tick", PipelineVersionID: "version-a", LastRunIndex: 1,
+		LastScheduledAtInSec: 100, LastCreatedAtInSec: 110, Pending: true,
+	}, claim)
+	// A retry preserves the first attempt's time even after the clock advances.
+	resumed, err := store.ClaimRecurringRun("1", "first-tick", 0, 200, 210, "version-b")
+	require.NoError(t, err)
+	require.Equal(t, claim, resumed)
+	_, err = store.ClaimRecurringRun("1", "different-tick", 1, 200, 210, "")
+	require.ErrorContains(t, err, "pending")
+
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch(), d)
+	firstRun := &model.Run{
+		UUID: util.NewDeterministicUUID("1/tick/1"), DisplayName: "first-tick", RecurringRunId: "1",
+		ExperimentId: defaultFakeExpId, Namespace: "n1", RunDetails: model.RunDetails{State: model.RuntimeStateSucceeded},
+	}
+	_, err = runStore.CreateRun(firstRun)
+	require.NoError(t, err)
+	_, err = runStore.CreateRun(firstRun)
+	require.NoError(t, err)
+	_, err = store.ClaimRecurringRun("1", "first-tick", 1, 200, 210, "")
+	require.ErrorContains(t, err, "already completed")
+	_, err = store.ClaimRecurringRun("1", "second-tick", 0, 200, 210, "")
+	require.ErrorContains(t, err, "scheduling progress changed")
+	_, err = store.ClaimRecurringRun("1", "second-tick", 1, 100, 210, "")
+	require.ErrorContains(t, err, "scheduled time does not advance")
+
+	second, err := store.ClaimRecurringRun("1", "second-tick", 1, 200, 210, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), second.LastRunIndex)
+	// A delayed completion cannot release the newer claim.
+	_, err = runStore.CreateRun(firstRun)
+	require.NoError(t, err)
+	current, err := store.GetRecurringRunState("1")
+	require.NoError(t, err)
+	require.Equal(t, second, current)
+	require.NoError(t, store.DeleteJob("1"))
+	_, err = store.GetRecurringRunState("1")
+	require.ErrorContains(t, err, "recreate it through the KFP API")
+}
+
+func TestRecurringRunStateRequiresEnabledRegisteredJob(t *testing.T) {
+	db, _, store := initializeDBAndStore()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	_, err := store.ClaimRecurringRun("missing", "tick", 0, 100, 110, "")
+	require.Error(t, err)
+	_, err = store.ClaimRecurringRun("1", "", 0, 100, 110, "")
+	require.ErrorContains(t, err, "idempotency key")
+	require.NoError(t, store.ChangeJobMode("1", false))
+	_, err = store.ClaimRecurringRun("1", "tick", 0, 100, 110, "")
+	require.ErrorContains(t, err, "disabled")
+	require.NoError(t, store.ChangeJobMode("1", true))
+	_, err = db.Exec(`DELETE FROM recurring_run_states WHERE JobUUID = ?`, "1")
+	require.NoError(t, err)
+	_, err = store.ClaimRecurringRun("1", "tick", 0, 100, 110, "")
+	require.ErrorContains(t, err, "recreate it through the KFP API")
+	// Missing state is never reconstructed from an editable Kubernetes report.
+	_, err = store.GetJob("1")
+	require.NoError(t, err)
+	_, err = store.GetRecurringRunState("1")
+	require.Error(t, err)
+}
+
+func TestRecurringRunClaimConcurrency(t *testing.T) {
+	for _, sameKey := range []bool{false, true} {
+		t.Run(fmt.Sprintf("same-key-%v", sameKey), func(t *testing.T) {
+			db, _, store := initializeDBAndStore()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			// SQLite is test-only and serializes transactions on one connection;
+			// production dialects serialize claims with SELECT FOR UPDATE.
+			db.SetMaxOpenConns(1)
+			const attempts = 12
+			var wg sync.WaitGroup
+			errors := make(chan error, attempts)
+			claims := make(chan *model.RecurringRunState, attempts)
+			for i := range attempts {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					key := "same-tick"
+					if !sameKey {
+						key = fmt.Sprintf("tick-%d", i)
+					}
+					claim, err := store.ClaimRecurringRun("1", key, 0, 100, int64(110+i), "")
+					if err != nil {
+						errors <- err
+					} else {
+						claims <- claim
+					}
+				}()
+			}
+			wg.Wait()
+			close(errors)
+			close(claims)
+			if sameKey {
+				require.Len(t, claims, attempts)
+				require.Empty(t, errors)
+			} else {
+				require.Len(t, claims, 1)
+				require.Len(t, errors, attempts-1)
+			}
+			stored, err := store.GetRecurringRunState("1")
+			require.NoError(t, err)
+			require.Equal(t, int64(1), stored.LastRunIndex)
+			for claim := range claims {
+				require.Equal(t, stored, claim)
+			}
+			for err := range errors {
+				require.ErrorContains(t, err, "pending")
+			}
+		})
+	}
+}
+
+func TestRecurringRunClaimCountsActiveRuns(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		state      any
+		conditions string
+		active     bool
+	}{
+		{"pending", "PENDING", "Pending", true},
+		{"running", "RUNNING", "Running", true},
+		{"canceling", "CANCELING", "Terminating", true},
+		{"paused", "PAUSED", "Pending", true},
+		{"unknown", nil, "", true},
+		{"v1-running", "", "Running", true},
+		{"v2-succeeded", "SUCCEEDED", "Running", false},
+		{"v2-canceled", "CANCELED", "Failed", false},
+		{"v1-succeeded", nil, "Succeeded", false},
+		{"v1-failed", "", "Failed", false},
+		{"v1-error", nil, "Error", false},
+		{"v1-state-succeeded", "Succeeded", "Running", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, d, store := initializeDBAndStore()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			runStore := NewRunStore(db, util.NewFakeTimeForEpoch(), d)
+			_, err := runStore.CreateRun(&model.Run{
+				UUID: "run", DisplayName: "run", RecurringRunId: "1", ExperimentId: defaultFakeExpId,
+				Namespace: "n1", RunDetails: model.RunDetails{State: model.RuntimeStateRunning},
+			})
+			require.NoError(t, err)
+			_, err = db.Exec(`UPDATE run_details SET State = ?, Conditions = ? WHERE UUID = ?`, tc.state, tc.conditions, "run")
+			require.NoError(t, err)
+			_, err = store.ClaimRecurringRun("1", "tick", 0, 100, 110, "")
+			if tc.active {
+				require.ErrorContains(t, err, "maximum concurrency")
+				state, err := store.GetRecurringRunState("1")
+				require.NoError(t, err)
+				require.Zero(t, state.LastRunIndex)
+				// The stored policy can permit another execution.
+				_, err = db.Exec(`UPDATE jobs SET MaxConcurrency = ? WHERE UUID = ?`, 2, "1")
+				require.NoError(t, err)
+				_, err = store.ClaimRecurringRun("1", "tick", 0, 100, 110, "")
+				require.NoError(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateJobRollsBackWhenSchedulingStateCannotBeCreated(t *testing.T) {
+	db, _, store := initializeDBAndStore()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	_, err := db.Exec(`INSERT INTO recurring_run_states (JobUUID, RequestKey, PipelineVersionID) VALUES (?, ?, ?)`, "conflict", "", "")
+	require.NoError(t, err)
+	_, err = store.CreateJob(&model.Job{UUID: "conflict", DisplayName: "new-job", ExperimentId: defaultFakeExpId})
+	require.ErrorContains(t, err, "initialize scheduling state")
+	var id string
+	err = db.QueryRow(`SELECT UUID FROM jobs WHERE UUID = ?`, "conflict").Scan(&id)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestCreateRunAtomicallyCompletesRecurringClaim(t *testing.T) {
+	for _, reporter := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reporter-%v", reporter), func(t *testing.T) {
+			db, d, store := initializeDBAndStore()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			_, err := store.ClaimRecurringRun("1", "original-request", 0, 100, 110, "version-a")
+			require.NoError(t, err)
+			run := &model.Run{
+				UUID: util.NewDeterministicUUID("1/tick/1"), DisplayName: "original-request", RecurringRunId: "1",
+				ExperimentId: defaultFakeExpId, Namespace: "n1", RunDetails: model.RunDetails{State: model.RuntimeStateSucceeded},
+			}
+			if reporter {
+				run.K8SName = "run-" + util.NewDeterministicUUID(run.UUID)
+				run.DisplayName = run.K8SName
+				run.CreatedAtInSec = 900
+				run.ScheduledAtInSec = 800
+			}
+			runStore := NewRunStore(db, util.NewFakeTimeForEpoch(), d)
+			created, err := runStore.CreateRun(run)
+			require.NoError(t, err)
+			require.Equal(t, "original-request", created.DisplayName)
+			if reporter {
+				require.Equal(t, "version-a", created.PipelineVersionId)
+				require.Equal(t, int64(110), created.CreatedAtInSec)
+				require.Equal(t, int64(100), created.ScheduledAtInSec)
+				stored, err := runStore.GetRun(created.UUID)
+				require.NoError(t, err)
+				require.Equal(t, created.PipelineVersionId, stored.PipelineVersionId)
+				require.Equal(t, created.CreatedAtInSec, stored.CreatedAtInSec)
+				require.Equal(t, created.ScheduledAtInSec, stored.ScheduledAtInSec)
+			}
+			id, err := runStore.GetRunByRecurringRunIDAndDisplayName("1", "original-request")
+			require.NoError(t, err)
+			require.Equal(t, run.UUID, id)
+			state, err := store.GetRecurringRunState("1")
+			require.NoError(t, err)
+			require.False(t, state.Pending)
+			require.Equal(t, int64(1), state.LastRunIndex)
+			require.Equal(t, "version-a", state.PipelineVersionID)
+			require.NoError(t, runStore.DeleteRun(run.UUID))
+			_, err = store.ClaimRecurringRun("1", "original-request", 1, 200, 210, "version-b")
+			require.ErrorContains(t, err, "already completed")
+		})
+	}
+}
+
+func TestCreateRunRollsBackWhenRecurringClaimCompletionFails(t *testing.T) {
+	db, d, store := initializeDBAndStore()
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	claim, err := store.ClaimRecurringRun("1", "tick", 0, 100, 110, "")
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TRIGGER fail_completion BEFORE UPDATE OF Pending ON recurring_run_states
+		WHEN NEW.Pending = 0 BEGIN SELECT RAISE(ABORT, 'simulated completion failure'); END`)
+	require.NoError(t, err)
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch(), d)
+	run := &model.Run{
+		UUID: util.NewDeterministicUUID("1/tick/1"), DisplayName: "tick", RecurringRunId: "1",
+		ExperimentId: defaultFakeExpId, Namespace: "n1", RunDetails: model.RunDetails{State: model.RuntimeStateSucceeded},
+	}
+	_, err = runStore.CreateRun(run)
+	require.ErrorContains(t, err, "simulated completion failure")
+	state, err := store.GetRecurringRunState("1")
+	require.NoError(t, err)
+	require.Equal(t, claim, state)
+	_, err = runStore.GetRun(run.UUID)
+	require.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound), "run insertion must roll back with claim completion: %v", err)
+	_, err = db.Exec(`DROP TRIGGER fail_completion`)
+	require.NoError(t, err)
+	_, err = runStore.CreateRun(run)
+	require.NoError(t, err)
+	state, err = store.GetRecurringRunState("1")
+	require.NoError(t, err)
+	require.False(t, state.Pending)
+}
+
+func TestCreateRunDoesNotReleaseAnotherRecurringClaim(t *testing.T) {
+	for _, kind := range []string{"run-id", "request-key", "reporter-workflow", "job-id"} {
+		t.Run(kind, func(t *testing.T) {
+			db, d, store := initializeDBAndStore()
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			claim, err := store.ClaimRecurringRun("1", "tick", 0, 100, 110, "")
+			require.NoError(t, err)
+			run := &model.Run{
+				UUID: util.NewDeterministicUUID("1/tick/1"), DisplayName: "tick", RecurringRunId: "1",
+				ExperimentId: defaultFakeExpId, Namespace: "n1", RunDetails: model.RunDetails{State: model.RuntimeStateSucceeded},
+			}
+			switch kind {
+			case "run-id":
+				run.UUID = "different-run"
+			case "request-key":
+				run.DisplayName = "different-request"
+			case "reporter-workflow":
+				run.DisplayName = "run-" + util.NewDeterministicUUID(run.UUID)
+				run.K8SName = "different-workflow"
+			case "job-id":
+				run.RecurringRunId = "2"
+			}
+			_, err = NewRunStore(db, util.NewFakeTimeForEpoch(), d).CreateRun(run)
+			require.NoError(t, err)
+			state, err := store.GetRecurringRunState("1")
+			require.NoError(t, err)
+			require.Equal(t, claim, state)
+		})
+	}
+}

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -884,7 +884,7 @@ func (s *RunStore) CreateRun(r *model.Run) (*model.Run, error) {
 	if err != nil {
 		tx.Rollback()
 		// A concurrent recurring-run trigger may have already created this run. Such runs
-		// use a deterministic UUID derived from (RecurringRunId, DisplayName), so the
+		// use a deterministic UUID derived from their trusted tick or request key, so the
 		// duplicate insert collides on the primary key. Resolve it idempotently by
 		// returning the already-persisted run instead of surfacing an error.
 		if r.RecurringRunId != "" && s.dbDialect.IsDuplicateKeyError(err) {
@@ -903,6 +903,9 @@ func (s *RunStore) CreateRun(r *model.Run) (*model.Run, error) {
 	if err != nil {
 		tx.Rollback()
 		return nil, util.NewInternalServerError(err, "Failed to store resource references to table for run %v ", r.DisplayName)
+	}
+	if err := s.completeRecurringRunWithInsert(tx, r); err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to complete the scheduling claim for run %s", r.UUID)
 	}
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/template/argo_status_test.go
+++ b/backend/src/apiserver/template/argo_status_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template_test
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestArgoFreshWorkflowsDiscardSubmittedStatus(t *testing.T) {
+	wf := &workflowapi.Workflow{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Workflow"},
+		ObjectMeta: metav1.ObjectMeta{Name: "fresh"},
+		Spec: workflowapi.WorkflowSpec{Entrypoint: "main", Templates: []workflowapi.Template{{
+			Name: "main", Container: &corev1.Container{Image: "alpine"},
+		}}},
+		Status: workflowapi.WorkflowStatus{
+			Phase:              workflowapi.WorkflowRunning,
+			StoredTemplates:    map[string]workflowapi.Template{"stored": {Name: "stored", ServiceAccountName: "unauthorized"}},
+			StoredWorkflowSpec: &workflowapi.WorkflowSpec{ServiceAccountName: "unauthorized"},
+		},
+	}
+	original := wf.DeepCopy()
+	data, err := yaml.Marshal(wf)
+	require.NoError(t, err)
+	validated, err := template.ValidateWorkflow(data)
+	require.NoError(t, err)
+	assert.Empty(t, validated.Status)
+
+	// The direct constructor bypasses manifest validation; both execution paths
+	// must still discard status without changing the reusable source template.
+	tmpl, err := template.NewArgoTemplateFromWorkflow(wf)
+	require.NoError(t, err)
+	run, err := tmpl.RunWorkflow(&model.Run{}, template.RunWorkflowOptions{RunID: "fresh-run"})
+	require.NoError(t, err)
+	assert.Empty(t, run.(*util.Workflow).Status)
+	job, err := tmpl.ScheduledWorkflow(&model.Job{UUID: "fresh-job"})
+	require.NoError(t, err)
+	require.IsType(t, "", job.Spec.Workflow.Spec)
+	scheduled, err := util.NewWorkflowFromScheduleWorkflowSpecBytesJSON([]byte(job.Spec.Workflow.Spec.(string)))
+	require.NoError(t, err)
+	assert.Empty(t, scheduled.Status)
+	assert.Equal(t, original, wf)
+}

--- a/backend/src/apiserver/template/argo_template.go
+++ b/backend/src/apiserver/template/argo_template.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
-	"github.com/argoproj/argo-workflows/v4/workflow/validate"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -28,6 +27,7 @@ import (
 
 func (t *Argo) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (util.ExecutionSpec, error) {
 	workflow := util.NewWorkflow(t.wf.Workflow.DeepCopy())
+	workflow.Status = workflowapi.WorkflowStatus{}
 
 	// Overwrite namespace from the run object
 	if modelRun.Namespace != "" {
@@ -101,6 +101,7 @@ var _ Template = &Argo{}
 
 func (t *Argo) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
 	workflow := util.NewWorkflow(t.wf.Workflow.DeepCopy())
+	workflow.Status = workflowapi.WorkflowStatus{}
 	// Overwrite namespace from the job object
 	if modelJob.Namespace != "" {
 		workflow.SetExecutionNamespace(modelJob.Namespace)
@@ -217,15 +218,15 @@ func ValidateWorkflow(template []byte) (*util.Workflow, error) {
 	if wf.Kind != argoK8sResource {
 		return nil, util.NewInvalidInputError("Unexpected resource type. Expected: %v. Received: %v", argoK8sResource, wf.Kind)
 	}
-	err = validate.Workflow(util.ArgoContext(), nil, nil, &wf, nil, validate.Opts{
-		Lint:                       true,
-		IgnoreEntrypoint:           true,
-		WorkflowTemplateValidation: false, // not used by kubeflow
-	})
+	// Status belongs to Argo, not the submitted pipeline. In particular, its
+	// cached templates must not participate in fresh workflow validation.
+	wf.Status = workflowapi.WorkflowStatus{}
+	workflow := util.NewWorkflow(&wf)
+	err = workflow.Validate(true, true)
 	if err != nil {
 		return nil, err
 	}
-	return util.NewWorkflow(&wf), nil
+	return workflow, nil
 }
 
 func AddRuntimeMetadata(wf *workflowapi.Workflow) {

--- a/backend/src/apiserver/template/argo_template.go
+++ b/backend/src/apiserver/template/argo_template.go
@@ -52,7 +52,14 @@ func (t *Argo) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (uti
 	workflow.OverrideParameters(parameters)
 
 	// Replace macros
-	formatter := util.NewRunParameterFormatter(options.RunID, options.RunAt)
+	scheduledAt, index := int64(-1), int64(-1)
+	if options.RecurringRunIndex != nil {
+		index = *options.RecurringRunIndex
+		if modelRun.ScheduledAtInSec > 0 {
+			scheduledAt = modelRun.ScheduledAtInSec
+		}
+	}
+	formatter := util.NewSWFParameterFormatter(options.RunID, scheduledAt, options.RunAt, index)
 	formattedParams := formatter.FormatWorkflowParameters(workflow.GetWorkflowParametersAsMap())
 	workflow.OverrideParameters(formattedParams)
 

--- a/backend/src/apiserver/template/scheduled_parameter_test.go
+++ b/backend/src/apiserver/template/scheduled_parameter_test.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestScheduledParameterMacrosPreserveNestedValues(t *testing.T) {
+	value, err := structpb.NewValue(map[string]interface{}{
+		"nested": []interface{}{"[[Index]]", map[string]interface{}{"time": "[[ScheduledTime]]", "run": "[[RunUUID]]"}},
+		"number": float64(42), "boolean": true, "null": nil,
+	})
+	require.NoError(t, err)
+	formatParameterMacros(value, util.NewSWFParameterFormatter("run-id", 100, 200, 3))
+	require.Equal(t, map[string]interface{}{
+		"nested": []interface{}{"3", map[string]interface{}{"time": "19700101000140", "run": "run-id"}},
+		"number": float64(42), "boolean": true, "null": nil,
+	}, value.AsInterface())
+}

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -144,6 +144,8 @@ type Template interface {
 type RunWorkflowOptions struct {
 	RunID string
 	RunAt int64
+	// Nil for one-off runs; derived from the live schedule for recurring runs.
+	RecurringRunIndex *int64
 }
 
 type TemplateOptions struct {

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -68,6 +68,31 @@ func TestValidateWorkflow_ParametersTooLong(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, err.(*commonutil.UserError).ExternalStatusCode())
 }
 
+func TestValidateWorkflow_RejectsExternalTemplateReference(t *testing.T) {
+	wf := v1alpha1.Workflow{
+		TypeMeta: metav1.TypeMeta{APIVersion: argoVersion, Kind: argoK8sResource},
+		Spec: v1alpha1.WorkflowSpec{
+			WorkflowTemplateRef: &v1alpha1.WorkflowTemplateRef{Name: "external-template"},
+		},
+	}
+	templateBytes, err := yaml.Marshal(wf)
+	require.NoError(t, err)
+
+	_, err = ValidateWorkflow(templateBytes)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "external workflow template references cannot be authorized")
+}
+
+func TestValidateWorkflow_AllowsParameterizedPodSpecPatch(t *testing.T) {
+	wf := unmarshalWf(awfTemplate)
+	wf.Spec.Templates[0].PodSpecPatch = `serviceAccountName: "{{inputs.parameters.dup}}"`
+	templateBytes, err := yaml.Marshal(wf)
+	require.NoError(t, err)
+
+	_, err = ValidateWorkflow(templateBytes)
+	require.NoError(t, err)
+}
+
 func TestParseSpecFormat(t *testing.T) {
 	tt := []struct {
 		template     string

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -353,25 +353,18 @@ func (t *V2Spec) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (u
 		if modelRun.ScheduledAtInSec > 0 {
 			scheduledEpoch = modelRun.ScheduledAtInSec
 		}
+		index := int64(-1)
+		if options.RecurringRunIndex != nil {
+			index = *options.RecurringRunIndex
+		}
 		formatter := util.NewSWFParameterFormatter(
 			options.RunID,
 			scheduledEpoch,
 			options.RunAt,
-			-1,
+			index,
 		)
-		// Convert structpb.Value to strings, format, convert back
-		paramValues := job.RuntimeConfig.GetParameterValues()
-		stringParams := make(map[string]string)
-		for key, val := range paramValues {
-			if strVal := val.GetStringValue(); strVal != "" {
-				stringParams[key] = strVal
-			}
-		}
-		// Format the string parameters
-		formattedParams := formatter.FormatWorkflowParameters(stringParams)
-		// Convert formatted strings back to structpb.Value
-		for key, formattedVal := range formattedParams {
-			paramValues[key] = structpb.NewStringValue(formattedVal)
+		for _, value := range job.RuntimeConfig.GetParameterValues() {
+			formatParameterMacros(value, formatter)
 		}
 	}
 	if err = t.validatePipelineJobInputs(job); err != nil {
@@ -554,4 +547,23 @@ func modelPluginsInputToCRD(lt *model.LargeText) (map[string]apiextensionsv1.JSO
 		result[k] = apiextensionsv1.JSON{Raw: v}
 	}
 	return result, nil
+}
+
+// Format nested values as well as strings, matching embedded schedule expansion.
+func formatParameterMacros(value *structpb.Value, formatter *util.ParameterFormatter) {
+	if value == nil {
+		return
+	}
+	switch kind := value.Kind.(type) {
+	case *structpb.Value_StringValue:
+		kind.StringValue = formatter.Format(kind.StringValue)
+	case *structpb.Value_ListValue:
+		for _, item := range kind.ListValue.Values {
+			formatParameterMacros(item, formatter)
+		}
+	case *structpb.Value_StructValue:
+		for _, item := range kind.StructValue.Fields {
+			formatParameterMacros(item, formatter)
+		}
+	}
 }

--- a/backend/src/apiserver/validation/recurring_run.go
+++ b/backend/src/apiserver/validation/recurring_run.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"unicode/utf8"
+
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+// ValidateRecurringRunRequestKey ensures a claimed key can be stored as the run's display name.
+func ValidateRecurringRunRequestKey(requestKey string) error {
+	if requestKey == "" {
+		return util.NewInvalidInputError("Provide an idempotency key when claiming a recurring run")
+	}
+	if !utf8.ValidString(requestKey) {
+		return util.NewInvalidInputError("Use valid UTF-8 for the recurring run idempotency key")
+	}
+	// MySQL stores run display names in VARCHAR(255), whose limit is characters, not bytes.
+	if utf8.RuneCountInString(requestKey) > 255 {
+		return util.NewInvalidInputError("Recurring run idempotency key cannot exceed 255 characters; shorten the run display name")
+	}
+	return nil
+}

--- a/backend/src/common/util/execution_spec.go
+++ b/backend/src/common/util/execution_spec.go
@@ -97,6 +97,9 @@ type ExecutionSpec interface {
 	// Get ServiceAccountName
 	ServiceAccount() string
 
+	// ServiceAccounts returns every service account the execution can use.
+	ServiceAccounts(allowCompilerPodSpecPatch bool) ([]string, error)
+
 	// Get ExecutionStatus which can be used to
 	// access status related information
 	ExecutionStatus() ExecutionStatus

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"context"
+	stdjson "encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -45,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/yaml"
 )
@@ -170,6 +172,282 @@ func (w *Workflow) SetServiceAccount(serviceAccount string) {
 
 func (w *Workflow) ServiceAccount() string {
 	return w.Spec.ServiceAccountName
+}
+
+func (w *Workflow) walkTemplates(visit func(*workflowapi.Template) error) error {
+	hasReference := func(ref *workflowapi.TemplateRef, hooks workflowapi.LifecycleHooks) bool {
+		if ref != nil {
+			return true
+		}
+		for _, hook := range hooks {
+			if hook.TemplateRef != nil {
+				return true
+			}
+		}
+		return false
+	}
+	referenceError := func() error {
+		return NewInvalidInputError("external workflow template references cannot be authorized; inline the referenced template")
+	}
+
+	var walk func(*workflowapi.Template) error
+	walk = func(tmpl *workflowapi.Template) error {
+		if tmpl == nil {
+			return nil
+		}
+		if visit != nil {
+			if err := visit(tmpl); err != nil {
+				return err
+			}
+		}
+		for i := range tmpl.Steps {
+			for j := range tmpl.Steps[i].Steps {
+				step := &tmpl.Steps[i].Steps[j]
+				if hasReference(step.TemplateRef, step.Hooks) {
+					return referenceError()
+				}
+				if err := walk(step.Inline); err != nil {
+					return err
+				}
+			}
+		}
+		if tmpl.DAG != nil {
+			for i := range tmpl.DAG.Tasks {
+				task := &tmpl.DAG.Tasks[i]
+				if hasReference(task.TemplateRef, task.Hooks) {
+					return referenceError()
+				}
+				if err := walk(task.Inline); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	for _, spec := range []*workflowapi.WorkflowSpec{&w.Spec, w.Status.StoredWorkflowSpec} {
+		if spec == nil {
+			continue
+		}
+		if spec.WorkflowTemplateRef != nil || hasReference(nil, spec.Hooks) {
+			return referenceError()
+		}
+		if err := walk(spec.TemplateDefaults); err != nil {
+			return err
+		}
+		for i := range spec.Templates {
+			if err := walk(&spec.Templates[i]); err != nil {
+				return err
+			}
+		}
+	}
+	for _, tmpl := range w.Status.StoredTemplates {
+		if err := walk(&tmpl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateNoExternalTemplateReferences rejects template references because KFP
+// does not resolve them while validating or authorizing a workflow.
+func (w *Workflow) validateNoExternalTemplateReferences() error {
+	return w.walkTemplates(nil)
+}
+
+// ServiceAccounts returns every service account that pods created by the
+// workflow can use.
+func (w *Workflow) ServiceAccounts(allowCompilerPodSpecPatch bool) ([]string, error) {
+	workflowAccount := w.Spec.ServiceAccountName
+	if workflowAccount == "" {
+		workflowAccount = "default"
+	}
+	accounts := make([]string, 0, len(w.Spec.Templates)+1)
+	seen := make(map[string]struct{}, len(w.Spec.Templates)+1)
+	add := func(account string) {
+		if account == workflowServiceAccountTemplate {
+			account = workflowAccount
+		}
+		if account == "" {
+			return
+		}
+		if _, ok := seen[account]; ok {
+			return
+		}
+		seen[account] = struct{}{}
+		accounts = append(accounts, account)
+	}
+	addPatch := func(patch string) error {
+		patchAccounts, err := serviceAccountsInPodSpecPatch(patch, allowCompilerPodSpecPatch)
+		if err != nil {
+			return err
+		}
+		for _, account := range patchAccounts {
+			add(account)
+		}
+		return nil
+	}
+	add(workflowAccount)
+	if w.Spec.Executor != nil {
+		add(w.Spec.Executor.ServiceAccountName)
+	}
+	for _, plugin := range w.Spec.ExecutorPlugins {
+		if plugin.Spec.Sidecar.AutomountServiceAccountToken {
+			add(plugin.Name + "-executor-plugin")
+		}
+	}
+	if err := addPatch(w.Spec.PodSpecPatch); err != nil {
+		return nil, err
+	}
+
+	var artifactGCPatchAccounts []string
+	artifactGCPatchInspected := false
+
+	visitArtifacts := func(artifacts []workflowapi.Artifact) error {
+		for i := range artifacts {
+			artifact := &artifacts[i]
+			strategy := w.GetArtifactGCStrategy(artifact)
+			if strategy == workflowapi.ArtifactGCNever || strategy == workflowapi.ArtifactGCStrategyUndefined {
+				continue
+			}
+			account := ""
+			if w.Spec.ArtifactGC != nil {
+				account = w.Spec.ArtifactGC.ServiceAccountName
+			}
+			if artifact.ArtifactGC != nil && artifact.ArtifactGC.ServiceAccountName != "" {
+				account = artifact.ArtifactGC.ServiceAccountName
+			}
+			if account != "" {
+				add(account)
+				continue
+			}
+			if !artifactGCPatchInspected {
+				artifactGCPatchInspected = true
+				if w.Spec.ArtifactGC != nil {
+					var err error
+					artifactGCPatchAccounts, err = serviceAccountsInPodSpecPatch(w.Spec.ArtifactGC.PodSpecPatch, allowCompilerPodSpecPatch)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			if len(artifactGCPatchAccounts) == 0 {
+				add("default")
+			}
+			for _, patchAccount := range artifactGCPatchAccounts {
+				add(patchAccount)
+			}
+		}
+		return nil
+	}
+
+	visitTemplate := func(tmpl *workflowapi.Template) error {
+		add(tmpl.ServiceAccountName)
+		if tmpl.Executor != nil {
+			add(tmpl.Executor.ServiceAccountName)
+		}
+		if err := addPatch(tmpl.PodSpecPatch); err != nil {
+			return err
+		}
+		return visitArtifacts(tmpl.Outputs.Artifacts)
+	}
+
+	if err := w.walkTemplates(visitTemplate); err != nil {
+		return nil, err
+	}
+	// Argo also schedules artifact-GC pods from retained node outputs on retry.
+	for _, node := range w.Status.Nodes {
+		if node.Type == workflowapi.NodeTypePod && node.Outputs != nil {
+			if err := visitArtifacts(node.Outputs.Artifacts); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if storedSpec := w.Status.StoredWorkflowSpec; storedSpec != nil {
+		// Retried workflows retain Argo's cached spec. Inspect its own defaults
+		// as well as the submitted spec, including helpers for cached templates.
+		storedWorkflow := NewWorkflow(&workflowapi.Workflow{
+			Spec: *storedSpec,
+			Status: workflowapi.WorkflowStatus{
+				StoredTemplates: w.Status.StoredTemplates,
+				Nodes:           w.Status.Nodes,
+			},
+		})
+		storedAccounts, err := storedWorkflow.ServiceAccounts(allowCompilerPodSpecPatch)
+		if err != nil {
+			return nil, err
+		}
+		for _, account := range storedAccounts {
+			add(account)
+		}
+	}
+	return accounts, nil
+}
+
+const (
+	workflowServiceAccountTemplate        = "{{workflow.serviceAccountName}}"
+	podSpecPatchServiceAccountSentinel    = "<unchanged>" // Invalid as a Kubernetes service account name.
+	compilerGeneratedPodSpecPatchTemplate = "{{inputs.parameters.pod-spec-patch}}"
+)
+
+func serviceAccountsInPodSpecPatch(patch string, allowCompilerPatch bool) ([]string, error) {
+	if patch == "" {
+		return nil, nil
+	}
+	if strings.Contains(patch, "{{") {
+		if allowCompilerPatch && strings.TrimSpace(patch) == compilerGeneratedPodSpecPatchTemplate {
+			return nil, nil
+		}
+		return nil, NewInvalidInputError("podSpecPatch contains a template expression, so its service account cannot be authorized before execution; use a literal podSpecPatch")
+	}
+
+	// Argo preserves JSON input before validating it with encoding/json.
+	patchJSON := []byte(patch)
+	if !strings.HasPrefix(strings.TrimSpace(patch), "{") {
+		var err error
+		patchJSON, err = yaml.YAMLToJSON(patchJSON)
+		if err != nil {
+			return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+		}
+	}
+	// Case variants can be hidden by an inherited canonical field and exposed
+	// when a later template patch removes it, before Argo's case-folding decode.
+	var fields map[string]stdjson.RawMessage
+	if err := stdjson.Unmarshal(patchJSON, &fields); err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+	for field := range fields {
+		for _, canonical := range []string{"serviceAccountName", "serviceAccount"} {
+			if field != canonical && strings.EqualFold(field, canonical) {
+				return nil, NewInvalidInputError("podSpecPatch field %q has a noncanonical service account spelling; use %q", field, canonical)
+			}
+		}
+	}
+	if err := stdjson.Unmarshal(patchJSON, &corev1.PodSpec{}); err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+	baseJSON := []byte(`{"serviceAccountName":"` + podSpecPatchServiceAccountSentinel + `"}`)
+	patchedJSON, err := strategicpatch.StrategicMergePatch(baseJSON, patchJSON, corev1.PodSpec{})
+	if err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+	var patched corev1.PodSpec
+	if err := stdjson.Unmarshal(patchedJSON, &patched); err != nil {
+		return nil, NewInvalidInputError("podSpecPatch is not a valid Kubernetes PodSpec patch; provide a literal valid patch: %v", err)
+	}
+
+	var accounts []string
+	canonicalTouched := patched.ServiceAccountName != podSpecPatchServiceAccountSentinel
+	if canonicalTouched && patched.ServiceAccountName != "" {
+		accounts = append(accounts, patched.ServiceAccountName)
+	}
+	if patched.DeprecatedServiceAccount != "" {
+		accounts = append(accounts, patched.DeprecatedServiceAccount)
+	}
+	if canonicalTouched && patched.ServiceAccountName == "" && patched.DeprecatedServiceAccount == "" {
+		accounts = append(accounts, "default")
+	}
+	return accounts, nil
 }
 
 func (w *Workflow) SpecParameters() SpecParameters {
@@ -814,6 +1092,11 @@ func (w *Workflow) IsV2Compatible() bool {
 }
 
 func (w *Workflow) Validate(lint, ignoreEntrypoint bool) error {
+	// Argo validation receives no external-template getters, so reject
+	// references instead of allowing validation to dereference a nil getter.
+	if err := w.validateNoExternalTemplateReferences(); err != nil {
+		return err
+	}
 	err := validate.Workflow(ArgoContext(), nil, nil, w.Workflow, nil, validate.Opts{
 		Lint:                       lint,
 		IgnoreEntrypoint:           ignoreEntrypoint,

--- a/backend/src/common/util/workflow_pod_spec_patch_internal_test.go
+++ b/backend/src/common/util/workflow_pod_spec_patch_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceAccountsInPodSpecPatchRejectsNoncanonicalFields(t *testing.T) {
+	tests := []struct {
+		name, patch string
+	}{
+		{name: "lowercase JSON", patch: `{"serviceaccountname":"privileged-sa"}`},
+		{name: "mixed case YAML", patch: `serviceAccountname: privileged-sa`},
+		{name: "uppercase with replacement", patch: "$patch: replace\nServiceAccountName: privileged-sa"},
+		{name: "conflicting spellings", patch: `{"serviceAccountName":"allowed-sa","serviceaccountname":"privileged-sa"}`},
+		{name: "Unicode case folding", patch: `{"ſerviceAccountName":"privileged-sa"}`},
+		{name: "deprecated alias", patch: `{"ServiceAccount":"privileged-sa"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := serviceAccountsInPodSpecPatch(tt.patch, false)
+			require.ErrorContains(t, err, "canonical")
+		})
+	}
+}
+
+func TestWorkflow_ServiceAccountsRejectsAccountHiddenUntilTemplatePatch(t *testing.T) {
+	workflowPatch := `{"ServiceAccountName":"privileged-sa"}`
+	templatePatch := `serviceAccountName: null`
+	// Argo merges both patches before decoding: deleting the canonical field
+	// exposes ServiceAccountName, which its decoder accepts as privileged-sa.
+	w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+		ServiceAccountName: "allowed-sa",
+		PodSpecPatch:       workflowPatch,
+		Templates:          []workflowapi.Template{{PodSpecPatch: templatePatch}},
+	}})
+	_, err := w.ServiceAccounts(false)
+	require.ErrorContains(t, err, "canonical")
+}
+
+func TestServiceAccountsInPodSpecPatchPreservesArgoJSONValidation(t *testing.T) {
+	// Argo validates the original JSON before merging, including overwritten fields.
+	patch := `{"serviceAccountName":[],"serviceAccountName":"allowed-sa"}`
+	_, err := serviceAccountsInPodSpecPatch(patch, false)
+	require.ErrorContains(t, err, "valid Kubernetes PodSpec patch")
+}

--- a/backend/src/common/util/workflow_stored_status_test.go
+++ b/backend/src/common/util/workflow_stored_status_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWorkflowServiceAccountsIncludesStoredExecutionState(t *testing.T) {
+	w := util.NewWorkflow(&workflowapi.Workflow{
+		Spec: workflowapi.WorkflowSpec{ServiceAccountName: "submitted-sa"},
+		Status: workflowapi.WorkflowStatus{
+			StoredWorkflowSpec: &workflowapi.WorkflowSpec{
+				ServiceAccountName: "stored-workflow-sa",
+				Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "stored-executor-sa"},
+				PodSpecPatch:       `serviceAccountName: stored-patch-sa`,
+				ExecutorPlugins: []workflowapi.ExecutorPlugin{{
+					ObjectMeta: metav1.ObjectMeta{Name: "stored"},
+					Spec:       workflowapi.ExecutorPluginSpec{Sidecar: workflowapi.ExecutorPluginSidecar{AutomountServiceAccountToken: true}},
+				}},
+				TemplateDefaults: &workflowapi.Template{
+					ServiceAccountName: "{{workflow.serviceAccountName}}",
+					Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "stored-default-executor-sa"},
+				},
+				Templates: []workflowapi.Template{{Name: "stored", ServiceAccountName: "stored-template-sa"}},
+				ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+					ArtifactGC: workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion, ServiceAccountName: "stored-gc-sa"},
+				},
+			},
+			StoredTemplates: map[string]workflowapi.Template{
+				"local/mapped": {
+					Name: "mapped", ServiceAccountName: "mapped-sa",
+					Steps: []workflowapi.ParallelSteps{{Steps: []workflowapi.WorkflowStep{{
+						Name: "inline", Inline: &workflowapi.Template{ServiceAccountName: "inline-sa"},
+					}}}},
+					Outputs: workflowapi.Outputs{Artifacts: workflowapi.Artifacts{{Name: "cached-output"}}},
+				},
+			},
+			Nodes: workflowapi.Nodes{
+				"succeeded": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeSucceeded, Outputs: &workflowapi.Outputs{
+					Artifacts: workflowapi.Artifacts{
+						{Name: "inherited-gc"},
+						{Name: "override-gc", ArtifactGC: &workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowDeletion, ServiceAccountName: "node-gc-sa"}},
+						{Name: "inactive", ArtifactGC: &workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCNever, ServiceAccountName: "inactive-sa"}},
+					},
+				}},
+			},
+		},
+	})
+	original := w.DeepCopy()
+	accounts, err := w.ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"submitted-sa", "stored-workflow-sa", "stored-executor-sa", "stored-patch-sa", "stored-executor-plugin",
+		"stored-default-executor-sa", "stored-template-sa", "mapped-sa", "inline-sa", "stored-gc-sa", "node-gc-sa",
+	}, accounts)
+	assert.Equal(t, original, w.Workflow, "authorization must not discard retry state")
+}
+
+func TestWorkflowServiceAccountsRejectsUnsafeStoredTemplates(t *testing.T) {
+	for _, location := range []string{"stored templates", "stored workflow templates", "stored defaults"} {
+		t.Run(location, func(t *testing.T) {
+			for _, kind := range []string{"external reference", "dynamic patch"} {
+				t.Run(kind, func(t *testing.T) {
+					tmpl := workflowapi.Template{Name: "stored"}
+					wantError := "external workflow template references"
+					if kind == "external reference" {
+						tmpl.DAG = &workflowapi.DAGTemplate{Tasks: []workflowapi.DAGTask{{TemplateRef: &workflowapi.TemplateRef{Name: "external", Template: "task"}}}}
+					} else {
+						tmpl.PodSpecPatch = `serviceAccountName: "{{workflow.parameters.account}}"`
+						wantError = "podSpecPatch contains a template expression"
+					}
+					w := util.NewWorkflow(&workflowapi.Workflow{})
+					switch location {
+					case "stored templates":
+						w.Status.StoredTemplates = map[string]workflowapi.Template{"stored": tmpl}
+					case "stored workflow templates":
+						w.Status.StoredWorkflowSpec = &workflowapi.WorkflowSpec{Templates: []workflowapi.Template{tmpl}}
+					case "stored defaults":
+						w.Status.StoredWorkflowSpec = &workflowapi.WorkflowSpec{TemplateDefaults: &tmpl}
+					}
+					_, err := w.ServiceAccounts(false)
+					require.ErrorContains(t, err, wantError)
+				})
+			}
+		})
+	}
+}
+
+func TestWorkflowServiceAccountsChecksStoredNodeArtifactGCDefaults(t *testing.T) {
+	w := util.NewWorkflow(&workflowapi.Workflow{Status: workflowapi.WorkflowStatus{
+		StoredWorkflowSpec: &workflowapi.WorkflowSpec{ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+			ArtifactGC:   workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion},
+			PodSpecPatch: `serviceAccountName: cached-gc-sa`,
+		}},
+		Nodes: workflowapi.Nodes{"retained": {Type: workflowapi.NodeTypePod, Outputs: &workflowapi.Outputs{
+			Artifacts: workflowapi.Artifacts{{Name: "output"}},
+		}}},
+	}})
+	accounts, err := w.ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"default", "cached-gc-sa"}, accounts)
+	w.Status.StoredWorkflowSpec.ArtifactGC.PodSpecPatch = `{{workflow.parameters.gc-patch}}`
+	_, err = w.ServiceAccounts(false)
+	require.ErrorContains(t, err, "podSpecPatch contains a template expression")
+}

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2987,3 +2987,220 @@ func TestReadNodeMetricsOrNil_MaxResponseBytesPropagation(t *testing.T) {
 	assert.Contains(t, err.Error(), "sentinel stop here")
 	assert.Equal(t, 1, callCount, "mock must be invoked exactly once")
 }
+
+func TestWorkflow_ServiceAccountsCollectsPodIdentities(t *testing.T) {
+	dagInline := &workflowapi.Template{ServiceAccountName: "dag-inline-sa"}
+	stepInline := &workflowapi.Template{
+		ServiceAccountName: "step-inline-sa",
+		DAG: &workflowapi.DAGTemplate{Tasks: []workflowapi.DAGTask{{
+			Name:   "nested-task",
+			Inline: dagInline,
+		}}},
+	}
+	rootTemplate := workflowapi.Template{
+		Name:               "root",
+		ServiceAccountName: "{{workflow.serviceAccountName}}", // Resolves to, and de-duplicates, the workflow account.
+		Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "template-executor-sa"},
+		PodSpecPatch:       `serviceAccountName: template-patch-sa`,
+		Steps: []workflowapi.ParallelSteps{{Steps: []workflowapi.WorkflowStep{{
+			Name:   "nested-step",
+			Inline: stepInline,
+		}}}},
+	}
+	w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+		ServiceAccountName: "workflow-sa",
+		Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "workflow-executor-sa"},
+		PodSpecPatch:       `serviceAccountName: workflow-patch-sa`,
+		ExecutorPlugins: []workflowapi.ExecutorPlugin{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "token"},
+				Spec:       workflowapi.ExecutorPluginSpec{Sidecar: workflowapi.ExecutorPluginSidecar{AutomountServiceAccountToken: true}},
+			},
+			{ObjectMeta: metav1.ObjectMeta{Name: "no-token"}},
+		},
+		TemplateDefaults: &workflowapi.Template{
+			ServiceAccountName: "defaults-sa",
+			Executor:           &workflowapi.ExecutorConfig{ServiceAccountName: "defaults-executor-sa"},
+			PodSpecPatch:       `serviceAccountName: defaults-patch-sa`,
+		},
+		Templates: []workflowapi.Template{rootTemplate},
+	}})
+
+	accounts, err := w.ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"workflow-sa",
+		"workflow-executor-sa",
+		"token-executor-plugin",
+		"workflow-patch-sa",
+		"defaults-sa",
+		"defaults-executor-sa",
+		"defaults-patch-sa",
+		"template-executor-sa",
+		"template-patch-sa",
+		"step-inline-sa",
+		"dag-inline-sa",
+	}, accounts)
+
+	accounts, err = NewWorkflow(&workflowapi.Workflow{}).ServiceAccounts(false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"default"}, accounts)
+
+	accounts, err = NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+		ServiceAccountName: "workflow-sa",
+		Templates: []workflowapi.Template{{
+			ServiceAccountName: "static-v2-sa",
+			PodSpecPatch:       compilerGeneratedPodSpecPatchTemplate,
+		}},
+	}}).ServiceAccounts(true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"workflow-sa", "static-v2-sa"}, accounts)
+}
+
+func TestWorkflow_ServiceAccountsCollectsArtifactGCIdentities(t *testing.T) {
+	artifact := func(strategy workflowapi.ArtifactGCStrategy, account string) workflowapi.Artifact {
+		return workflowapi.Artifact{
+			Name: account,
+			ArtifactGC: &workflowapi.ArtifactGC{
+				Strategy:           strategy,
+				ServiceAccountName: account,
+			},
+		}
+	}
+
+	tests := []struct {
+		name, account, patch string
+		outputs              workflowapi.Artifacts
+		want                 []string
+	}{
+		{
+			name:    "workflow and artifact accounts; inactive output ignored",
+			account: "workflow-gc-sa",
+			outputs: workflowapi.Artifacts{
+				artifact(workflowapi.ArtifactGCOnWorkflowCompletion, ""),
+				artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "artifact-gc-sa"),
+				artifact(workflowapi.ArtifactGCNever, "never-gc-sa"),
+			},
+			want: []string{"workflow-sa", "workflow-gc-sa", "artifact-gc-sa"},
+		},
+		{
+			name: "workflow-level pod patch", patch: `serviceAccountName: patched-gc-sa`,
+			outputs: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "")},
+			want:    []string{"workflow-sa", "patched-gc-sa"},
+		},
+		{
+			name:    "Kubernetes default account",
+			outputs: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "")},
+			want:    []string{"workflow-sa", "default"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+				ServiceAccountName: "workflow-sa",
+				ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+					ArtifactGC:   workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion, ServiceAccountName: tt.account},
+					PodSpecPatch: tt.patch,
+				},
+				Templates: []workflowapi.Template{{
+					Inputs:  workflowapi.Inputs{Artifacts: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "input-gc-sa")}},
+					Outputs: workflowapi.Outputs{Artifacts: tt.outputs},
+				}},
+			}})
+
+			accounts, err := w.ServiceAccounts(false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, accounts)
+		})
+	}
+
+	t.Run("parameterized workflow-level patch is rejected", func(t *testing.T) {
+		w := NewWorkflow(&workflowapi.Workflow{Spec: workflowapi.WorkflowSpec{
+			ArtifactGC: &workflowapi.WorkflowLevelArtifactGC{
+				ArtifactGC:   workflowapi.ArtifactGC{Strategy: workflowapi.ArtifactGCOnWorkflowCompletion},
+				PodSpecPatch: `{{workflow.parameters.gc-patch}}`,
+			},
+			Templates: []workflowapi.Template{{
+				Outputs: workflowapi.Outputs{Artifacts: workflowapi.Artifacts{artifact(workflowapi.ArtifactGCOnWorkflowCompletion, "")}},
+			}},
+		}})
+		_, err := w.ServiceAccounts(false)
+		require.ErrorContains(t, err, "template expression")
+	})
+}
+
+func TestServiceAccountsInPodSpecPatch(t *testing.T) {
+	tests := []struct {
+		name, patch, wantErr string
+		allowCompiler        bool
+		want                 []string
+	}{
+		{name: "empty"},
+		{name: "canonical JSON field", patch: `{"serviceAccountName":"canonical-sa"}`, want: []string{"canonical-sa"}},
+		{name: "deprecated YAML alias", patch: `serviceAccount: alias-sa`, want: []string{"alias-sa"}},
+		{name: "null clears inherited account", patch: `serviceAccountName: null`, want: []string{"default"}},
+		{name: "root null is a no-op", patch: `null`},
+		{name: "root replacement clears inherited account", patch: "$patch: replace\ncontainers: []", want: []string{"default"}},
+		{name: "unrelated patch", patch: `containers: []`},
+		{name: "compiler patch", patch: compilerGeneratedPodSpecPatchTemplate, allowCompiler: true},
+		{name: "templated account", patch: `serviceAccountName: "{{workflow.parameters.account}}"`, wantErr: "template expression"},
+		{name: "templated unrelated field", patch: `nodeName: "{{inputs.parameters.node}}"`, allowCompiler: true, wantErr: "template expression"},
+		{name: "compiler patch in V1", patch: compilerGeneratedPodSpecPatchTemplate, wantErr: "template expression"},
+		{name: "malformed YAML", patch: `serviceAccountName: [`, wantErr: "valid Kubernetes PodSpec patch"},
+		{name: "wrong field type", patch: "serviceAccountName:\n- invalid", wantErr: "valid Kubernetes PodSpec patch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accounts, err := serviceAccountsInPodSpecPatch(tt.patch, tt.allowCompiler)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, accounts)
+		})
+	}
+}
+
+func TestWorkflow_ServiceAccountsRejectsExternalTemplateReferences(t *testing.T) {
+	templateRef := func() *workflowapi.TemplateRef {
+		return &workflowapi.TemplateRef{Name: "external", Template: "entrypoint"}
+	}
+	hookWithRef := func() workflowapi.LifecycleHooks {
+		return workflowapi.LifecycleHooks{workflowapi.ExitLifecycleEvent: {TemplateRef: templateRef()}}
+	}
+	stepSpec := func(step workflowapi.WorkflowStep) workflowapi.WorkflowSpec {
+		return workflowapi.WorkflowSpec{Templates: []workflowapi.Template{{
+			Steps: []workflowapi.ParallelSteps{{Steps: []workflowapi.WorkflowStep{step}}},
+		}}}
+	}
+	dagSpec := func(task workflowapi.DAGTask) workflowapi.WorkflowSpec {
+		return workflowapi.WorkflowSpec{Templates: []workflowapi.Template{{
+			DAG: &workflowapi.DAGTemplate{Tasks: []workflowapi.DAGTask{task}},
+		}}}
+	}
+	tests := []struct {
+		name string
+		spec workflowapi.WorkflowSpec
+	}{
+		{name: "workflow template reference", spec: workflowapi.WorkflowSpec{WorkflowTemplateRef: &workflowapi.WorkflowTemplateRef{Name: "external"}}},
+		{name: "workflow hook reference", spec: workflowapi.WorkflowSpec{Hooks: hookWithRef()}},
+		{name: "step reference", spec: stepSpec(workflowapi.WorkflowStep{TemplateRef: templateRef()})},
+		{name: "step hook reference", spec: stepSpec(workflowapi.WorkflowStep{Hooks: hookWithRef()})},
+		{name: "DAG task reference", spec: dagSpec(workflowapi.DAGTask{TemplateRef: templateRef()})},
+		{name: "DAG task hook reference", spec: dagSpec(workflowapi.DAGTask{Hooks: hookWithRef()})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.spec.ServiceAccountName = "workflow-sa"
+
+			accounts, err := NewWorkflow(&workflowapi.Workflow{Spec: tt.spec}).ServiceAccounts(false)
+			require.Error(t, err)
+			assert.Nil(t, accounts)
+			assert.Contains(t, err.Error(), "external workflow template references")
+		})
+	}
+}

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -95,6 +96,7 @@ type Controller struct {
 	swfClient      *client.ScheduledWorkflowClient
 	workflowClient *client.WorkflowClient
 	runClient      api.RunServiceClient
+	multiUser      bool
 
 	// workqueue is a rate limited work queue. This is used to queue work to be
 	// processed instead of performing it as soon as a change happens. This
@@ -155,6 +157,7 @@ func NewController(
 	tokenSrc transport.ResettableTokenSource,
 	userIdentityHeader string,
 	userIdentityValue string,
+	multiUser bool,
 ) (*Controller, error) {
 	// Normalize and validate the user identity metadata key up front so the
 	// controller fails fast at startup rather than risking failed requests
@@ -185,6 +188,7 @@ func NewController(
 		kubeClient:     client.NewKubeClient(kubeClientSet, recorder),
 		swfClient:      client.NewScheduledWorkflowClient(swfClientSet, swfInformer),
 		runClient:      runClient,
+		multiUser:      multiUser,
 		workflowClient: client.NewWorkflowClient(workflowClientSet, executionInformer),
 		workqueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.NewItemExponentialFailureRateLimiter(DefaultJobBackOff, MaxJobBackOff), swfregister.Kind),
@@ -626,7 +630,7 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	}
 
 	// If the workflow is not found, we need to create it.
-	if swf.Spec.Workflow != nil && swf.Spec.Workflow.Spec != nil {
+	if !c.multiUser && swf.Spec.Workflow != nil && swf.Spec.Workflow.Spec != nil {
 		// V1 recurring runs bypass the API server by embedding the workflow spec directly in the ScheduledWorkflow CRD,
 		// so the V1 pipeline block needs to be enforced at the controller level as well.
 		if shouldEnforceV1Block(swf) {
@@ -659,6 +663,16 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 		ctx = metadata.AppendToOutgoingContext(ctx, c.userIdentityHeader, c.userIdentityValue)
 	}
 
+	if c.multiUser {
+		// ScheduledWorkflow objects are editable by namespace users. The API server
+		// restores execution inputs from the authorized, persisted recurring run.
+		return c.createRun(ctx, swf, &api.CreateRunRequest{Run: &api.Run{
+			RecurringRunId: string(swf.UID),
+			DisplayName:    workflowName,
+			ScheduledAt:    timestamppb.New(time.Unix(nextScheduledEpoch, 0)),
+		}})
+	}
+
 	var runtimeConfig *api.RuntimeConfig
 
 	if swf.Spec.Workflow != nil {
@@ -689,7 +703,7 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 		}
 	}
 
-	run, err := c.runClient.CreateRun(ctx, &api.CreateRunRequest{
+	return c.createRun(ctx, swf, &api.CreateRunRequest{
 		ExperimentId: swf.Spec.ExperimentId,
 		Run: &api.Run{
 			ExperimentId:   swf.Spec.ExperimentId,
@@ -707,6 +721,10 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 			ServiceAccount: swf.Spec.ServiceAccount,
 		},
 	})
+}
+
+func (c *Controller) createRun(ctx context.Context, swf *util.ScheduledWorkflow, request *api.CreateRunRequest) (bool, string, error) {
+	run, err := c.runClient.CreateRun(ctx, request)
 	if err != nil {
 		return false, "", fmt.Errorf(
 			"failed to create a run from the scheduled workflow (%s/%s): %w", swf.Namespace, swf.Name, err,

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -754,7 +754,7 @@ func (c *Controller) updateStatus(
 	swfCopy.UpdateStatus(submitted, nextScheduledEpoch, active, completed, c.location)
 
 	// Pre-update check: determine if the Workflow (wf) object has actually changed
-	// by comparing its Status.Conditions, Status.WorkflowHistory, and Labels
+	// by comparing its Status.Conditions, Status.WorkflowHistory, Status.Trigger, and Labels
 	// with the previous copy (swfCopy). `updated` will be true if any of these
 	// fields were modified.
 	//
@@ -763,9 +763,11 @@ func (c *Controller) updateStatus(
 	// unnecessary writes to the Kubernetes API
 	conditionsWasUpdated := !equality.Semantic.DeepEqual(swf.Status.Conditions, swfCopy.Status.Conditions)
 	workHistoryWasUpdated := !equality.Semantic.DeepEqual(swf.Status.WorkflowHistory, swfCopy.Status.WorkflowHistory)
+	triggerWasUpdated := !equality.Semantic.DeepEqual(swf.Status.Trigger, swfCopy.Status.Trigger)
 	labelsWasUpdated := !equality.Semantic.DeepEqual(swf.Labels, swfCopy.Labels)
 	var updated = conditionsWasUpdated ||
 		workHistoryWasUpdated ||
+		triggerWasUpdated ||
 		labelsWasUpdated
 
 	// Until #38113 is merged, we must use Update instead of UpdateStatus to

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -587,7 +587,7 @@ func (c *Controller) submitNextWorkflowIfNeeded(ctx context.Context, swf *util.S
 	}
 
 	var workflowName string
-	submitted, workflowName, err = c.submitNewWorkflowIfNotAlreadySubmitted(ctx, swf, nextScheduledEpoch, nowEpoch)
+	submitted, workflowName, nextScheduledEpoch, err = c.submitNewWorkflowIfNotAlreadySubmitted(ctx, swf, nextScheduledEpoch, nowEpoch)
 	if err != nil {
 		log.WithFields(log.Fields{
 			ScheduledWorkflow: swf.Name,
@@ -608,7 +608,7 @@ func (c *Controller) submitNextWorkflowIfNeeded(ctx context.Context, swf *util.S
 func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	ctx context.Context,
 	swf *util.ScheduledWorkflow, nextScheduledEpoch int64, nowEpoch int64) (
-	bool, string, error) {
+	bool, string, int64, error) {
 
 	workflowName := swf.NextResourceName()
 
@@ -621,12 +621,12 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 		// The workflow was already created by a previous iteration of this controller.
 		// Nothing to do except returning the information needed by the controller to update
 		// the ScheduledWorkflow status.
-		return true, workflowName, nil
+		return true, workflowName, nextScheduledEpoch, nil
 	}
 
 	if !isNotFoundError {
 		// There was an error while attempting to retrieve the workflow
-		return false, "", err
+		return false, "", nextScheduledEpoch, err
 	}
 
 	// If the workflow is not found, we need to create it.
@@ -634,25 +634,25 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 		// V1 recurring runs bypass the API server by embedding the workflow spec directly in the ScheduledWorkflow CRD,
 		// so the V1 pipeline block needs to be enforced at the controller level as well.
 		if shouldEnforceV1Block(swf) {
-			return false, "", fmt.Errorf(
+			return false, "", nextScheduledEpoch, fmt.Errorf(
 				"namespace %s is not allowed to run v1 pipelines; please migrate to KFP v2 pipelines", swf.Namespace)
 		}
 		newWorkflow, err := swf.NewWorkflow(nextScheduledEpoch, nowEpoch)
 		if err != nil {
-			return false, "", err
+			return false, "", nextScheduledEpoch, err
 		}
 
 		createdWorkflow, err := c.workflowClient.Create(ctx, swf.Namespace, newWorkflow)
 		if err != nil {
-			return false, "", err
+			return false, "", nextScheduledEpoch, err
 		}
-		return true, createdWorkflow.ExecutionName(), nil
+		return true, createdWorkflow.ExecutionName(), nextScheduledEpoch, nil
 	}
 
 	if c.tokenSrc != nil {
 		token, err := c.tokenSrc.Token()
 		if err != nil {
-			return false, "", fmt.Errorf("Failed to get a token to communicate with the REST API: %w", err)
+			return false, "", nextScheduledEpoch, fmt.Errorf("failed to get a token to communicate with the REST API: %w", err)
 		}
 
 		ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", "Bearer "+token.AccessToken)
@@ -666,7 +666,7 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	if c.multiUser {
 		// ScheduledWorkflow objects are editable by namespace users. The API server
 		// restores execution inputs from the authorized, persisted recurring run.
-		return c.createRun(ctx, swf, &api.CreateRunRequest{Run: &api.Run{
+		return c.createRun(ctx, swf, nextScheduledEpoch, &api.CreateRunRequest{Run: &api.Run{
 			RecurringRunId: string(swf.UID),
 			DisplayName:    workflowName,
 			ScheduledAt:    timestamppb.New(time.Unix(nextScheduledEpoch, 0)),
@@ -686,7 +686,7 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 
 			err := val.UnmarshalJSON([]byte(param.Value))
 			if err != nil {
-				return false, "", err
+				return false, "", nextScheduledEpoch, err
 			}
 
 			runtimeConfig.Parameters[param.Name] = val
@@ -699,11 +699,11 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	if len(swf.Spec.PluginsInput) > 0 {
 		pluginsInput, err = crdPluginsInputToProto(swf.Spec.PluginsInput)
 		if err != nil {
-			return false, "", fmt.Errorf("failed to parse plugins_input from SWF spec: %w", err)
+			return false, "", nextScheduledEpoch, fmt.Errorf("failed to parse plugins_input from SWF spec: %w", err)
 		}
 	}
 
-	return c.createRun(ctx, swf, &api.CreateRunRequest{
+	return c.createRun(ctx, swf, nextScheduledEpoch, &api.CreateRunRequest{
 		ExperimentId: swf.Spec.ExperimentId,
 		Run: &api.Run{
 			ExperimentId:   swf.Spec.ExperimentId,
@@ -723,15 +723,21 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	})
 }
 
-func (c *Controller) createRun(ctx context.Context, swf *util.ScheduledWorkflow, request *api.CreateRunRequest) (bool, string, error) {
+func (c *Controller) createRun(ctx context.Context, swf *util.ScheduledWorkflow, nextScheduledEpoch int64, request *api.CreateRunRequest) (bool, string, int64, error) {
 	run, err := c.runClient.CreateRun(ctx, request)
 	if err != nil {
-		return false, "", fmt.Errorf(
+		return false, "", nextScheduledEpoch, fmt.Errorf(
 			"failed to create a run from the scheduled workflow (%s/%s): %w", swf.Namespace, swf.Name, err,
 		)
 	}
 
-	return true, run.DisplayName, nil
+	if c.multiUser {
+		if run.GetScheduledAt() == nil || run.GetScheduledAt().CheckValid() != nil {
+			return false, "", nextScheduledEpoch, fmt.Errorf("API returned no valid scheduled time for scheduled workflow (%s/%s)", swf.Namespace, swf.Name)
+		}
+		nextScheduledEpoch = run.GetScheduledAt().AsTime().Unix()
+	}
+	return true, run.DisplayName, nextScheduledEpoch, nil
 }
 
 func (c *Controller) updateStatus(

--- a/backend/src/crd/controller/scheduledworkflow/controller_auth_header_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_auth_header_test.go
@@ -37,11 +37,15 @@ import (
 type fakeRunServiceClient struct {
 	capturedCtx     context.Context
 	capturedRequest *api.CreateRunRequest
+	response        *api.Run
 }
 
 func (f *fakeRunServiceClient) CreateRun(ctx context.Context, in *api.CreateRunRequest, opts ...grpc.CallOption) (*api.Run, error) {
 	f.capturedCtx = ctx
 	f.capturedRequest = in
+	if f.response != nil {
+		return f.response, nil
+	}
 	return &api.Run{DisplayName: "fake-run"}, nil
 }
 
@@ -117,7 +121,7 @@ func TestUserIdentityHeader_BothSet(test *testing.T) {
 	}
 
 	swf := newTestSWFForAPIPath()
-	submitted, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+	submitted, _, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
 		context.Background(), swf, 100, 200)
 
 	require.NoError(test, err)
@@ -141,7 +145,7 @@ func TestUserIdentityHeader_BothEmpty(test *testing.T) {
 	}
 
 	swf := newTestSWFForAPIPath()
-	submitted, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+	submitted, _, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
 		context.Background(), swf, 100, 200)
 
 	require.NoError(test, err)
@@ -185,7 +189,7 @@ func TestUserIdentityHeader_OnlyOneSet(test *testing.T) {
 			}
 
 			swf := newTestSWFForAPIPath()
-			submitted, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+			submitted, _, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
 				context.Background(), swf, 100, 200)
 
 			require.NoError(test, err)
@@ -214,7 +218,7 @@ func TestUserIdentityHeader_CoexistsWithBearerToken(test *testing.T) {
 	}
 
 	swf := newTestSWFForAPIPath()
-	submitted, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+	submitted, _, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
 		context.Background(), swf, 100, 200)
 
 	require.NoError(test, err)

--- a/backend/src/crd/controller/scheduledworkflow/controller_auth_header_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_auth_header_test.go
@@ -35,11 +35,13 @@ import (
 // fakeRunServiceClient captures the context passed to CreateRun so tests can
 // inspect outgoing gRPC metadata.
 type fakeRunServiceClient struct {
-	capturedCtx context.Context
+	capturedCtx     context.Context
+	capturedRequest *api.CreateRunRequest
 }
 
 func (f *fakeRunServiceClient) CreateRun(ctx context.Context, in *api.CreateRunRequest, opts ...grpc.CallOption) (*api.Run, error) {
 	f.capturedCtx = ctx
+	f.capturedRequest = in
 	return &api.Run{DisplayName: "fake-run"}, nil
 }
 
@@ -278,6 +280,7 @@ func TestNewController_InvalidUserIdentityHeader(test *testing.T) {
 		nil, // tokenSrc
 		"invalid header",
 		"some-value",
+		false, // multiUser
 	)
 	require.Error(test, err)
 	assert.Contains(test, err.Error(), "invalid userIdentityHeader")

--- a/backend/src/crd/controller/scheduledworkflow/controller_recurring_run_recovery_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_recurring_run_recovery_test.go
@@ -147,7 +147,7 @@ func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
 		DisplayName: "recovery", K8SName: "recovery", Namespace: "ns1", ExperimentId: experiment.UUID,
 		Enabled: true, MaxConcurrency: 1, NoCatchup: true,
 		Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
-			PeriodicScheduleStartTimeInSec: commonutil.Int64Pointer(90), IntervalSecond: commonutil.Int64Pointer(10),
+			PeriodicScheduleStartTimeInSec: commonutil.Int64Pointer(290), IntervalSecond: commonutil.Int64Pointer(10),
 		}},
 		PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(`{
    "apiVersion":"argoproj.io/v1alpha1", "kind":"Workflow",
@@ -165,7 +165,7 @@ func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
 	var updated *swfapi.ScheduledWorkflow
 	fakeSWF.PrependReactor("update", "scheduledworkflows", func(action ktesting.Action) (bool, runtime.Object, error) {
 		updateCount++
-		if updateCount == 1 {
+		if updateCount == 2 {
 			return true, nil, errors.New("status temporarily unavailable")
 		}
 		updated = action.(ktesting.UpdateAction).GetObject().(*swfapi.ScheduledWorkflow).DeepCopy()
@@ -180,12 +180,20 @@ func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
 		runClient:      runs, multiUser: true, location: time.UTC, time: clock,
 	}
 	key := swf.Namespace + "/" + swf.Name
+	// Establish stable conditions, labels and empty history before the first tick.
+	_, _, _, err = c.syncHandler(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, 1, updateCount)
+	require.Nil(t, runs.run)
+	require.Nil(t, updated.Status.Trigger.LastIndex)
+
+	clock.now = 300
 	_, retry, _, err := c.syncHandler(ctx, key)
 	require.ErrorContains(t, err, "status temporarily unavailable")
 	require.True(t, retry)
 	require.NotNil(t, runs.run)
 	firstRun := runs.run
-	require.Equal(t, int64(200), firstRun.ScheduledAt.Seconds)
+	require.Equal(t, int64(300), firstRun.ScheduledAt.Seconds)
 	state, err := clients.JobStore().GetRecurringRunState(job.UUID)
 	require.NoError(t, err)
 	require.False(t, state.Pending)
@@ -194,7 +202,7 @@ func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
 	// Retention or a user may delete the run while the controller is recovering.
 	require.NoError(t, manager.DeleteRun(ctx, firstRun.RunId))
 
-	clock.now = 300
+	clock.now = 400
 	again, retry, _, err := c.syncHandler(ctx, key)
 	require.NoError(t, err)
 	require.True(t, again)
@@ -204,8 +212,8 @@ func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
 	require.Equal(t, firstRun.ScheduledAt, runs.run.ScheduledAt)
 	require.NotNil(t, updated)
 	require.Equal(t, int64(1), *updated.Status.Trigger.LastIndex)
-	require.Equal(t, int64(200), updated.Status.Trigger.LastTriggeredTime.Unix(), "acknowledge the consumed tick's original API time")
-	require.Equal(t, 2, updateCount)
+	require.Equal(t, int64(300), updated.Status.Trigger.LastTriggeredTime.Unix(), "acknowledge the consumed tick's original API time")
+	require.Equal(t, 3, updateCount)
 	require.Equal(t, []string{runs.keys[0], runs.keys[0]}, runs.keys)
 	require.Zero(t, clients.ExecClientFake.GetWorkflowCount(), "acknowledgement must not recreate the deleted Workflow")
 	_, err = manager.GetRun(firstRun.RunId)
@@ -215,18 +223,18 @@ func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
 	require.Equal(t, state, afterAcknowledgement)
 
 	// The refreshed controller cursor requests a new key for the next due tick.
-	clock.now = 400
+	clock.now = 500
 	again, retry, _, err = c.syncHandler(ctx, key)
 	require.NoError(t, err)
 	require.True(t, again)
 	require.False(t, retry)
 	require.NotEqual(t, firstRun.RunId, runs.run.RunId)
-	require.Equal(t, int64(400), runs.run.ScheduledAt.Seconds)
+	require.Equal(t, int64(500), runs.run.ScheduledAt.Seconds)
 	require.NotEqual(t, runs.keys[0], runs.keys[2])
 	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
 	nextState, err := clients.JobStore().GetRecurringRunState(job.UUID)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), nextState.LastRunIndex)
-	require.Equal(t, int64(400), nextState.LastScheduledAtInSec)
+	require.Equal(t, int64(500), nextState.LastScheduledAtInSec)
 	require.False(t, nextState.Pending)
 }

--- a/backend/src/crd/controller/scheduledworkflow/controller_recurring_run_recovery_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_recurring_run_recovery_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	apicommon "github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/server"
+	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/client"
+	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	swffake "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/clientset/versioned/fake"
+	swfinformers "github.com/kubeflow/pipelines/backend/src/crd/pkg/client/informers/externalversions"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+type retryingRunServiceClient struct {
+	fakeRunServiceClient
+	calls int
+	keys  []string
+	hints []int64
+}
+
+func (f *retryingRunServiceClient) CreateRun(ctx context.Context, request *api.CreateRunRequest, opts ...grpc.CallOption) (*api.Run, error) {
+	f.calls++
+	f.keys = append(f.keys, request.Run.DisplayName)
+	f.hints = append(f.hints, request.Run.ScheduledAt.AsTime().Unix())
+	if f.calls == 1 {
+		return nil, errors.New("workflow creation temporarily failed after claim")
+	}
+	return &api.Run{DisplayName: f.keys[0], ScheduledAt: timestamppb.New(time.Unix(200, 0))}, nil
+}
+
+func TestSyncHandlerNoCatchupRetainsRequestKeyAfterSubmissionAndStatusFailures(t *testing.T) {
+	swf := newTestSWFForAPIPath()
+	swf.APIVersion = swfapi.SchemeGroupVersion.String()
+	swf.Spec.Enabled = true
+	swf.CreationTimestamp = metav1.NewTime(time.Unix(100, 0))
+	swf.Spec.NoCatchup = commonutil.BoolPointer(true)
+	swf.Spec.PeriodicSchedule = &swfapi.PeriodicSchedule{IntervalSecond: 10}
+	fakeSWF := swffake.NewSimpleClientset(swf.Get())
+	informer := swfinformers.NewSharedInformerFactory(fakeSWF, 0).Scheduledworkflow().V1beta1().ScheduledWorkflows()
+	require.NoError(t, informer.Informer().GetStore().Add(swf.Get()))
+	updates := 0
+	var updated *swfapi.ScheduledWorkflow
+	fakeSWF.PrependReactor("update", "scheduledworkflows", func(action ktesting.Action) (bool, runtime.Object, error) {
+		updates++
+		if updates == 1 {
+			return true, nil, errors.New("status update temporarily failed")
+		}
+		updated = action.(ktesting.UpdateAction).GetObject().(*swfapi.ScheduledWorkflow).DeepCopy()
+		return true, updated, nil
+	})
+	runs := &retryingRunServiceClient{}
+	c := &Controller{
+		swfClient:      client.NewScheduledWorkflowClient(fakeSWF, informer),
+		workflowClient: client.NewWorkflowClient(&fakeExecutionClient{}, &fakeExecutionInformer{}),
+		runClient:      runs, multiUser: true, location: time.UTC,
+	}
+	for i, now := range []int64{200, 300, 400} {
+		c.time = &recurringRunRecoveryClock{now: now}
+		_, retry, _, err := c.syncHandler(context.Background(), swf.Namespace+"/"+swf.Name)
+		if i < 2 {
+			require.Error(t, err)
+			require.True(t, retry)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+	require.Equal(t, []string{swf.NextResourceName(), swf.NextResourceName(), swf.NextResourceName()}, runs.keys)
+	require.Equal(t, []int64{200, 300, 400}, runs.hints)
+	require.NotNil(t, updated)
+	require.Equal(t, int64(200), updated.Status.Trigger.LastTriggeredTime.Unix())
+	require.Equal(t, int64(1), *updated.Status.Trigger.LastIndex)
+}
+
+type recurringRunRecoveryClock struct{ now int64 }
+
+func (c *recurringRunRecoveryClock) Now() time.Time { return time.Unix(c.now, 0) }
+
+type inProcessRunServiceClient struct {
+	fakeRunServiceClient
+	server *server.RunServer
+	run    *api.Run
+	keys   []string
+}
+
+func (f *inProcessRunServiceClient) CreateRun(ctx context.Context, req *api.CreateRunRequest, opts ...grpc.CallOption) (*api.Run, error) {
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(apicommon.GoogleIAPUserIdentityHeader, apicommon.GoogleIAPUserIdentityPrefix+"user@google.com"))
+	f.keys = append(f.keys, req.Run.DisplayName)
+	run, err := f.server.CreateRun(ctx, req)
+	if err == nil {
+		f.run = run
+	}
+	return run, err
+}
+
+func TestSyncHandlerAcknowledgesDeletedRunAfterStatusFailure(t *testing.T) {
+	originalMultiUser := viper.Get(apicommon.MultiUserMode)
+	originalNamespace := viper.Get(apicommon.PodNamespace)
+	originalV1Block := viper.Get(commonutil.BlockV1Pipelines)
+	viper.Set(apicommon.MultiUserMode, "true")
+	viper.Set(apicommon.PodNamespace, "ns1")
+	viper.Set(commonutil.BlockV1Pipelines, "false")
+	t.Cleanup(func() {
+		viper.Set(apicommon.MultiUserMode, originalMultiUser)
+		viper.Set(apicommon.PodNamespace, originalNamespace)
+		viper.Set(commonutil.BlockV1Pipelines, originalV1Block)
+	})
+	proxy.InitializeConfigWithEmptyForTests()
+	clock := &recurringRunRecoveryClock{now: 200}
+	clients, err := resource.NewFakeClientManager(clock, commonutil.NewUUIDGenerator())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, clients.Close()) })
+	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "recovery", Namespace: "ns1"})
+	require.NoError(t, err)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(apicommon.GoogleIAPUserIdentityHeader, apicommon.GoogleIAPUserIdentityPrefix+"user@google.com"))
+	job, err := manager.CreateJob(ctx, &model.Job{
+		DisplayName: "recovery", K8SName: "recovery", Namespace: "ns1", ExperimentId: experiment.UUID,
+		Enabled: true, MaxConcurrency: 1, NoCatchup: true,
+		Trigger: model.Trigger{PeriodicSchedule: model.PeriodicSchedule{
+			PeriodicScheduleStartTimeInSec: commonutil.Int64Pointer(90), IntervalSecond: commonutil.Int64Pointer(10),
+		}},
+		PipelineSpec: model.PipelineSpec{WorkflowSpecManifest: model.LargeText(`{
+   "apiVersion":"argoproj.io/v1alpha1", "kind":"Workflow",
+   "metadata":{"generateName":"recovery-"},
+   "spec":{"entrypoint":"main", "templates":[{"name":"main", "container":{"image":"alpine"}}]}
+  }`)},
+	})
+	require.NoError(t, err)
+	swf, err := clients.SwfClient().ScheduledWorkflow(job.Namespace).Get(ctx, job.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	fakeSWF := swffake.NewSimpleClientset()
+	informer := swfinformers.NewSharedInformerFactory(fakeSWF, 0).Scheduledworkflow().V1beta1().ScheduledWorkflows()
+	require.NoError(t, informer.Informer().GetStore().Add(swf))
+	updateCount := 0
+	var updated *swfapi.ScheduledWorkflow
+	fakeSWF.PrependReactor("update", "scheduledworkflows", func(action ktesting.Action) (bool, runtime.Object, error) {
+		updateCount++
+		if updateCount == 1 {
+			return true, nil, errors.New("status temporarily unavailable")
+		}
+		updated = action.(ktesting.UpdateAction).GetObject().(*swfapi.ScheduledWorkflow).DeepCopy()
+		require.NoError(t, informer.Informer().GetStore().Update(updated))
+		_, err := clients.SwfClient().ScheduledWorkflow(job.Namespace).Update(ctx, updated)
+		return true, updated, err
+	})
+	runs := &inProcessRunServiceClient{server: server.NewRunServer(manager, &server.RunServerOptions{CollectMetrics: false})}
+	c := &Controller{
+		swfClient:      client.NewScheduledWorkflowClient(fakeSWF, informer),
+		workflowClient: client.NewWorkflowClient(&fakeExecutionClient{}, &fakeExecutionInformer{}),
+		runClient:      runs, multiUser: true, location: time.UTC, time: clock,
+	}
+	key := swf.Namespace + "/" + swf.Name
+	_, retry, _, err := c.syncHandler(ctx, key)
+	require.ErrorContains(t, err, "status temporarily unavailable")
+	require.True(t, retry)
+	require.NotNil(t, runs.run)
+	firstRun := runs.run
+	require.Equal(t, int64(200), firstRun.ScheduledAt.Seconds)
+	state, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.False(t, state.Pending)
+	require.Equal(t, int64(1), state.LastRunIndex)
+	// The API committed the tick, but the controller has not acknowledged it.
+	// Retention or a user may delete the run while the controller is recovering.
+	require.NoError(t, manager.DeleteRun(ctx, firstRun.RunId))
+
+	clock.now = 300
+	again, retry, _, err := c.syncHandler(ctx, key)
+	require.NoError(t, err)
+	require.True(t, again)
+	require.False(t, retry)
+	require.Equal(t, firstRun.RunId, runs.run.RunId)
+	require.Equal(t, firstRun.DisplayName, runs.run.DisplayName)
+	require.Equal(t, firstRun.ScheduledAt, runs.run.ScheduledAt)
+	require.NotNil(t, updated)
+	require.Equal(t, int64(1), *updated.Status.Trigger.LastIndex)
+	require.Equal(t, int64(200), updated.Status.Trigger.LastTriggeredTime.Unix(), "acknowledge the consumed tick's original API time")
+	require.Equal(t, 2, updateCount)
+	require.Equal(t, []string{runs.keys[0], runs.keys[0]}, runs.keys)
+	require.Zero(t, clients.ExecClientFake.GetWorkflowCount(), "acknowledgement must not recreate the deleted Workflow")
+	_, err = manager.GetRun(firstRun.RunId)
+	require.Error(t, err, "acknowledgement must not recreate the deleted database row")
+	afterAcknowledgement, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, state, afterAcknowledgement)
+
+	// The refreshed controller cursor requests a new key for the next due tick.
+	clock.now = 400
+	again, retry, _, err = c.syncHandler(ctx, key)
+	require.NoError(t, err)
+	require.True(t, again)
+	require.False(t, retry)
+	require.NotEqual(t, firstRun.RunId, runs.run.RunId)
+	require.Equal(t, int64(400), runs.run.ScheduledAt.Seconds)
+	require.NotEqual(t, runs.keys[0], runs.keys[2])
+	require.Equal(t, 1, clients.ExecClientFake.GetWorkflowCount())
+	nextState, err := clients.JobStore().GetRecurringRunState(job.UUID)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), nextState.LastRunIndex)
+	require.Equal(t, int64(400), nextState.LastScheduledAtInSec)
+	require.False(t, nextState.Pending)
+}

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -288,7 +288,7 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_BlockV1AllowsV2(t *testing.T) {
 				},
 			})
 
-			submitted, workflowName, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+			submitted, workflowName, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
 				context.Background(), swf, 100, 200)
 
 			if tt.expectError != "" {
@@ -430,7 +430,7 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_MultiUserUsesPersistedRun(t *tes
 		}
 		t.Run(name, func(t *testing.T) {
 			executionClient := &fakeExecutionClient{}
-			runClient := &fakeRunServiceClient{}
+			runClient := &fakeRunServiceClient{response: &api.Run{DisplayName: "fake-run", ScheduledAt: timestamppb.New(time.Unix(80, 0))}}
 			controller := &Controller{
 				workflowClient:     client.NewWorkflowClient(executionClient, &fakeExecutionInformer{}),
 				runClient:          runClient,
@@ -454,10 +454,11 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_MultiUserUsesPersistedRun(t *tes
 				swf.Spec.Workflow.Spec = "invalid embedded workflow"
 			}
 
-			submitted, name, err := controller.submitNewWorkflowIfNotAlreadySubmitted(context.Background(), swf, 100, 200)
+			submitted, name, scheduledAt, err := controller.submitNewWorkflowIfNotAlreadySubmitted(context.Background(), swf, 100, 200)
 			require.NoError(t, err)
 			assert.True(t, submitted)
 			assert.Equal(t, "fake-run", name)
+			assert.Equal(t, int64(80), scheduledAt, "the API owns the actual scheduled time")
 			assert.Nil(t, executionClient.createdWorkflow, "multi-user schedules must never create workflows directly")
 			want := &api.CreateRunRequest{Run: &api.Run{
 				RecurringRunId: string(swf.UID),
@@ -469,6 +470,58 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_MultiUserUsesPersistedRun(t *tes
 			require.True(t, ok)
 			assert.Equal(t, []string{"Bearer controller-token"}, md.Get("authorization"))
 			assert.Equal(t, []string{controller.userIdentityValue}, md.Get("kubeflow-userid"))
+		})
+	}
+}
+
+func TestSubmitNextWorkflowUsesAPIScheduledTimeInMultiUserMode(t *testing.T) {
+	for _, multiUser := range []bool{false, true} {
+		name := "single user"
+		if multiUser {
+			name = "multi user"
+		}
+		t.Run(name, func(t *testing.T) {
+			runClient := &fakeRunServiceClient{response: &api.Run{
+				DisplayName: "scheduled-run", ScheduledAt: timestamppb.New(time.Unix(80, 0)),
+			}}
+			controller := &Controller{
+				workflowClient: client.NewWorkflowClient(&fakeExecutionClient{}, &fakeExecutionInformer{}),
+				runClient:      runClient, multiUser: multiUser, location: time.UTC,
+			}
+			swf := newTestSWFForAPIPath()
+			swf.Spec.Enabled = true
+			swf.CreationTimestamp = metav1.NewTime(time.Unix(100, 0))
+			swf.Spec.PeriodicSchedule = &swfapi.PeriodicSchedule{IntervalSecond: 60}
+			submitted, scheduledAt, err := controller.submitNextWorkflowIfNeeded(context.Background(), swf, 0, 200)
+			require.NoError(t, err)
+			require.True(t, submitted)
+			wantTime := int64(160)
+			if multiUser {
+				wantTime = 80
+			}
+			require.Equal(t, wantTime, scheduledAt)
+			swf.UpdateStatus(submitted, scheduledAt, nil, nil, time.UTC)
+			require.Equal(t, wantTime, swf.Status.Trigger.LastTriggeredTime.Unix())
+		})
+	}
+}
+
+func TestMultiUserSubmissionRejectsMissingOrInvalidAPIScheduledTime(t *testing.T) {
+	for name, timestamp := range map[string]*timestamppb.Timestamp{
+		"missing": nil,
+		"invalid": {Seconds: 253402300800},
+	} {
+		t.Run(name, func(t *testing.T) {
+			controller := &Controller{
+				workflowClient: client.NewWorkflowClient(&fakeExecutionClient{}, &fakeExecutionInformer{}),
+				runClient: &fakeRunServiceClient{response: &api.Run{
+					DisplayName: "scheduled-run", ScheduledAt: timestamp,
+				}},
+				multiUser: true,
+			}
+			submitted, _, _, err := controller.submitNewWorkflowIfNotAlreadySubmitted(context.Background(), newTestSWFForAPIPath(), 100, 200)
+			require.ErrorContains(t, err, "no valid scheduled time")
+			require.False(t, submitted)
 		})
 	}
 }

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
+
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/client"
@@ -26,6 +29,9 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -414,4 +420,55 @@ func TestCrdPluginsInputToProto(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid plugins_input entry")
 	})
+}
+
+func TestSubmitNewWorkflowIfNotAlreadySubmitted_MultiUserUsesPersistedRun(t *testing.T) {
+	for _, embedded := range []bool{false, true} {
+		name := "pipeline reference"
+		if embedded {
+			name = "embedded workflow"
+		}
+		t.Run(name, func(t *testing.T) {
+			executionClient := &fakeExecutionClient{}
+			runClient := &fakeRunServiceClient{}
+			controller := &Controller{
+				workflowClient:     client.NewWorkflowClient(executionClient, &fakeExecutionInformer{}),
+				runClient:          runClient,
+				multiUser:          true,
+				tokenSrc:           &fakeTokenSource{token: "controller-token"},
+				userIdentityHeader: "kubeflow-userid",
+				userIdentityValue:  "system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow",
+			}
+			swf := newTestSWFForAPIPath()
+			swf.Spec.ExperimentId = "untrusted-experiment"
+			swf.Spec.PipelineId = "untrusted-pipeline"
+			swf.Spec.PipelineVersionId = "untrusted-version"
+			swf.Spec.ServiceAccount = "privileged-account"
+			swf.Spec.Workflow.PipelineRoot = "s3://untrusted-root"
+			// Invalid inputs must not even be parsed on the multi-user path.
+			swf.Spec.Workflow.Parameters = []swfapi.Parameter{{Name: "command", Value: "invalid json"}}
+			swf.Spec.PluginsInput = map[string]apiextensionsv1.JSON{
+				"plugin": {Raw: []byte("invalid json")},
+			}
+			if embedded {
+				swf.Spec.Workflow.Spec = "invalid embedded workflow"
+			}
+
+			submitted, name, err := controller.submitNewWorkflowIfNotAlreadySubmitted(context.Background(), swf, 100, 200)
+			require.NoError(t, err)
+			assert.True(t, submitted)
+			assert.Equal(t, "fake-run", name)
+			assert.Nil(t, executionClient.createdWorkflow, "multi-user schedules must never create workflows directly")
+			want := &api.CreateRunRequest{Run: &api.Run{
+				RecurringRunId: string(swf.UID),
+				DisplayName:    swf.NextResourceName(),
+				ScheduledAt:    timestamppb.New(time.Unix(100, 0)),
+			}}
+			assert.True(t, proto.Equal(want, runClient.capturedRequest), "unexpected request: %v", runClient.capturedRequest)
+			md, ok := metadata.FromOutgoingContext(runClient.capturedCtx)
+			require.True(t, ok)
+			assert.Equal(t, []string{"Bearer controller-token"}, md.Get("authorization"))
+			assert.Equal(t, []string{controller.userIdentityValue}, md.Get("kubeflow-userid"))
+		})
+	}
 }

--- a/backend/src/crd/controller/scheduledworkflow/main.go
+++ b/backend/src/crd/controller/scheduledworkflow/main.go
@@ -55,6 +55,7 @@ var (
 	recurringRunResyncIntervalSeconds int
 	userIdentityHeader                string
 	userIdentityValue                 string
+	multiUser                         bool
 )
 
 const (
@@ -154,6 +155,7 @@ func main() {
 		tokenSrc,
 		userIdentityHeader,
 		userIdentityValue,
+		multiUser,
 	)
 	if err != nil {
 		log.Fatalf("Failed to instantiate the controller: %v", err)
@@ -211,6 +213,7 @@ func init() {
 	flag.StringVar(&caCertPath, caCertPathFlagName, "", "CA cert to connect to the ML pipeline API server.")
 	flag.IntVar(&clientBurst, "clientBurst", 10, "Maximum burst for throttle from this client.")
 	flag.IntVar(&recurringRunResyncIntervalSeconds, "recurringRunResyncIntervalSeconds", 30, "The full resync interval in seconds for recurring run reconciliations.")
+	flag.BoolVar(&multiUser, "multiUser", false, "Submit all scheduled runs through the API server using persisted recurring-run inputs.")
 	flag.StringVar(&userIdentityHeader, "userIdentityHeader", "", "User identity metadata key for multi-user mode (e.g. kubeflow-userid). If set, the controller injects this key into the outgoing gRPC metadata when calling the API server. The key is normalized to lowercase and must be a valid gRPC metadata key.")
 	flag.StringVar(&userIdentityValue, "userIdentityValue", "", "Value for the user identity gRPC metadata key (e.g. system:serviceaccount:kubeflow:ml-pipeline-scheduledworkflow).")
 	var err error

--- a/backend/test/v2/integration/recurring_run_service_account_test.go
+++ b/backend/test/v2/integration/recurring_run_service_account_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/eapache/go-resiliency/retrier"
+	experiment_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/experiment_client/experiment_service"
+	upload_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
+	recurring_run_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/recurring_run_client/recurring_run_service"
+	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/recurring_run_model"
+	run_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_client/run_service"
+	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_model"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	test "github.com/kubeflow/pipelines/backend/test/v2"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+// TestRecurringRunCustomServiceAccount requires a multi-user installation with
+// KFP_SCHEDULE_TEST_SERVICE_ACCOUNT naming an existing custom runner in the test
+// resource namespace. Allowlist that account and grant serviceaccounts/use on
+// that exact account to both the test API caller and scheduled-workflow controller.
+// The runner needs normal pipeline execution permissions; the test Kubernetes
+// identity needs get/list/update on ScheduledWorkflows to exercise CR tampering.
+func (s *RecurringRunApiTestSuite) TestRecurringRunCustomServiceAccount() {
+	t := s.T()
+	serviceAccount := os.Getenv("KFP_SCHEDULE_TEST_SERVICE_ACCOUNT")
+	if !*isKubeflowMode || serviceAccount == "" {
+		t.Skip("requires multi-user mode and KFP_SCHEDULE_TEST_SERVICE_ACCOUNT")
+	}
+	defer s.cleanUp()
+
+	pipeline, err := s.pipelineUploadClient.UploadFile("../resources/arguments-parameters.yaml", upload_params.NewUploadPipelineParams())
+	require.NoError(t, err)
+	// Pipeline-version creation timestamps have second precision.
+	time.Sleep(time.Second)
+	version, err := s.pipelineUploadClient.UploadPipelineVersion("../resources/arguments-parameters.yaml", &upload_params.UploadPipelineVersionParams{
+		Name:       util.StringPointer("authorized-schedule-version"),
+		Pipelineid: util.StringPointer(pipeline.PipelineID),
+	})
+	require.NoError(t, err)
+
+	for _, pinned := range []bool{false, true} {
+		name := "latest"
+		if pinned {
+			name = "pinned"
+		}
+		s.Run(name, func() {
+			t := s.T()
+			experiment, err := s.experimentClient.Create(&experiment_params.ExperimentServiceCreateExperimentParams{
+				Experiment: test.MakeExperiment("authorized-schedule-"+name, "", s.resourceNamespace),
+			})
+			require.NoError(t, err)
+			reference := &recurring_run_model.V2beta1PipelineVersionReference{PipelineID: pipeline.PipelineID}
+			if pinned {
+				reference.PipelineVersionID = version.PipelineVersionID
+			}
+			schedule, err := s.recurringRunClient.Create(&recurring_run_params.RecurringRunServiceCreateRecurringRunParams{
+				RecurringRun: &recurring_run_model.V2beta1RecurringRun{
+					DisplayName:              "authorized-schedule-" + name,
+					ExperimentID:             experiment.ExperimentID,
+					PipelineVersionReference: reference,
+					RuntimeConfig: &recurring_run_model.V2beta1RuntimeConfig{Parameters: map[string]interface{}{
+						"param1": "authorized", "param2": "schedule",
+					}},
+					ServiceAccount: serviceAccount,
+					MaxConcurrency: 1,
+					Mode:           recurring_run_model.RecurringRunModeDISABLE.Pointer(),
+				},
+			})
+			require.NoError(t, err)
+
+			// The UID binds a CR to its API recurring run; never select by a user label.
+			workflowClient := s.swfClient.ScheduledWorkflow(s.resourceNamespace)
+			workflows, err := workflowClient.List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			workflowName := ""
+			for _, workflow := range workflows.Items {
+				if string(workflow.UID) == schedule.RecurringRunID {
+					workflowName = workflow.Name
+					break
+				}
+			}
+			require.NotEmpty(t, workflowName, "the disabled schedule must have a backing ScheduledWorkflow")
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				workflow, err := workflowClient.Get(context.Background(), workflowName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				workflow.Spec.ServiceAccount = "tampered-schedule-account"
+				workflow.Spec.PipelineId = "tampered-pipeline-id"
+				workflow.Spec.PipelineVersionId = "tampered-version-id"
+				if workflow.Spec.Workflow == nil {
+					workflow.Spec.Workflow = &swfapi.WorkflowResource{}
+				}
+				workflow.Spec.Workflow.Parameters = []swfapi.Parameter{{Name: "param1", Value: `"tampered"`}}
+				_, err = workflowClient.Update(context.Background(), workflow)
+				return err
+			})
+			require.NoError(t, err)
+			require.NoError(t, s.recurringRunClient.Enable(&recurring_run_params.RecurringRunServiceEnableRecurringRunParams{
+				RecurringRunID: schedule.RecurringRunID,
+			}))
+
+			patched, err := workflowClient.Get(context.Background(), workflowName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, "tampered-schedule-account", patched.Spec.ServiceAccount)
+			require.Equal(t, "tampered-pipeline-id", patched.Spec.PipelineId)
+
+			var executed *run_model.V2beta1Run
+			err = retrier.New(retrier.ConstantBackoff(120, 5*time.Second), nil).Run(func() error {
+				runs, _, _, err := s.runClient.List(&run_params.RunServiceListRunsParams{ExperimentID: util.StringPointer(experiment.ExperimentID)})
+				if err != nil {
+					return err
+				}
+				if len(runs) != 1 {
+					return fmt.Errorf("expected one scheduled run, got %d", len(runs))
+				}
+				executed = runs[0]
+				if executed.State == nil {
+					return fmt.Errorf("scheduled run %s has no state yet", executed.RunID)
+				}
+				if *executed.State != run_model.V2beta1RuntimeStateSUCCEEDED {
+					return fmt.Errorf("scheduled run %s has not succeeded: %s", executed.RunID, *executed.State)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, schedule.RecurringRunID, executed.RecurringRunID)
+			require.Equal(t, serviceAccount, executed.ServiceAccount)
+			require.NotNil(t, executed.RuntimeConfig)
+			require.Equal(t, "authorized", executed.RuntimeConfig.Parameters["param1"])
+			require.Equal(t, "schedule", executed.RuntimeConfig.Parameters["param2"])
+			require.NotNil(t, executed.PipelineVersionReference)
+			require.Equal(t, pipeline.PipelineID, executed.PipelineVersionReference.PipelineID)
+			require.Equal(t, version.PipelineVersionID, executed.PipelineVersionReference.PipelineVersionID)
+		})
+	}
+}

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -7,6 +7,7 @@ Documentation for operators deploying and configuring Kubeflow Pipelines.
 
 installation
 server-config
+scheduled-service-accounts
 multi-user
 configure-object-store
 mlflow-plugin

--- a/docs/operator-guides/scheduled-service-accounts.md
+++ b/docs/operator-guides/scheduled-service-accounts.md
@@ -37,6 +37,13 @@ selected pipeline version, and run identity, with a deterministic workflow name
 to prevent duplicate executions. Saving the run also completes its pending tick
 in the same database transaction.
 
+If that run is deleted before the controller records the successful submission,
+retrying the same tick returns its retained identity and timestamps with an
+unspecified runtime state. This acknowledgement advances the controller without
+recreating the deleted run or workflow, and still requires the normal permissions.
+Recurring-run request keys (the run display names) must contain at most 255
+characters so the run and its scheduling state can both be stored.
+
 Single-user controller behavior remains unchanged. In a custom multi-user
 installation, explicitly set `--multiUser=true`; authentication headers or bearer
 tokens alone do not enable this execution mode.

--- a/docs/operator-guides/scheduled-service-accounts.md
+++ b/docs/operator-guides/scheduled-service-accounts.md
@@ -41,6 +41,9 @@ If that run is deleted before the controller records the successful submission,
 retrying the same tick returns its retained identity and timestamps with an
 unspecified runtime state. This acknowledgement advances the controller without
 recreating the deleted run or workflow, and still requires the normal permissions.
+For a follow-latest schedule, acknowledgement of a retained or deleted run does
+not require its original pipeline version to remain available. The schedule
+resolves the current version again for its next tick.
 Recurring-run request keys (the run display names) must contain at most 255
 characters so the run and its scheduling state can both be stored.
 

--- a/docs/operator-guides/scheduled-service-accounts.md
+++ b/docs/operator-guides/scheduled-service-accounts.md
@@ -1,0 +1,126 @@
+# Service accounts for recurring runs
+
+A recurring run is a standing authorization to execute a stored pipeline with
+its stored parameters, pipeline root, plugin inputs, and service account.
+Creating it does not grant its creator new service-account permissions.
+
+For a non-default service account, the API server requires its name in the
+comma-separated `ALLOWEDSERVICEACCOUNTS` configuration. In multi-user mode it
+also checks the caller's `use` permission on that exact `serviceaccounts` resource
+in the execution namespace. The configured default pipeline runner remains
+exempt from the additional service-account check.
+
+## Multi-user execution
+
+The ScheduledWorkflow controller submits each execution as its own identity.
+Consequently, both the creating user and the controller need permission to use
+the selected custom account. The controller does not impersonate the creator,
+and supplying a recurring-run ID does not bypass the caller's authorization.
+
+The multi-user manifests set `MULTIUSER=true` on the controller, enabling its
+`--multiUser=true` mode. Every schedule, including a pinned or inline workflow,
+then goes through the API. The API resolves execution inputs from the stored job,
+checks its namespace and backing Kubernetes UID, and checks that it is enabled.
+Changes to execution fields in the Kubernetes `ScheduledWorkflow` cannot change
+which pipeline, parameters, account, or plugin inputs the API executes. Controller
+reports update status only in multi-user mode. To change a recurring run's
+specification, recreate it through the API; use the API to enable or disable it.
+
+Single-user controller behavior remains unchanged. In a custom multi-user
+installation, explicitly set `--multiUser=true`; authentication headers or bearer
+tokens alone do not enable this execution mode.
+
+## Grant access to an approved custom account
+
+Do not grant the controller cluster-wide `use` access to all service accounts.
+For each approved namespace/account pair, create a namespaced Role and bind it
+to the authorized user and the actual controller service account. For example,
+replace the names below with the installation's identities:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: use-approved-pipeline-runner
+  namespace: team-a
+rules:
+  - apiGroups: [""]
+    resources: [serviceaccounts]
+    resourceNames: [approved-pipeline-runner]
+    verbs: [use]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: approved-pipeline-runner-user
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-approved-pipeline-runner
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: user@example.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: approved-pipeline-runner-controller
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-approved-pipeline-runner
+subjects:
+  - kind: ServiceAccount
+    name: ml-pipeline-scheduledworkflow
+    namespace: kubeflow
+```
+
+Add `approved-pipeline-runner` to the API server's `ALLOWEDSERVICEACCOUNTS` value
+and retain any other deliberately approved names. This name-based allowlist does
+not grant namespace access: the namespaced Role above supplies that restriction.
+The runner separately needs its normal pipeline execution permissions.
+
+## Upgrade and revocation
+
+Upgrade the API server and the ScheduledWorkflow controller together, apply the
+release RBAC, and wait for old controller pods to stop before adding custom-account
+grants. The release controller also needs the documented pipeline-read grants;
+apply the complete release manifests rather than only changing images.
+
+Review existing schedules before granting controller access to an account.
+Schedules created before service-account authorization, or whose inputs were
+previously changed through Kubernetes, must be reviewed and recreated through the
+API to establish authorized inputs. Multi-user schedules created only as Kubernetes
+CRs, without a corresponding API job, must also be recreated through the API.
+Unresolvable namespaces or missing/replaced Kubernetes objects fail closed.
+
+A follow-latest schedule intentionally executes future versions of its referenced
+pipeline. Trust publishers of that pipeline to supply code running under the
+schedule's approved account, or pin a reviewed version instead. Users who can
+create arbitrary Kubernetes Workflows or Pods may already be able to execute as
+other accounts; this API control does not replace Kubernetes admission policies
+for that separate access path.
+
+Removing the creator's `use` permission does not revoke an existing standing
+schedule. Disable or delete the recurring run through the API to stop future
+executions. Removing the controller's account-specific `use` grant, or removing
+the account from the allowlist, also prevents subsequent API submissions under
+that custom account. Already-created runs continue; terminate them separately if
+required. Retain the normal permission checks when troubleshooting a denied tick.
+
+## Scheduling regression test
+
+The live integration suite includes an opt-in test for both latest and pinned
+custom-account schedules. It modifies the backing CR before activation and checks
+that the run succeeds with the original API-stored account and parameters.
+
+On a disposable multi-user test installation, provision a custom runner using the
+scoped grants above for the integration-test caller and controller. Set
+`KFP_SCHEDULE_TEST_SERVICE_ACCOUNT` to that account, and run the existing v2
+integration suite with the installation's usual endpoint/authentication flags and
+`-run '^TestRecurringRunApi$' -testify.m '^TestRecurringRunCustomServiceAccount$'`.
+The test requires permission to list and update ScheduledWorkflows and cleans up
+pipeline resources in the test namespace; do not run it against production.

--- a/docs/operator-guides/scheduled-service-accounts.md
+++ b/docs/operator-guides/scheduled-service-accounts.md
@@ -151,3 +151,57 @@ integration suite with the installation's usual endpoint/authentication flags an
 `-run '^TestRecurringRunApi$' -testify.m '^TestRecurringRunCustomServiceAccount$'`.
 The test requires permission to list and update ScheduledWorkflows and cleans up
 pipeline resources in the test namespace; do not run it against production.
+
+## Temporary audit mode for migration
+
+Service-account authorization is enforced by default in 2.18.0, including on
+upgrades. Administrators can temporarily set the API server environment variable
+`SERVICEACCOUNTAUTHORIZATIONMODE=audit` while configuring the allowlist and scoped
+RBAC grants described above. The only supported modes are `enforce` and `audit`;
+unset or empty configuration means `enforce`, and invalid values are rejected.
+
+**Audit mode restores the security exposure addressed by service-account
+authorization.** It evaluates the allowlist and, in multi-user mode, the caller's
+`serviceaccounts/use` permission, but allows policy denials. It logs a startup
+warning and warning events prefixed with `service_account_authorization_audit`
+containing the failed check, namespace, and requested service account. These
+events describe a bypassed check, not confirmation that the overall request
+succeeded. They do not include pipeline inputs, tokens, or the configured
+allowlist. Authentication failures and authorization-service errors still reject
+the request.
+
+This is an administrator deployment setting, not a request or ScheduledWorkflow
+field. Apply the same configuration to every API server replica and complete the
+rollout before relying on a mode change. For example, with the standard deployment:
+
+```bash
+kubectl -n kubeflow set env deployment/ml-pipeline SERVICEACCOUNTAUTHORIZATIONMODE=audit
+kubectl -n kubeflow rollout status deployment/ml-pipeline
+```
+
+Persist the setting in your deployment configuration if using GitOps. No separate
+controller audit setting is needed: the upgraded multi-user controller submits
+scheduled runs through the API server, which applies the same mode on each tick
+and replay. Keep the controller in multi-user mode. Audit does not restore
+CR-only schedules, trust CR edits to execution inputs, or bypass namespace
+permissions, schedule identity checks, or disabled-schedule checks. Single-user
+mode still evaluates the allowlist; its existing lack of user RBAC checks is
+unchanged.
+
+Use audit events to configure the required allowlist and narrowly scoped user
+and controller grants. Exercise both immediate runs and each recurring run's
+execution path, then restore enforcement:
+
+```bash
+kubectl -n kubeflow set env deployment/ml-pipeline SERVICEACCOUNTAUTHORIZATIONMODE=enforce
+kubectl -n kubeflow rollout status deployment/ml-pipeline
+```
+
+Verify both run types succeed under enforcement before completing migration.
+An absence of audit warnings alone does not prove that unexercised schedules are
+ready. Removing the opt-out does not stop runs already executing.
+
+We plan to remove audit mode in **3.0.0**, tracked in
+[#14367](https://github.com/kubeflow/pipelines/issues/14367). Deployments using audit
+mode remain exposed even though version-based vulnerability scanners may identify
+2.18.0 as patched.

--- a/docs/operator-guides/scheduled-service-accounts.md
+++ b/docs/operator-guides/scheduled-service-accounts.md
@@ -26,9 +26,22 @@ which pipeline, parameters, account, or plugin inputs the API executes. Controll
 reports update status only in multi-user mode. To change a recurring run's
 specification, recreate it through the API; use the API to enable or disable it.
 
+The API also owns durable scheduling state, initialized when a recurring run is
+created through the API. It computes the actual scheduled time from the stored
+trigger and catch-up policy, ignoring the timestamp supplied by the controller,
+and enforces the stored maximum concurrency. Editing the CR's trigger, concurrency,
+or scheduling counters may cause submissions to be rejected; it cannot authorize
+earlier or additional executions. The API records a pending tick's index and time
+before submitting it. A retry of that tick retains its index, scheduled time,
+selected pipeline version, and run identity, with a deterministic workflow name
+to prevent duplicate executions. Saving the run also completes its pending tick
+in the same database transaction.
+
 Single-user controller behavior remains unchanged. In a custom multi-user
 installation, explicitly set `--multiUser=true`; authentication headers or bearer
 tokens alone do not enable this execution mode.
+Set the same `CRON_SCHEDULE_TIMEZONE` on the API server and controller; the supplied
+manifests use `pipeline-install-config.cronScheduleTimezone` for both.
 
 ## Grant access to an approved custom account
 
@@ -95,6 +108,8 @@ Schedules created before service-account authorization, or whose inputs were
 previously changed through Kubernetes, must be reviewed and recreated through the
 API to establish authorized inputs. Multi-user schedules created only as Kubernetes
 CRs, without a corresponding API job, must also be recreated through the API.
+Existing schedules that predate API-owned scheduling state must be recreated as
+well; the API does not initialize trusted counters from an existing CR's status.
 Unresolvable namespaces or missing/replaced Kubernetes objects fail closed.
 
 A follow-latest schedule intentionally executes future versions of its referenced
@@ -116,6 +131,8 @@ required. Retain the normal permission checks when troubleshooting a denied tick
 The live integration suite includes an opt-in test for both latest and pinned
 custom-account schedules. It modifies the backing CR before activation and checks
 that the run succeeds with the original API-stored account and parameters.
+Backend regression tests also cover rejected scheduling-state tampering and
+retries that preserve the pending tick's execution identity.
 
 On a disposable multi-user test installation, provision a custom runner using the
 scoped grants above for the integration-test caller and controller. Set

--- a/docs/operator-guides/server-config.md
+++ b/docs/operator-guides/server-config.md
@@ -111,3 +111,9 @@ spec:
         - name: NO_PROXY
           value: localhost,127.0.0.1,.svc.cluster.local,kubernetes.default.svc,metadata-grpc-service,0,1,2,3,4,5,6,7,8,9
 ```
+
+## Recurring runs and custom service accounts
+
+See [Service accounts for recurring runs](scheduled-service-accounts.md) for
+`ALLOWEDSERVICEACCOUNTS`, scoped controller grants, multi-user upgrade requirements,
+and revoking scheduled execution.

--- a/docs/operator-guides/server-config.md
+++ b/docs/operator-guides/server-config.md
@@ -7,6 +7,79 @@ customizations are available for more advanced usage.
 When deploying Kubeflow Pipelines servers, you can pass various environment variables
 to customize the behavior of servers.
 
+## API Server workflow service-account checks
+
+By default, the API server enforces the service-account policy for all identities
+it finds in a workflow before creating a run or recurring run, retrying a run, or
+re-enabling an embedded recurring workflow. It also checks again after plugins
+modify a new run. Non-default accounts must be listed in `ALLOWEDSERVICEACCOUNTS`;
+in multi-user mode, the caller must additionally have `use` permission on those
+`serviceaccounts`. The configured default pipeline runner retains its existing
+exemption.
+
+### Audit mode for rollout
+
+`WORKFLOW_SERVICE_ACCOUNT_AUDIT` defaults to `false`. Set it to `"true"` on the
+`ml-pipeline` API server deployment to observe the **additional** identity checks
+without blocking on their findings:
+
+```yaml
+env:
+  - name: WORKFLOW_SERVICE_ACCOUNT_AUDIT
+    value: "true"
+```
+
+Audit mode still enforces the workflow's main service account, including Kubernetes'
+`default` account if the main field is empty. Failures involving
+other accounts, including accounts introduced by plugins or retained retry state,
+produce `Workflow service account audit:` warning logs and execution continues.
+These accounts can therefore run without passing the expanded policy while audit
+mode is enabled. Use this option temporarily to assess compatibility, then unset
+it or set it to `"false"` to enforce the checks. It applies to both V1 and V2.
+
+Warnings include the operation, namespace, workflow name or generated-name prefix,
+run ID when available, account name when known, and one of these findings:
+
+| Finding | Meaning |
+| --- | --- |
+| `account_not_allowed` | The additional account is not allowed or its name is not literal. |
+| `account_denied` | Kubernetes denied the caller permission to use the additional account. |
+| `authorization_error` | Authorization of the additional account could not be completed. |
+| `inspection_incomplete` | The workflow's identities could not be fully collected, for example because a patch is dynamic or uses noncanonical account fields. |
+
+An inspection failure stops collection, so `inspection_incomplete` is **not** a
+complete account inventory and later violations may not be reported. Review that
+workflow's templates, pod patches and retained execution state before enabling
+enforcement. Audit warnings do not include manifests, patch contents or raw error
+payloads. Logs may repeat across lifecycle operations and the post-plugin check.
+
+Audit mode does not bypass ordinary workflow validation: fresh submissions still
+reject external template references and discard caller-supplied workflow status.
+On retained workflows checked during retry or re-enable, an external reference
+instead produces an `inspection_incomplete` warning in audit mode. Existing enabled
+embedded schedules are not automatically inspected; re-enabling them triggers the
+check. Running workloads are not retroactively reauthorized.
+
+### V1 and V2 compatibility
+
+**V1 / raw Argo workflows:** this is the main compatibility change. Enforcement
+requires literal service-account names and canonical `serviceAccountName` or
+`serviceAccount` fields in pod patches. Dynamic `podSpecPatch` expressions are
+rejected even when they only affect resources. Every declared template is checked,
+including unused templates and overridden settings. External templates must be
+inlined. Submitted workflow status is ignored, so entrypoints must be defined in
+the submitted spec. Audit mode can help identify additional-account and patch
+inspection failures, but the validation and status rules still apply.
+
+**V2 / compiler-generated workflows:** the compiler's exact
+`{{inputs.parameters.pod-spec-patch}}` placeholder remains supported because the
+KFP driver constructs the runtime patch without selecting a service account.
+Literal accounts elsewhere in the workflow are still checked. V2 creation,
+plugin processing, retries and recurring runs use the same enforcement or audit
+mode as V1. V2 recurring runs remain retryable when their persisted records contain
+both the source pipeline spec and the compiled workflow manifest. Audit mode is
+not normally needed solely for the compiler-generated patch.
+
 ## Frontend Server
 
 When deploying frontend server called `ml-pipeline-ui`, you can pass various environment

--- a/docs/operator-guides/server-config.md
+++ b/docs/operator-guides/server-config.md
@@ -117,3 +117,12 @@ spec:
 See [Service accounts for recurring runs](scheduled-service-accounts.md) for
 `ALLOWEDSERVICEACCOUNTS`, scoped controller grants, multi-user upgrade requirements,
 and revoking scheduled execution.
+
+### Service-account authorization migration mode
+
+`SERVICEACCOUNTAUTHORIZATIONMODE` accepts `enforce` (default, including upgrades)
+or `audit`. Audit temporarily allows service-account policy denials and logs
+warnings, restoring the associated security exposure. It does not disable
+existing authentication or namespace authorization. See the
+[scope, rollout, and migration instructions](scheduled-service-accounts.md#temporary-audit-mode-for-migration).
+Audit mode is planned for removal in 3.0.0 ([#14367](https://github.com/kubeflow/pipelines/issues/14367)).

--- a/manifests/kustomize/base/installs/multi-user/scheduled-workflow/deployment-patch.yaml
+++ b/manifests/kustomize/base/installs/multi-user/scheduled-workflow/deployment-patch.yaml
@@ -8,6 +8,8 @@ spec:
       containers:
       - name: ml-pipeline-scheduledworkflow
         env:
+        - name: MULTIUSER
+          value: "true"
         - name: NAMESPACE
           value: '' # Empty namespace lets viewer controller watch all namespaces
           valueFrom: null # HACK: https://github.com/kubernetes-sigs/kustomize/issues/2606

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -118,6 +118,11 @@ spec:
             # Driver / launcher log level during pipeline execution
             - name: PIPELINE_LOG_LEVEL
               value: "1"
+            - name: CRON_SCHEDULE_TIMEZONE
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: cronScheduleTimezone
             - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
**Description of your changes:**

Secure custom-service-account recurring runs by enforcing both the caller's permissions and the API-created schedule's authorized inputs. Mutable ScheduledWorkflow resources cannot select a different pipeline, account, parameter expansion, or scheduling policy for execution under the controller's grant.

In multi-user mode:

- Route every schedule, including embedded V1/V2 workflows, through the API. Restore stored pipeline, parameter, root, plugin and effective service-account inputs; validate namespace, experiment, live Kubernetes identity and enabled state. Preserve normal pipeline/namespace authorization and enforce the account allowlist and caller `serviceaccounts/use` check by default, including replays.
- Keep controller reports status-only. Use API-owned durable state to allocate indices and calculate execution times from the stored trigger and catch-up policy. Serialize reservations against stored maximum concurrency. Pending retries retain their selected pipeline version, timestamps and run identity.
- Use deterministic Kubernetes workflow names and validate `AlreadyExists` identities. Save the run and complete its pending tick in one transaction, including persistence-agent recovery, so database deduplication cannot hide duplicate workflow execution.
- Acknowledge consumed follow-latest ticks even if their original pipeline version has been deleted, whether the run is retained or deleted. Preserve authorization against the API-stored job account, including persistence-agent recovery, and persist trigger-only controller progress without recreating resources. Reject request keys that cannot fit the run display-name column before reserving a tick.
- Requests that find an existing Workflow wait for its creator or persistence agent to persist the run, preserving the creator's plugin metadata. Record plugin parent IDs on the execution so a concurrent losing request can finalize its distinct parents without touching shared parents or overwriting stored plugin output.
- Have the controller use the API's returned scheduled timestamp and configure both processes with the same cron timezone. Preserve nested parameter macros, embedded V1 accounts and plugin-enabled account overrides.

Single-user recurring-run retries return the retained run before resolving the current schedule or template. Account checks use the original execution identity, including stored runtime manifests for recovered rows. Retries do not repeat plugin hooks or workflow creation; new tick keys still validate the current template.

The operator guide supplies namespace/account-scoped grants. There is no scheduler-specific authorization exemption or unconditional controller permission expansion.

**Temporary audit mode:** `KFP_SECURITY_SERVICE_ACCOUNT_MODE=enforce` is the default, including upgrades. Administrators may explicitly select `audit` to evaluate and log allowlist and `serviceaccounts/use` policy denials while permitting those operations. Authentication, namespace authorization, authorization-service failures, and stored schedule protections remain enforced. One API-server setting covers immediate submissions, schedule creation, scheduled ticks, and replay; no controller bypass flag is introduced. Invalid modes are rejected. Startup and per-check warnings identify the exposure without logging pipeline inputs, credentials, or the allowlist. Audit mode restores the associated security exposure and is planned for removal in 3.0.0, tracked in #14367.

**Integrated workflow identity policy:** This branch now includes #14356. `KFP_SECURITY_WORKFLOW_IDENTITY_MODE=enforce|audit` independently controls additional identities and incomplete local inspection; both modes default to enforcement and replace the unreleased names without aliases. Main-account audit cannot relax expanded enforcement, and workflow audit cannot relax main-account enforcement. All SAR evaluation/transport errors remain blocking, even with both controls in audit. Templated main-account names remain invalid.

Preserve rendered identities during schedule creation even when plugins require a generic ScheduledWorkflow. Check expanded identities before claiming a new tick, after plugin mutation, and before a retry claim. A post-plugin denial can leave a tick pending for correction and retry. Retained/recovered acknowledgements inspect available runtime identities; metadata-only acknowledgements never reconstruct deleted pipelines or create executions. Existing ownership, authoritative schedule state, concurrency, replay deduplication, and plugin cleanup protections remain intact.

Merge #14356 first, then this integration; backport the combined behavior to `release-2.18` through #14409. See the independent mode matrix and scoped helper-account grants in the operator guide. Release acceptance remains tracked in #14421.

**Migration:** Upgrade API server and controller together and stop old controller pods before granting custom-account access. Recreate schedules that predate API-owned scheduling state; the API does not import trusted counters from editable CR status. Review legacy inputs/accounts before recreation. Multi-user CR-only schedules must be recreated through the API, and specification changes require API recreation. Existing schedules remain standing delegations: revoke the controller's scoped account grant or disable/delete the schedule to prevent future submissions. Custom installations must enable `--multiUser=true` and use matching API/controller cron timezones. Audit mode eases migration of the new service-account policy only; it does not restore CR-only schedules or trust CR edits. Configure all API replicas consistently, complete the rollout, and validate both immediate and recurring runs under enforcement before completing migration.

**Validation:**

- Complete Go suites passed for API main/common/resources/server/template, common util, and ScheduledWorkflow controller. The final resource suite and combined-mode regressions passed after integration.
- Regression coverage includes CR input/counter/policy tampering, denied/revoked replay, stored concurrency, catch-up policy, non-UTC cron, concurrent V1/V2 ticks, fixed-name V1 templates, pending-version recovery, transactional completion and persistence-agent recovery.
- In-process recovery tests connect the controller to the API and database after stable pre-due reconciliation, failed status writes and run deletion, then verify the next tick executes. Additional tests cover retained/deleted run acknowledgement after historical-version deletion, replay authorization for reporter-recovered runs, request-key character boundaries, distinct/shared plugin parents and lost Workflow-creation responses.
- Single-user replay regressions cover incompatible latest versions, deleted pinned versions, retained-account allowlist checks, unchanged stored output and zero repeated plugin hooks. Stored-identity tests cover both runtime fields and missing/malformed recovery metadata.
- Audit-mode regressions cover default enforcement, explicit opt-out, invalid modes, authentication/SAR failures, unrelated permission denials, and a scheduled tick migrating from audit to enforcement followed by permission revocation.
- Added four-way mode composition, main/helper SAR failures (including allowed-with-evaluation-error), audit-to-enforce tick/replay, recovered runtime identity, and templated-main-account regression coverage.
- Diff-scoped affected-package golangci-lint: 0 issues; applicable pre-commit checks passed.
- Full Sphinx documentation build passed with warnings treated as errors; multi-user deployment timezone wiring verified.
- The opt-in live multi-user custom-account integration suite compiled. It was not executed against a full KFP installation; provisioning and invocation are documented.

**Checklist:**

- [x] Commits are DCO signed off.
- [x] PR title follows the repository convention.
