### PR TITLE
docs: hyphenate "end to end" in Pipelines README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 The Kubeflow pipelines service has the following goals:
 
-* End to end orchestration: enabling and simplifying the orchestration of end to end machine learning pipelines
+* End-to-end orchestration: enabling and simplifying the orchestration of end-to-end machine learning pipelines
 * Easy experimentation: making it easy for you to try numerous ideas and techniques, and manage your various trials/experiments.
-* Easy re-use: enabling you to re-use components and pipelines to quickly cobble together end to end solutions, without having to re-build each time.
+* Easy re-use: enabling you to re-use components and pipelines to quickly cobble together end-to-end solutions, without having to re-build each time.
 
 ## Installation
 


### PR DESCRIPTION
**Description of your changes:**

Added hyphens to "end to end" in the Kubeflow Pipelines README.
`* End-to-end orchestration: enabling and simplifying the orchestration of end-to-end machine learning pipelines`
`* Easy re-use: enabling you to re-use components and pipelines to quickly cobble together end-to-end solutions, without having to re-build each time.`

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
