### PR TITLE
fix(frontend): patch unhandled stream backpressure in artifact previews

### DIFF
--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -428,18 +428,28 @@ function detectCompression(onCompressionDetermined: (compressed: boolean) => voi
  */
 function extractFirstTarRecordAsStream() {
   const extract = tar.extract();
+  let currentStream: NodeJS.ReadableStream | null = null;
   const transformStream = new Transform({
+    read(_size: number) {
+      if (currentStream) {
+        currentStream.resume();
+      }
+    },
     write: (chunk: any, _encoding: string, callback: (error?: Error | null) => void) => {
       extract.write(chunk, callback);
     },
   });
   extract.once('entry', function (_header, stream, next) {
-    stream.on('data', (buffer: any) => transformStream.push(buffer));
+    currentStream = stream;
+    stream.on('data', (buffer: any) => {
+      if (!transformStream.push(buffer)) {
+        stream.pause();
+      }
+    });
     stream.on('end', () => {
-      transformStream.emit('end');
+      transformStream.push(null);
       next();
     });
-    stream.resume(); // just auto drain the stream
   });
   extract.on('error', (error) => transformStream.emit('error', error));
   return transformStream;


### PR DESCRIPTION
Description of changes:

Why: The Kubeflow Pipelines frontend server API endpoint for previewing `.tar.gz` artifacts suffers from an unbounded memory leak when streaming to a slow HTTP client. The `extractFirstTarRecordAsStream` function listens for `'data'` events and pushes to a Transform stream without checking if the stream has reached its high-water mark or pausing the readable side. Consequently, it loses backpressure, buffering the entire artifact payload into the Node.js V8 heap and risking severe OOM (Out Of Memory) Denial of Service (DoS) attacks.

What: Modified `extractFirstTarRecordAsStream` to honor backpressure by pausing the readable stream when `transformStream.push()` returns false, and resuming it in the `Transform`'s `_read()` hook when the downstream client is ready for more data. Also replaced `stream.resume()` with controlled flowing and used `.push(null)` instead of `.emit('end')` to cleanly signal EOF per Node.js stream standards.

Fixes: #14368 

Technical summary:
- Add `currentStream` pointer to track the current tarball entry stream.
- Handle `stream.pause()` when `transformStream.push(buffer)` is false.
- Implement `read(_size)` on the Transform stream to trigger `currentStream.resume()` when downstream drains.
- Swap `.emit('end')` with standard `.push(null)` to properly close the readable stream.