### PR TITLE
fix(sdk): support None (null_value) in to_protobuf_value for dict and list parameters Fixes #14373

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -67,8 +67,10 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
     Raises:
         ValueError if the given value is not one of the parameter types.
     """
+    if value is None:
+        return struct_pb2.Value(null_value=struct_pb2.NULL_VALUE)
     # bool check must be above (int, float) check because bool is a subclass of int so isinstance(True, int) == True
-    if isinstance(value, bool):
+    elif isinstance(value, bool):
         return struct_pb2.Value(bool_value=value)
     elif isinstance(value, str):
         return struct_pb2.Value(string_value=value)

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -139,6 +139,38 @@ class PipelineSpecBuilderTest(parameterized.TestCase):
             component_spec.input_definitions.parameters['input1'].default_value,
         )
 
+    def test_to_protobuf_value_with_none(self):
+        self.assertEqual(
+            pipeline_spec_builder.to_protobuf_value(None),
+            struct_pb2.Value(null_value=struct_pb2.NULL_VALUE),
+        )
+
+    def test_to_protobuf_value_with_none_in_dict(self):
+        self.assertEqual(
+            pipeline_spec_builder.to_protobuf_value({
+                'key': None,
+                'threshold': 0.5
+            }),
+            struct_pb2.Value(
+                struct_value=struct_pb2.Struct(fields={
+                    'key':
+                        struct_pb2.Value(null_value=struct_pb2.NULL_VALUE),
+                    'threshold':
+                        struct_pb2.Value(number_value=0.5),
+                })),
+        )
+
+    def test_to_protobuf_value_with_none_in_list(self):
+        self.assertEqual(
+            pipeline_spec_builder.to_protobuf_value([1, None, 2]),
+            struct_pb2.Value(
+                list_value=struct_pb2.ListValue(values=[
+                    struct_pb2.Value(number_value=1),
+                    struct_pb2.Value(null_value=struct_pb2.NULL_VALUE),
+                    struct_pb2.Value(number_value=2),
+                ])),
+        )
+
     def test_merge_deployment_spec_and_component_spec(self):
         main_deployment_config = pipeline_spec_pb2.PipelineDeploymentConfig()
         main_deployment_config.executors['exec-1'].CopyFrom(


### PR DESCRIPTION
Fixes #14373

**Description of your changes:**

While looking into how the compiler serializes parameter values, I found that `to_protobuf_value` in `pipeline_spec_builder.py` doesn't handle `None`. If a dict or list parameter has a `None` value anywhere in it — something like `{"key": None}` or `[1, None, 2]` — the compiler crashes with a `ValueError`, even though protobuf's `struct_pb2.Value` already has a `null_value` field built in for exactly this case.

What's interesting is that the reverse direction already works: `pb2_value_to_python` in `kfp/local/executor_output_utils.py` already converts `null_value` back into `None` when reading values. So the serializer and deserializer were just out of sync — the deserializer was ready for nulls, but the serializer never learned to produce them.

The fix is small: add a `value is None` check that returns `struct_pb2.Value(null_value=struct_pb2.NULL_VALUE)`, alongside the existing bool/str/int/float/dict/list checks.

**Testing:**
- Reproduced the original crash first, to confirm the bug (bare `None`, `None` inside a dict, and `None` inside a list all failed the same way).
- Applied the fix and re-ran the same cases — all three now serialize correctly instead of raising.
- Added three unit tests to `pipeline_spec_builder_test.py` covering each case.
- Ran the full `kfp/compiler/` suite (296 tests) afterward to make sure nothing else broke — all passing.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).