### PR TITLE
fix(backend): prevent memory leaks in pipeline archive extraction

### DIFF
--- a/backend/src/apiserver/server/util.go
+++ b/backend/src/apiserver/server/util.go
@@ -68,6 +68,11 @@ func decompressPipelineTarball(compressedFile []byte, maxFileLength int) ([]byte
 	if err != nil {
 		return nil, util.NewInvalidInputErrorWithDetails(err, "Error extracting pipeline from the tarball file. Not a valid tarball file")
 	}
+	defer func() {
+		if gzipReader != nil {
+			gzipReader.Close()
+		}
+	}()
 
 	// Use the shared overflow-safe traversal budget for tar headers,
 	// PAX/GNU metadata, and padding.
@@ -98,6 +103,7 @@ func decompressPipelineTarball(compressedFile []byte, maxFileLength int) ([]byte
 	// Old behavior - taking the first file in the archive
 	if tarReader == nil {
 		// Resetting the reader
+		gzipReader.Close()
 		gzipReader, err = gzip.NewReader(bytes.NewReader(compressedFile))
 		if err != nil {
 			return nil, util.NewInvalidInputErrorWithDetails(err, "Error extracting pipeline from the tarball file. Not a valid tarball file")
@@ -161,6 +167,7 @@ func decompressPipelineZip(compressedFile []byte, maxFileLength int) ([]byte, er
 	if err != nil {
 		return nil, util.NewInvalidInputErrorWithDetails(err, "Error extracting pipeline from the zip file. Failed to read the content")
 	}
+	defer rc.Close()
 	limitedReader := io.LimitReader(rc, util.SaturatingAdd(int64(maxFileLength), 1))
 	decompressedFile, err := io.ReadAll(limitedReader)
 	if err != nil {


### PR DESCRIPTION
Description of your changes:

**Why:** During pipeline uploads, the API Server extracts `.zip` and `.tar.gz` archives in `decompressPipelineZip` and `decompressPipelineTarball`. Currently, the `io.ReadCloser` returned by `zip.File.Open()` and the `*gzip.Reader` returned by `gzip.NewReader()` are never explicitly closed. Because Go's `compress/flate` and `compress/gzip` heavily rely on `sync.Pool` to recycle decompression state, failing to call `.Close()` permanently leaks these DEFLATE decoders until garbage collection. Under automated or heavy upload traffic, this causes severe memory bloat, GC CPU thrashing, and eventual Out-Of-Memory (OOM) Denial of Service.
**What:** `decompressPipelineZip` now explicitly defers `rc.Close()` to ensure the zip file reader is returned to the pool. `decompressPipelineTarball` now explicitly closes the `gzip.Reader` via `defer` (and explicitly before fallback reassignment) to guarantee safe resource teardown.

Technical summary:
* Add `defer rc.Close()` immediately after successful `pipelineYamlFile.Open()` in `decompressPipelineZip`.
* Add `defer func() { if gzipReader != nil { gzipReader.Close() } }()` in `decompressPipelineTarball`.
* Ensure the initial `gzipReader` is explicitly closed before the fallback assignment `gzipReader = gzip.NewReader(...)` to prevent leaking the primary reader during backwards-compatibility loops.
* This restores O(1) memory recycling for DEFLATE decompression in the API server.

Validation on current upstream master, with Go 1.27.1:
* `go test ./backend/src/apiserver/server/... -count=1`
* `go vet ./backend/src/apiserver/server/...`
* `go build ./backend/src/apiserver/server/...`
* `golangci-lint run --new-from-rev upstream/master ./backend/src/apiserver/server/...`
* Remaining applicable pre-commit hooks, including Go formatting (`gofmt`).
* Live-cluster integration tests were not run.

Checklist:
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits).
- [x] The PR title follows the [repository convention](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).