### PR TITLE
fix(frontend): make artifact endpoint guidance actionable. Fixes #14354

### DIFF
--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -44,7 +44,11 @@ import { URL } from 'url';
 import { getGCSClient, listGCSObjectNames, downloadGCSObjectStream } from '../gcs-helper.js';
 import type { GCSClient } from '../gcs-helper.js';
 
-import { isAllowedDomain, isTrustedArtifactEndpoint } from './domain-checker.js';
+import {
+  formatUntrustedArtifactEndpointError,
+  isAllowedDomain,
+  isTrustedArtifactEndpoint,
+} from './domain-checker.js';
 import { getK8sSecret } from '../k8s-helper.js';
 import { CredentialBody } from 'google-auth-library';
 import { AuthorizeFn } from '../helpers/auth.js';
@@ -566,11 +570,7 @@ export function getArtifactsHandler({
           console.warn(
             `Rejected artifact store origin ${providerEndpointUrl}; configure ALLOWED_ARTIFACT_ENDPOINTS to trust an additional operator-controlled origin`,
           );
-          sendArtifactError(
-            res,
-            400,
-            'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
-          );
+          sendArtifactError(res, 400, formatUntrustedArtifactEndpointError(providerEndpointUrl));
           return;
         }
       }

--- a/frontend/server/handlers/domain-checker.test.ts
+++ b/frontend/server/handlers/domain-checker.test.ts
@@ -11,7 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { isAllowedDomain, isTrustedArtifactEndpoint } from './domain-checker.js';
+import {
+  formatUntrustedArtifactEndpointError,
+  isAllowedDomain,
+  isTrustedArtifactEndpoint,
+} from './domain-checker.js';
 
 describe('isAllowedDomain', () => {
   it('matches a host-only allowlist for a plain https URL', () => {
@@ -50,6 +54,14 @@ describe('isAllowedDomain', () => {
 
   it('rejects non-http schemes before applying the allowlist', () => {
     expect(isAllowedDomain('file:///etc/passwd', '^.*$')).toBe(false);
+  });
+});
+
+describe('formatUntrustedArtifactEndpointError', () => {
+  it('includes the rejected origin and directs the reader to a cluster operator', () => {
+    expect(formatUntrustedArtifactEndpointError('https://objects.example.com:9443')).toBe(
+      'Artifact store endpoint https://objects.example.com:9443 is not allowed. Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
+    );
   });
 });
 

--- a/frontend/server/handlers/domain-checker.ts
+++ b/frontend/server/handlers/domain-checker.ts
@@ -40,6 +40,14 @@ export function isTrustedArtifactEndpoint(
   );
 }
 
+export function formatUntrustedArtifactEndpointError(endpointOrigin: string): string {
+  return (
+    `Artifact store endpoint ${endpointOrigin} is not allowed. ` +
+    'Ask a cluster operator to add this exact origin to the cluster-level ' +
+    'ALLOWED_ARTIFACT_ENDPOINTS setting.'
+  );
+}
+
 function normalizeEndpoint(endpoint: string): string | undefined {
   try {
     const parsedUrl = new URL(endpoint.includes('://') ? endpoint : `https://${endpoint}`);

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -947,7 +947,7 @@ describe('/artifacts', () => {
         )
         .expect(
           400,
-          'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
+          'Artifact store endpoint https://s3.us-east-2.amazonaws.com is not allowed. Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
         );
       expect(mockedMinioClient).not.toBeCalled();
     });
@@ -1010,7 +1010,7 @@ describe('/artifacts', () => {
         )
         .expect(
           400,
-          'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
+          'Artifact store endpoint https://s3-attacker-123.us-east-1.elb.amazonaws.com is not allowed. Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
         );
       expect(mockedMinioClient).not.toBeCalled();
     });
@@ -1039,7 +1039,7 @@ describe('/artifacts', () => {
         )
         .expect(
           400,
-          'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
+          'Artifact store endpoint https://tenant-bucket.s3.us-east-1.amazonaws.com is not allowed. Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
         );
       expect(mockedMinioClient).not.toBeCalled();
     });
@@ -1135,7 +1135,7 @@ describe('/artifacts', () => {
         )
         .expect(
           400,
-          'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
+          'Artifact store endpoint https://objects.example.com:9000 is not allowed. Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
         );
       expect(mockedMinioClient).not.toBeCalled();
     });

--- a/frontend/server/integration-tests/pod-logs-endpoint.test.ts
+++ b/frontend/server/integration-tests/pod-logs-endpoint.test.ts
@@ -147,7 +147,12 @@ describe('/k8s/pod/logs workflow artifact endpoints', () => {
         .query({ podname: podName, ...(namespace ? { podnamespace: namespace } : {}) })
         .expect(500);
 
-      expect(response.text).toContain('Artifact store endpoint is not allowed');
+      expect(response.text).toContain(
+        'Artifact store endpoint https://untrusted.example.com is not allowed.',
+      );
+      expect(response.text).toContain(
+        'Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
+      );
       expect(getPodLogs).toHaveBeenCalledWith(podName, namespace, 'main');
       expect(getArgoWorkflow).toHaveBeenCalledWith('workflow-1', namespace);
       expect(getK8sSecret).not.toHaveBeenCalled();
@@ -173,7 +178,9 @@ describe('/k8s/pod/logs workflow artifact endpoints', () => {
         .query({ podname: podName, podnamespace: 'kubeflow' })
         .expect(500);
 
-      expect(response.text).toContain('Artifact store endpoint is not allowed');
+      expect(response.text).toContain(
+        'Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
+      );
       expect(getK8sSecret).not.toHaveBeenCalled();
       expect(MinioClient).not.toHaveBeenCalled();
       expect(getObject).not.toHaveBeenCalled();
@@ -350,7 +357,9 @@ describe('/k8s/pod/logs workflow artifact endpoints', () => {
         .query({ podname: podName, podnamespace: 'tenant' })
         .expect(500);
 
-      expect(response.text).toContain('Artifact store endpoint is not allowed');
+      expect(response.text).toContain(
+        'Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
+      );
       expect(getK8sSecret).not.toHaveBeenCalled();
       expect(MinioClient).not.toHaveBeenCalled();
       expect(getObject).not.toHaveBeenCalled();

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -283,7 +283,7 @@ describe('workflow-helper', () => {
                 namespace,
               ),
             ).rejects.toThrow(
-              'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
+              'Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
             );
 
             expect(getK8sSecret).not.toHaveBeenCalled();
@@ -306,7 +306,9 @@ describe('workflow-helper', () => {
           '2024-07-09',
           'kubeflow',
         ),
-      ).rejects.toThrow('Artifact store endpoint is not allowed');
+      ).rejects.toThrow(
+        'Artifact store endpoint http://seaweedfs.kubeflow is not allowed. Ask a cluster operator to add this exact origin to the cluster-level ALLOWED_ARTIFACT_ENDPOINTS setting.',
+      );
 
       expect(getK8sSecret).not.toHaveBeenCalled();
       expect(minioHelper.createMinioClient).not.toHaveBeenCalled();

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -26,7 +26,10 @@ import {
   getObjectStream,
   parseArtifactStoreEndpoint,
 } from './minio-helper.js';
-import { isTrustedArtifactEndpoint } from './handlers/domain-checker.js';
+import {
+  formatUntrustedArtifactEndpointError,
+  isTrustedArtifactEndpoint,
+} from './handlers/domain-checker.js';
 import { CORE_SCHEMA, load as jsYamlLoad, mergeTag } from 'js-yaml';
 
 export interface PartialArgoWorkflow {
@@ -360,9 +363,7 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
     );
   }
   if (!isTrustedArtifactEndpoint(endpoint.origin, trustedEndpoints)) {
-    throw new Error(
-      'Artifact store endpoint is not allowed; add its exact origin to ALLOWED_ARTIFACT_ENDPOINTS',
-    );
+    throw new Error(formatUntrustedArtifactEndpointError(endpoint.origin));
   }
   // Security: Only read the object-store credential Secret from the server's own
   // namespace. In multi-user deployments the run namespace is a customer/user


### PR DESCRIPTION
**Description of your changes:**

Makes artifact endpoint rejection messages actionable for the people who see them.

- Includes the rejected endpoint origin in both artifact-read and archived-log error paths.
- Explains that `ALLOWED_ARTIFACT_ENDPOINTS` is a cluster-level setting and directs the user to a cluster operator.
- Centralizes the wording and updates the server coverage for both paths.

Fixes #14354

Validation:

- Focused frontend server tests: 187/187 passing.
- Server lint, frontend typecheck, server TypeScript build, Prettier, and diff checks passing.
- Manually started the compiled UI server and requested `/k8s/pod/logs` over loopback. The live HTTP 500 response included the rejected origin and the cluster-operator guidance.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the repository title convention.

