### PR TITLE
test(sdk): verify component description heading away from third line

### DIFF
--- a/sdk/python/kfp/components/load_yaml_utilities_test.py
+++ b/sdk/python/kfp/components/load_yaml_utilities_test.py
@@ -124,6 +124,26 @@ class LoadYamlTests(unittest.TestCase):
         #     component.component_spec.implementation.container.image,
         #     'python:3.11')
 
+    def test_load_component_from_text_description_heading_away_from_third_line(
+            self):
+        header = textwrap.dedent("""\
+            # Header line 1
+            # Header line 2
+            # Header line 3
+            # Header line 4
+            # Header line 5
+            # Description: custom component description
+            #              spanning multiple lines
+            """)
+        yaml_text = header + SAMPLE_YAML
+        component = components.load_component_from_text(yaml_text)
+        self.assertEqual(
+            component.description,
+            'custom component description\nspanning multiple lines')
+        self.assertEqual(
+            component.component_spec.description,
+            'custom component description\nspanning multiple lines')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a regression test ensuring component descriptions are correctly extracted when the `# Description:` heading is located away from the third line of the YAML comment header.

This follows up on the non-blocking review request from @jeffspahr in #13619.

The test exercises the public `components.load_component_from_text()` API using a valid component definition and verifies both the component description and underlying component spec description.

Related to #13420.
